### PR TITLE
feature: `statetransition` rollback

### DIFF
--- a/cmd/e2eTest/main.go
+++ b/cmd/e2eTest/main.go
@@ -143,7 +143,7 @@ func main() {
 			X: x,
 			Y: y,
 		},
-		StateRoot:   util.RandomBytes(32),
+		StateRoot:   new(types.BigInt).SetBytes(util.RandomBytes(32)),
 		StartTime:   time.Now().Add(5 * time.Minute),
 		Duration:    time.Hour,
 		MetadataURI: "https://example.com/metadata",

--- a/finalizer/finalizer.go
+++ b/finalizer/finalizer.go
@@ -190,8 +190,8 @@ func (f *Finalizer) finalize(pid *types.ProcessID) error {
 	// Open the state for the process
 	log.Infow("opening state",
 		"pid", pid.String(),
-		"stateRoot", process.StateRoot.BigInt())
-	st, err := state.LoadOnRoot(f.stateDB, pid.BigInt(), state.BytesToBigInt(process.StateRoot))
+		"stateRoot", process.StateRoot)
+	st, err := state.LoadOnRoot(f.stateDB, pid.BigInt(), process.StateRoot.MathBigInt())
 	if err != nil {
 		return fmt.Errorf("could not open state for process %x: %w", pid.Marshal(), err)
 	}

--- a/finalizer/finalizer.go
+++ b/finalizer/finalizer.go
@@ -188,7 +188,10 @@ func (f *Finalizer) finalize(pid *types.ProcessID) error {
 	}
 
 	// Open the state for the process
-	st, err := state.New(f.stateDB, pid.BigInt())
+	log.Infow("opening state for process",
+		"pid", pid.String(),
+		"stateRoot", process.StateRoot.String())
+	st, err := state.LoadOnRoot(f.stateDB, pid.BigInt(), process.StateRoot.BigInt().MathBigInt())
 	if err != nil {
 		return fmt.Errorf("could not open state for process %x: %w", pid.Marshal(), err)
 	}

--- a/finalizer/finalizer.go
+++ b/finalizer/finalizer.go
@@ -188,10 +188,10 @@ func (f *Finalizer) finalize(pid *types.ProcessID) error {
 	}
 
 	// Open the state for the process
-	log.Infow("opening state for process",
+	log.Infow("opening state",
 		"pid", pid.String(),
-		"stateRoot", process.StateRoot.String())
-	st, err := state.LoadOnRoot(f.stateDB, pid.BigInt(), process.StateRoot.BigInt().MathBigInt())
+		"stateRoot", process.StateRoot.BigInt())
+	st, err := state.LoadOnRoot(f.stateDB, pid.BigInt(), state.BytesToBigInt(process.StateRoot))
 	if err != nil {
 		return fmt.Errorf("could not open state for process %x: %w", pid.Marshal(), err)
 	}

