### PR TITLE
Support extraction of custom revert reasons via eth_simulateV1

### DIFF
--- a/config/contracts.go
+++ b/config/contracts.go
@@ -10,9 +10,9 @@ type DavinciWeb3Config struct {
 // DefaultConfig contains the default smart contract addresses for Davinci by network.
 var DefaultConfig = map[string]DavinciWeb3Config{
 	"sep": {
-		ProcessRegistrySmartContract:      "0xdecC4F656BE4C96617af7EeEaD0042a8855Fee9c",
-		OrganizationRegistrySmartContract: "0x218Ca677d701f535A239b1d4a4db2384CE81f371",
-		ResultsSmartContract:              "0x218Ca677d701f535A239b1d4a4db2384CE81f371", // duplicate for now
+		ProcessRegistrySmartContract:      "0x9936DBd1E225eCC44272B4Cb31e7e29799E3a166",
+		OrganizationRegistrySmartContract: "0x99502b97707Cc551448516E3120B0AA0202630Be",
+		ResultsSmartContract:              "0x99502b97707Cc551448516E3120B0AA0202630Be", // duplicate for now
 	},
 }
 

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/testcontainers/testcontainers-go/modules/compose v0.35.0
 	github.com/vocdoni/arbo v0.0.0-20250513133053-b35dcc9c1f00
 	github.com/vocdoni/circom2gnark v1.0.1-0.20241204100355-b93800bd88a4
-	github.com/vocdoni/contracts-z v0.0.0-20250512081945-889efab6a841
+	github.com/vocdoni/contracts-z v0.0.0-20250515233902-cd21958248fb
 	github.com/vocdoni/gnark-crypto-primitives v0.0.2-0.20250505073003-c9196af66639
 	go.vocdoni.io/dvote v1.10.2-0.20241024102542-c1ce6d744bc5
 	golang.org/x/sync v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -705,8 +705,8 @@ github.com/vocdoni/arbo v0.0.0-20250513133053-b35dcc9c1f00 h1:Xi9lW+nTiKoDSJ/hfe
 github.com/vocdoni/arbo v0.0.0-20250513133053-b35dcc9c1f00/go.mod h1:2EyGpN1IgziTvCxkosVQj2sdEJaWJxe8vwgWG1BIHbw=
 github.com/vocdoni/circom2gnark v1.0.1-0.20241204100355-b93800bd88a4 h1:aYeMlhWAW+/OQs9BinA8Yetjcf5IPoCsFFtxXx3uLdc=
 github.com/vocdoni/circom2gnark v1.0.1-0.20241204100355-b93800bd88a4/go.mod h1:A1WU0hL7rO9oZlvp82you2uCc4T3/ySi1UNW6N6hBJs=
-github.com/vocdoni/contracts-z v0.0.0-20250512081945-889efab6a841 h1:1GtBCOSzk4qfFiAQ1cM6RCacd8izETtCgILqR2+FlIY=
-github.com/vocdoni/contracts-z v0.0.0-20250512081945-889efab6a841/go.mod h1:ztzA4TBwnswOKlgiBqbVqRcCa+XkHkfazFcx2ZQsc50=
+github.com/vocdoni/contracts-z v0.0.0-20250515233902-cd21958248fb h1:89AasmA8SpLZi38aNCOQiv7Wh3lWWv61p2RKjVs/7Uw=
+github.com/vocdoni/contracts-z v0.0.0-20250515233902-cd21958248fb/go.mod h1:ztzA4TBwnswOKlgiBqbVqRcCa+XkHkfazFcx2ZQsc50=
 github.com/vocdoni/gnark-crypto-primitives v0.0.2-0.20250505073003-c9196af66639 h1:psqbd3ZjBHuGI24Rv/C3EAxAj7mDzyd8eyI5J4aqvGQ=
 github.com/vocdoni/gnark-crypto-primitives v0.0.2-0.20250505073003-c9196af66639/go.mod h1:Gvlz21dSc0M4UtlJSBLFW5CiUo3BkyvnrrERuyK9W38=
 github.com/vocdoni/gnark-no-assert v0.0.0-20250430090134-56f68baa9b16 h1:XtdKB+e8woVMp58Rx3lUBb9FSbxwgDdToHZspd8EA5U=

--- a/tests/helpers_test.go
+++ b/tests/helpers_test.go
@@ -101,6 +101,20 @@ func NewTestService(t *testing.T, ctx context.Context) *Services {
 	}
 	log.Infow("contracts deployed", "chainId", contracts.ChainID)
 
+	contracts.ContractABIs = &web3.ContractABIs{}
+	contracts.ContractABIs.ProcessRegistry, err = contracts.ProcessRegistryABI()
+	if err != nil {
+		log.Fatal(err)
+	}
+	contracts.ContractABIs.OrganizationRegistry, err = contracts.OrganizationRegistryABI()
+	if err != nil {
+		log.Fatal(err)
+	}
+	contracts.ContractABIs.ZKVerifier, err = contracts.ZKVerifierABI()
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	kv, err := metadb.New(db.TypePebble, t.TempDir())
 	qt.Assert(t, err, qt.IsNil)
 	stg := storage.New(kv)

--- a/web3/contracts.go
+++ b/web3/contracts.go
@@ -1,16 +1,23 @@
 package web3
 
 import (
+	"bytes"
 	"context"
 	"crypto/ecdsa"
 	"fmt"
 	"math/big"
+	"reflect"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
+	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
+
 	bindings "github.com/vocdoni/contracts-z/golang-types/non-proxy"
 	"github.com/vocdoni/vocdoni-z-sandbox/crypto/signatures/ethereum"
 	"github.com/vocdoni/vocdoni-z-sandbox/log"
@@ -36,10 +43,18 @@ type Addresses struct {
 	ZKVerifier           common.Address
 }
 
+type ContractABIs struct {
+	OrganizationRegistry *abi.ABI
+	ResultsRegistry      *abi.ABI
+	ProcessRegistry      *abi.ABI
+	ZKVerifier           *abi.ABI
+}
+
 // Contracts contains the bindings to the deployed contracts.
 type Contracts struct {
 	ChainID            uint64
 	ContractsAddresses *Addresses
+	ContractABIs       *ContractABIs
 	organizations      *bindings.OrganizationRegistry
 	processes          *bindings.ProcessRegistry
 	web3pool           *rpc.Web3Pool
@@ -148,6 +163,26 @@ func (c *Contracts) LoadContracts(addresses *Addresses) error {
 	c.ContractsAddresses = addresses
 	c.processes = process
 	c.organizations = organizations
+
+	orgRegistryABI, err := abi.JSON(strings.NewReader(bindings.OrganizationRegistryABI))
+	if err != nil {
+		return fmt.Errorf("failed to parse organization registry ABI: %w", err)
+	}
+	processRegistryABI, err := abi.JSON(strings.NewReader(bindings.ProcessRegistryABI))
+	if err != nil {
+		return fmt.Errorf("failed to parse process registry ABI: %w", err)
+	}
+	zkVerifierABI, err := abi.JSON(strings.NewReader(bindings.Groth16VerifierABI))
+	if err != nil {
+		return fmt.Errorf("failed to parse zk verifier ABI: %w", err)
+	}
+
+	c.ContractABIs = &ContractABIs{
+		OrganizationRegistry: &orgRegistryABI,
+		ProcessRegistry:      &processRegistryABI,
+		ZKVerifier:           &zkVerifierABI,
+	}
+
 	return nil
 }
 
@@ -317,4 +352,135 @@ func (c *Contracts) authTransactOpts() (*bind.TransactOpts, error) {
 	}
 	auth.Nonce = new(big.Int).SetUint64(nonce)
 	return auth, nil
+}
+
+// dev note: this is a temporary method to simulate contract calls
+// it works on geth but not expected to work on other clients or external rpc providers
+// SimulateContractCall simulates a contract call using the eth_simulateV1 RPC method.
+func (c *Contracts) SimulateContractCall(
+	ctx context.Context,
+	contractAddr common.Address,
+	contractABI *abi.ABI,
+	method string, args ...interface{},
+) error {
+	data, err := contractABI.Pack(method, args...)
+	if err != nil {
+		return fmt.Errorf("pack %s: %w", method, err)
+	}
+	auth, err := c.authTransactOpts()
+	if err != nil {
+		return fmt.Errorf("failed to create transactor: %w", err)
+	}
+
+	auth.GasPrice, err = c.cli.SuggestGasPrice(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get gas price: %w", err)
+	}
+	simReq := SimulationRequest{
+		BlockStateCalls: []BlockStateCall{
+			{
+				Calls: []Call{{
+					From:     c.signer.Address(),
+					To:       contractAddr,
+					Data:     data,
+					GasPrice: (*hexutil.Big)(big.NewInt(auth.GasPrice.Int64())),
+					Nonce:    hexutil.Uint64(auth.Nonce.Uint64()),
+				}},
+			},
+		},
+		Validation:             true,
+		ReturnFullTransactions: true,
+	}
+
+	var simBlocks []SimulatedBlock
+	if err := c.cli.CallSimulation(ctx, &simBlocks, simReq, "latest"); err != nil {
+		return fmt.Errorf("eth_simulateV1 RPC error: %w", err)
+	}
+
+	if len(simBlocks) == 0 || len(simBlocks[0].Calls) == 0 {
+		return fmt.Errorf("no simulation result")
+	}
+	call := simBlocks[0].Calls[0]
+	if call.Status == "0x1" {
+		// success, nothing to do
+		return nil
+	}
+
+	reason, uerr := c.decodeRevert(call.Error.Data)
+	if uerr != nil {
+		return fmt.Errorf("call reverted; failed to unpack reason: %w", uerr)
+	}
+	return fmt.Errorf("call reverted: %s", reason)
+}
+
+// decodeRevert decodes the revert reason from the given data.
+func (c *Contracts) decodeRevert(data hexutil.Bytes) (string, error) {
+	var errorName string
+	err := c.ContractABIs.ForEachABI(func(name string, a *abi.ABI) error {
+		log.Debugf("ABI %s has %d methods, %d events and %d errors\n",
+			name, len(a.Methods), len(a.Events), len(a.Errors))
+		for _, e := range a.Errors {
+			sig := strings.TrimPrefix(e.String(), "error ")
+			hash := crypto.Keccak256([]byte(sig))[:4]
+			if bytes.Equal(data, hash) {
+				errorName = sig
+				return nil
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	if errorName != "" {
+		return errorName, nil
+	}
+	return "", fmt.Errorf("unknown error selector %s", data.String())
+}
+
+// ForEachABI calls fn(name, abi) for each non-nil *abi.ABI field.
+// Stops and returns an error if fn returns an error.
+func (c *ContractABIs) ForEachABI(fn func(fieldName string, a *abi.ABI) error) error {
+	v := reflect.ValueOf(c).Elem()      // reflect.Value of the struct
+	t := v.Type()                       // reflect.Type of the struct
+	for i := 0; i < v.NumField(); i++ { // loop fields
+		fieldVal := v.Field(i)
+		if fieldVal.IsNil() {
+			continue
+		}
+		abiPtr, ok := fieldVal.Interface().(*abi.ABI)
+		if !ok {
+			// should never happen if your struct is well-typed
+			continue
+		}
+		fieldName := t.Field(i).Name
+		if err := fn(fieldName, abiPtr); err != nil {
+			return fmt.Errorf("%s: %w", fieldName, err)
+		}
+	}
+	return nil
+}
+
+func (c *Contracts) ProcessRegistryABI() (*abi.ABI, error) {
+	processRegistryABI, err := abi.JSON(strings.NewReader(bindings.ProcessRegistryABI))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse process registry ABI: %w", err)
+	}
+	return &processRegistryABI, nil
+}
+
+func (c *Contracts) OrganizationRegistryABI() (*abi.ABI, error) {
+	organizationRegistryABI, err := abi.JSON(strings.NewReader(bindings.OrganizationRegistryABI))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse organization registry ABI: %w", err)
+	}
+	return &organizationRegistryABI, nil
+}
+
+func (c *Contracts) ZKVerifierABI() (*abi.ABI, error) {
+	zkVerifierABI, err := abi.JSON(strings.NewReader(bindings.Groth16VerifierABI))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse zk verifier ABI: %w", err)
+	}
+	return &zkVerifierABI, nil
 }

--- a/web3/rpc/web3_iter.go
+++ b/web3/rpc/web3_iter.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
 )
 
 // Web3Endpoint struct contains all the required information about a web3
@@ -15,6 +16,7 @@ type Web3Endpoint struct {
 	URI       string
 	IsArchive bool
 	client    *ethclient.Client
+	rpcClient *rpc.Client
 }
 
 // Web3Iterator struct is a pool of Web3Endpoint that allows to get the next

--- a/web3/types.go
+++ b/web3/types.go
@@ -1,0 +1,67 @@
+package web3
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+)
+
+// SimulationRequest is the top‐level payload for eth_simulateV1
+type SimulationRequest struct {
+	BlockStateCalls        []BlockStateCall `json:"blockStateCalls"`
+	Validation             bool             `json:"validation,omitempty"`
+	TraceTransfers         bool             `json:"traceTransfers,omitempty"`
+	ReturnFullTransactions bool             `json:"returnFullTransactions,omitempty"`
+}
+
+// BlockStateCall lets you override block fields, state, and queue up calls
+type BlockStateCall struct {
+	BlockOverrides *BlockOverrides          `json:"blockOverrides,omitempty"`
+	StateOverrides map[string]StateOverride `json:"stateOverrides,omitempty"`
+	Calls          []Call                   `json:"calls"`
+}
+
+// minimal—you can add more fields if you need them
+type BlockOverrides struct {
+	BaseFeePerGas *hexutil.Big `json:"baseFeePerGas,omitempty"`
+	Timestamp     *hexutil.Big `json:"timestamp,omitempty"`
+}
+
+type StateOverride struct {
+	Balance *hexutil.Big   `json:"balance,omitempty"`
+	Nonce   hexutil.Uint64 `json:"nonce,omitempty"`
+	Code    *hexutil.Bytes `json:"code,omitempty"`
+}
+
+// Call is a single EVM call
+type Call struct {
+	From                 common.Address `json:"from,omitempty"`
+	To                   common.Address `json:"to,omitempty"`
+	Gas                  hexutil.Uint64 `json:"gas,omitempty"`
+	GasPrice             *hexutil.Big   `json:"gasPrice,omitempty"`
+	MaxFeePerGas         *hexutil.Big   `json:"maxFeePerGas,omitempty"`
+	MaxPriorityFeePerGas *hexutil.Big   `json:"maxPriorityFeePerGas,omitempty"`
+	Value                *hexutil.Big   `json:"value,omitempty"`
+	Data                 hexutil.Bytes  `json:"data,omitempty"`
+	Nonce                hexutil.Uint64 `json:"nonce,omitempty"`
+}
+
+// What comes back
+type SimulatedBlock struct {
+	Hash   common.Hash  `json:"hash"`
+	Number string       `json:"number"`
+	Calls  []CallResult `json:"calls"`
+}
+
+type CallResult struct {
+	Status     string         `json:"status"` // "0x1" or "0x0"
+	ReturnData hexutil.Bytes  `json:"returnData"`
+	GasUsed    hexutil.Uint64 `json:"gasUsed"`
+	Logs       []interface{}  `json:"logs"`
+	Error      *RPCError      `json:"error,omitempty"`
+}
+
+type RPCError struct {
+	Code    int           `json:"code"`
+	Message string        `json:"message"`
+	Data    hexutil.Bytes `json:"data"`
+}


### PR DESCRIPTION
- Previously, failed transactions only surfaced a generic revert error—losing any custom revert message emitted by the smart contract.
- This PR integrates the Geth RPC method eth_simulateV1 to simulate a transaction off-chain (no gas cost or state change) and capture the contract’s revert reason.
- Implementation is generic and works with any registered sequencer contract transaction.
- **Caveat**: not all RPC providers or Geth-based nodes expose eth_simulateV1. To avoid runtime failures in production, consider extracting this logic into a debug/dev-only package or feature-flagging it until broad RPC support is ensured.