### PR TITLE
feature: lower state tree levels

### DIFF
--- a/circuits/statetransition/merkleproof.go
+++ b/circuits/statetransition/merkleproof.go
@@ -219,3 +219,19 @@ func padStateSiblings(unpackedSiblings []*big.Int) [types.CensusTreeMaxLevels]fr
 	}
 	return paddedSiblings
 }
+
+// TruncateKeyForArbo helper function truncates a key to a given size to be
+// compared with the key included in an arbo proof. It only matches if the
+// tree was generated with the BigInt API of arbo. It converts the key to
+// bytes, swaps the endianness, crops it to the given size, and then swaps
+// the endianness back. It returns the truncated key as a frontend.Variable.
+func TruncateKeyForArbo(api frontend.API, input frontend.Variable, size int) (frontend.Variable, error) {
+	bInput, err := utils.VarToU8(api, input)
+	if err != nil {
+		return 0, err
+	}
+	swappedInput := utils.SwapEndianness(bInput)
+	croppedInput := swappedInput[:size]
+	reSwappedInput := utils.SwapEndianness(croppedInput)
+	return utils.U8ToVar(api, reSwappedInput)
+}

--- a/circuits/statetransition/statetransition.go
+++ b/circuits/statetransition/statetransition.go
@@ -251,9 +251,19 @@ func (circuit StateTransitionCircuit) VerifyLeafHashes(api frontend.API, hFn uti
 	// Votes
 	for i, v := range circuit.Votes {
 		// Nullifier
-		api.AssertIsEqual(v.Nullifier, circuit.VotesProofs.Ballot[i].NewKey)
+		nullifierKey, err := TruncateKeyForArbo(api, v.Nullifier, types.StateKeyMaxLen)
+		if err != nil {
+			circuits.FrontendError(api, "failed to truncate nullifier key: ", err)
+			return
+		}
+		api.AssertIsEqual(nullifierKey, circuit.VotesProofs.Ballot[i].NewKey)
 		// Address
-		api.AssertIsEqual(v.Address, circuit.VotesProofs.Commitment[i].NewKey)
+		addressKey, err := TruncateKeyForArbo(api, v.Address, types.StateKeyMaxLen)
+		if err != nil {
+			circuits.FrontendError(api, "failed to truncate address key: ", err)
+			return
+		}
+		api.AssertIsEqual(addressKey, circuit.VotesProofs.Commitment[i].NewKey)
 		// Ballot
 		if err := circuit.VotesProofs.Ballot[i].VerifyNewLeafHash(api, hFn, v.Ballot.SerializeVars()...); err != nil {
 			circuits.FrontendError(api, "failed to verify ballot vote proof leaf hash: ", err)

--- a/circuits/test/aggregator/aggregator_inputs.go
+++ b/circuits/test/aggregator/aggregator_inputs.go
@@ -116,7 +116,7 @@ func AggregatorInputsForTest(processId []byte, nValidVotes int) (
 			Address:    vvInputs.Addresses[i],
 			Commitment: vvInputs.Commitments[i],
 			Nullifier:  vvInputs.Nullifiers[i],
-			Ballot:     &vvInputs.Ballots[i],
+			Ballot:     vvInputs.Ballots[i].FromTEtoRTE(),
 		})
 	}
 	log.Printf("Aggregator inputs generation ends, it tooks %s", time.Since(now))

--- a/circuits/test/voteverifier/vote_verifier_inputs.go
+++ b/circuits/test/voteverifier/vote_verifier_inputs.go
@@ -69,7 +69,7 @@ func VoteVerifierInputsForTest(votersData []VoterTestData, processId []byte) (
 		Dir:           fmt.Sprintf("../assets/census%d", util.RandomInt(0, 1000)),
 		ValidSiblings: 10,
 		TotalSiblings: types.CensusTreeMaxLevels,
-		KeyLen:        20,
+		KeyLen:        types.CensusKeyMaxLen,
 		Hash:          arbo.HashFunctionMiMC_BLS12_377,
 		BaseField:     arbo.BLS12377BaseField,
 	}, bAddresses, bWeights)

--- a/circuits/voteverifier/vote_verifier.go
+++ b/circuits/voteverifier/vote_verifier.go
@@ -106,7 +106,7 @@ func censusKeyValue(api frontend.API, address, weight emulated.Element[sw_bn254.
 		return 0, 0, fmt.Errorf("failed to convert address emulated element to bytes: %w", err)
 	}
 	// swap the endianness of the address to le to be used in the census proof
-	key, err := utils.U8ToVar(api, bAddress[:20])
+	key, err := utils.U8ToVar(api, bAddress[:types.CensusKeyMaxLen])
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to convert address bytes to var: %w", err)
 	}

--- a/types/circuits.go
+++ b/types/circuits.go
@@ -4,13 +4,14 @@ package types
 const (
 	// CensusTreeMaxLevels is the maximum number of levels in the census merkle tree.
 	CensusTreeMaxLevels = 160
-	StateTreeMaxLevels  = 254
+	StateTreeMaxLevels  = 64
 	// CensusKeyMaxLen is the maximum length of a census key in bytes.
 	CensusKeyMaxLen = CensusTreeMaxLevels / 8
+	StateKeyMaxLen  = StateTreeMaxLevels / 8
 	// FieldsPerBallot is the number of fields in a ballot.
 	FieldsPerBallot = 8
 	// MaxValuePerBallotField is the maximum value per field in a ballot.
 	MaxValuePerBallotField = 2 << 16 // 65536
 	// VotesPerBatch is the number of votes per zkSnark batch.
-	VotesPerBatch = 10
+	VotesPerBatch = 100
 )


### PR DESCRIPTION
This PR reduces the number of the levels of the state merkle tree from 254 to 64. 
This change also reduces the length of the tree accordingly (`nLevels/8 bytes`), so now the `statetransition` circuit transforms the nullifiers and the addresses of the voters to this length applying the correct transformation.

This PR does not complete the #74 at all because the number of levels of the census tree can not be reduced right now. We need to build that tree using the arbo `BigInt` API first and then transform the inputs that are used as a keys inside the `voteverifier` circuit (the voter addresses) in the same way that this PR does with the `statetransition` ones.