--- a/finalizer/finalizer_test.go
+++ b/finalizer/finalizer_test.go
@@ -149,7 +149,7 @@ func setupTestEnvironment(t *testing.T, addValue, subValue int64) (
 		StartTime:   time.Now(),
 		Duration:    time.Hour,
 		MetadataURI: "http://example.com/metadata",
-		StateRoot:   make([]byte, 32),
+		StateRoot:   new(types.BigInt).SetUint64(100),
 		BallotMode: &types.BallotMode{
 			MaxCount:        8,
 			MaxValue:        new(types.BigInt).SetUint64(100),
@@ -192,7 +192,13 @@ func setupTestEnvironment(t *testing.T, addValue, subValue int64) (
 }
 
 // setupTestState initializes the state with encrypted test data
-func setupTestState(t *testing.T, stateDB db.Database, pid *types.ProcessID, pubKey ecc.Point, addValue, subValue int64) []byte {
+func setupTestState(
+	t *testing.T,
+	stateDB db.Database,
+	pid *types.ProcessID,
+	pubKey ecc.Point,
+	addValue, subValue int64,
+) *types.BigInt {
 	// Create a new state
 	st, err := state.New(stateDB, pid.BigInt())
 	if err != nil {
@@ -258,9 +264,9 @@ func setupTestState(t *testing.T, stateDB db.Database, pid *types.ProcessID, pub
 	st.SetResultsAdd(encryptedAdd)
 	st.SetResultsSub(encryptedSub)
 
-	stateRoot, err := st.Root()
+	stateRoot, err := st.RootAsBigInt()
 	if err != nil {
 		t.Fatalf("failed to get state root: %v", err)
 	}
-	return stateRoot
+	return (*types.BigInt)(stateRoot)
 }

--- a/sequencer/onchain.go
+++ b/sequencer/onchain.go
@@ -47,7 +47,7 @@ func (s *Sequencer) processOnChain() {
 		// get the process from the storage
 		process, err := s.stg.Process(new(types.ProcessID).SetBytes(pid))
 		if err != nil {
-			log.Errorw(err, "failed to get process metadata")
+			log.Errorw(err, "failed to get process data")
 			return true // Continue to next process ID
 		}
 		log.Infow("state transition batch ready for on-chain upload",
@@ -65,7 +65,7 @@ func (s *Sequencer) processOnChain() {
 			return true // Continue to next process ID
 		}
 		// update the process state with the new root hash
-		process.StateRoot = batch.Inputs.RootHashAfter.Bytes()
+		process.StateRoot = (*types.BigInt)(batch.Inputs.RootHashAfter)
 		if err := s.stg.SetProcess(process); err != nil {
 			log.Errorw(err, "failed to update process data")
 			return true // Continue to next process ID
@@ -111,7 +111,7 @@ func (s *Sequencer) pushToContract(processID []byte,
 	txHash, err := s.contracts.SetProcessTransition(processID,
 		abiProof,
 		abiInputs,
-		inputs.RootHashBefore.Bytes(),
+		(*types.BigInt)(inputs.RootHashBefore),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to submit state transition: %w", err)

--- a/sequencer/onchain.go
+++ b/sequencer/onchain.go
@@ -67,7 +67,7 @@ func (s *Sequencer) processOnChain() {
 		// update the process state with the new root hash
 		process.StateRoot = batch.Inputs.RootHashAfter.Bytes()
 		if err := s.stg.SetProcess(process); err != nil {
-			log.Errorw(err, "failed to update process metadata")
+			log.Errorw(err, "failed to update process data")
 			return true // Continue to next process ID
 		}
 		log.Infow("process state root updated",

--- a/sequencer/statetransition.go
+++ b/sequencer/statetransition.go
@@ -12,7 +12,6 @@ import (
 	stdgroth16 "github.com/consensys/gnark/std/recursion/groth16"
 	"github.com/vocdoni/vocdoni-z-sandbox/circuits"
 	"github.com/vocdoni/vocdoni-z-sandbox/circuits/statetransition"
-	"github.com/vocdoni/vocdoni-z-sandbox/crypto"
 	"github.com/vocdoni/vocdoni-z-sandbox/log"
 	"github.com/vocdoni/vocdoni-z-sandbox/state"
 	"github.com/vocdoni/vocdoni-z-sandbox/storage"
@@ -100,6 +99,7 @@ func (s *Sequencer) processPendingTransitions() {
 		log.Debugw("state transition proof generated",
 			"took", time.Since(startTime).String(),
 			"processID", processID.String(),
+			"rootHashBefore", root.String(),
 			"rootHashAfter", rootHashAfter.String(),
 		)
 
@@ -164,9 +164,7 @@ func (s *Sequencer) latestProcessState(pid *types.ProcessID) (*state.State, erro
 		return nil, fmt.Errorf("failed to get process metadata: %w", err)
 	}
 	// initialize the process state on the given root
-	ffPID := crypto.BigToFF(circuits.StateTransitionCurve.BaseField(), pid.BigInt())
-	bigStateRoot := process.StateRoot.BigInt().MathBigInt()
-	processState, err := state.LoadOnRoot(s.stg.StateDB(), ffPID, bigStateRoot)
+	processState, err := state.LoadOnRoot(s.stg.StateDB(), pid.BigInt(), process.StateRoot.MathBigInt())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create state: %w", err)
 	}

--- a/service/process_monitor_test.go
+++ b/service/process_monitor_test.go
@@ -43,7 +43,7 @@ func TestProcessMonitor(t *testing.T) {
 	pid, hash, err := contracts.CreateProcess(&types.Process{
 		Status:         0,
 		OrganizationId: contracts.AccountAddress(),
-		StateRoot:      make([]byte, 32),
+		StateRoot:      new(types.BigInt).SetUint64(100),
 		StartTime:      time.Now().Add(5 * time.Minute),
 		Duration:       time.Hour,
 		MetadataURI:    "https://example.com/metadata",

--- a/state/helpers.go
+++ b/state/helpers.go
@@ -1,0 +1,20 @@
+package state
+
+import (
+	"math/big"
+
+	"github.com/vocdoni/arbo"
+)
+
+// BytesToBigInt method converts a byte array to a big.Int. It is a wrapper
+// around the arbo.BytesToBigInt function.
+func BytesToBigInt(b []byte) *big.Int {
+	return arbo.BytesToBigInt(b)
+}
+
+// BigIntToBytes method converts a big.Int to a byte array. It is a wrapper
+// around the arbo.BigIntToBytes function, which uses the maximum key length
+// for the hash function.
+func BigIntToBytes(b *big.Int) []byte {
+	return arbo.BigIntToBytes(HashFn.Len(), b)
+}

--- a/state/state.go
+++ b/state/state.go
@@ -245,6 +245,23 @@ func (o *State) RootAsBigInt() (*big.Int, error) {
 	return arbo.BytesToBigInt(root), nil
 }
 
+// SetRoot method sets the root of the tree to the provided one.
+func (o *State) SetRoot(newRoot []byte) error {
+	if err := o.tree.SetRoot(newRoot); err != nil {
+		return err
+	}
+	return nil
+}
+
+// SetRootAsBigInt method sets the root of the tree to the provided one as a
+// big.Int.
+func (o *State) SetRootAsBigInt(newRoot *big.Int) error {
+	if err := o.tree.SetRoot(EncodeKey(newRoot)); err != nil {
+		return err
+	}
+	return nil
+}
+
 // BallotCount returns the number of ballots added in the current batch.
 func (o *State) BallotCount() int {
 	return o.ballotCount

--- a/state/state.go
+++ b/state/state.go
@@ -259,7 +259,7 @@ func (o *State) RootAsBigInt() (*big.Int, error) {
 	if err != nil {
 		return nil, err
 	}
-	return arbo.BytesToBigInt(root), nil
+	return BytesToBigInt(root), nil
 }
 
 // SetRoot method sets the root of the tree to the provided one.
@@ -273,7 +273,7 @@ func (o *State) SetRoot(newRoot []byte) error {
 // SetRootAsBigInt method sets the root of the tree to the provided one as a
 // big.Int.
 func (o *State) SetRootAsBigInt(newRoot *big.Int) error {
-	if err := o.tree.SetRoot(arbo.BigIntToBytes(o.tree.HashFunction().Len(), newRoot)); err != nil {
+	if err := o.tree.SetRoot(BigIntToBytes(newRoot)); err != nil {
 		return err
 	}
 	return nil

--- a/state/state.go
+++ b/state/state.go
@@ -95,6 +95,23 @@ func New(db db.Database, processId *big.Int) (*State, error) {
 	}, nil
 }
 
+// LoadOnRoot loads a State from the database using the provided processId and
+// root. It creates a new State with the given processId and sets the root of
+// the tree to the provided root. It returns an error if the processId is not
+// found in the database or if the root cannot be set.
+// The root provided is formatted to the arbo format before being set in the
+// state tree.
+func LoadOnRoot(db db.Database, processId, root *big.Int) (*State, error) {
+	state, err := New(db, processId)
+	if err != nil {
+		return nil, err
+	}
+	if err := state.SetRootAsBigInt(root); err != nil {
+		return nil, err
+	}
+	return state, nil
+}
+
 // Initialize creates a new State, initialized with the passed parameters.
 // After Initialize, caller is expected to StartBatch, AddVote, EndBatch,
 // StartBatch...
@@ -256,7 +273,7 @@ func (o *State) SetRoot(newRoot []byte) error {
 // SetRootAsBigInt method sets the root of the tree to the provided one as a
 // big.Int.
 func (o *State) SetRootAsBigInt(newRoot *big.Int) error {
-	if err := o.tree.SetRoot(EncodeKey(newRoot)); err != nil {
+	if err := o.tree.SetRoot(arbo.BigIntToBytes(o.tree.HashFunction().Len(), newRoot)); err != nil {
 		return err
 	}
 	return nil

--- a/storage/process_test.go
+++ b/storage/process_test.go
@@ -65,7 +65,7 @@ func TestProcess(t *testing.T) {
 		ID:             processID.Marshal(),
 		Status:         0,
 		OrganizationId: common.Address{},
-		StateRoot:      make([]byte, 32),
+		StateRoot:      new(types.BigInt).SetUint64(100),
 		StartTime:      time.Now(),
 		Duration:       time.Hour,
 		MetadataURI:    "https://example.com/metadata",

--- a/tests/helpers_test.go
+++ b/tests/helpers_test.go
@@ -252,7 +252,7 @@ func createProcess(c *qt.C, contracts *web3.Contracts, cli *client.HTTPclient, c
 		Status:         0,
 		OrganizationId: contracts.AccountAddress(),
 		EncryptionKey:  encryptionKeys,
-		StateRoot:      resp.StateRoot,
+		StateRoot:      resp.StateRoot.BigInt(),
 		StartTime:      time.Now().Add(1 * time.Minute),
 		Duration:       time.Hour,
 		MetadataURI:    "https://example.com/metadata",

--- a/types/process.go
+++ b/types/process.go
@@ -49,7 +49,7 @@ type Process struct {
 	Status             uint8          `json:"status"                   cbor:"1,keyasint,omitempty"`
 	OrganizationId     common.Address `json:"organizationId"           cbor:"2,keyasint,omitempty"`
 	EncryptionKey      *EncryptionKey `json:"encryptionKey"            cbor:"3,keyasint,omitempty"`
-	StateRoot          HexBytes       `json:"stateRoot"                cbor:"4,keyasint,omitempty"`
+	StateRoot          *BigInt        `json:"stateRoot"                cbor:"4,keyasint,omitempty"`
 	Result             []*BigInt      `json:"result"                   cbor:"5,keyasint,omitempty"`
 	StartTime          time.Time      `json:"startTime"                cbor:"6,keyasint,omitempty"`
 	Duration           time.Duration  `json:"duration"                 cbor:"7,keyasint,omitempty"`

--- a/web3/contracts.go
+++ b/web3/contracts.go
@@ -98,10 +98,7 @@ func New(web3rpcs []string) (*Contracts, error) {
 	)
 
 	// calculate the start block to watch
-	startBlock := int64(lastBlock) - maxPastBlocksToWatch
-	if startBlock < 0 {
-		startBlock = 0
-	}
+	startBlock := max(int64(lastBlock)-maxPastBlocksToWatch, 0)
 
 	return &Contracts{
 		ChainID:                *chainID,


### PR DESCRIPTION
Now the state is loaded using the latest state root known by a process (from the storage). 
The stateroot is updated in the storage only if the statetransition and onchain sequencer services success, so the rollback is no longer required.