### PR TITLE
sequencer: optimize ballot aggregation timing

### DIFF
--- a/sequencer/aggregate_test.go
+++ b/sequencer/aggregate_test.go
@@ -1,0 +1,50 @@
+package sequencer
+
+import (
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// TestBatchTimingBehavior tests the core behavior of our timing update:
+// - Time window only starts counting when there's at least one ballot
+// - Timer is reset after processing a batch
+func TestBatchTimingBehavior(t *testing.T) {
+	// This test verifies the logic flow, not actual dependencies
+	c := qt.New(t)
+
+	// Create a ProcessIDMap for testing
+	pmap := NewProcessIDMap()
+	pid := []byte{1, 2, 3, 4}
+
+	// 1. Initially, there should be no first ballot timestamp
+	_, exists := pmap.GetFirstBallotTime(pid)
+	c.Assert(exists, qt.Equals, false, qt.Commentf("Initially, there should be no first ballot timestamp"))
+
+	// Set the first ballot time
+	startTime := time.Now()
+	pmap.SetFirstBallotTime(pid)
+	initialTime, exists := pmap.GetFirstBallotTime(pid)
+	c.Assert(exists, qt.Equals, true, qt.Commentf("After setting, first ballot timestamp should exist"))
+
+	// Check time is recent (within 1 second of now)
+	c.Assert(initialTime.After(startTime.Add(-time.Second)), qt.IsTrue,
+		qt.Commentf("First ballot time should be recent"))
+
+	// Sleep a bit to ensure time difference
+	time.Sleep(10 * time.Millisecond)
+
+	// 3. After processing a batch, the timestamp should be cleared
+	pmap.ClearFirstBallotTime(pid)
+	_, exists = pmap.GetFirstBallotTime(pid)
+	c.Assert(exists, qt.Equals, false, qt.Commentf("After clearing, timestamp should not exist"))
+
+	// 4. When next ballot arrives, a new timestamp should be set
+	newStartTime := time.Now()
+	pmap.SetFirstBallotTime(pid)
+	newTime, exists := pmap.GetFirstBallotTime(pid)
+	c.Assert(exists, qt.Equals, true, qt.Commentf("After setting again, timestamp should exist"))
+	c.Assert(newTime.After(newStartTime.Add(-time.Second)), qt.IsTrue,
+		qt.Commentf("New first ballot time should be recent"))
+}

--- a/sequencer/processidmap_test.go
+++ b/sequencer/processidmap_test.go
@@ -60,3 +60,38 @@ func TestProcessIDMap(t *testing.T) {
 	pids := pidMap.List()
 	c.Assert(len(pids), qt.Equals, 3, qt.Commentf("List should return all process IDs"))
 }
+
+func TestFirstBallotTime(t *testing.T) {
+	c := qt.New(t)
+
+	// Create a new ProcessIDMap
+	pidMap := NewProcessIDMap()
+	pid1 := []byte{1, 2, 3, 4}
+
+	// Initially, there should be no first ballot time
+	_, exists := pidMap.GetFirstBallotTime(pid1)
+	c.Assert(exists, qt.Equals, false, qt.Commentf("Initially, there should be no first ballot time"))
+
+	// Set the first ballot time
+	pidMap.SetFirstBallotTime(pid1)
+	time1, exists := pidMap.GetFirstBallotTime(pid1)
+	c.Assert(exists, qt.Equals, true, qt.Commentf("Should have a first ballot time after setting it"))
+
+	// Setting it again should not change the time
+	time.Sleep(10 * time.Millisecond) // Small delay to ensure time difference
+	pidMap.SetFirstBallotTime(pid1)
+	time2, exists := pidMap.GetFirstBallotTime(pid1)
+	c.Assert(exists, qt.Equals, true, qt.Commentf("Should still have a first ballot time"))
+	c.Assert(time1, qt.Equals, time2, qt.Commentf("Setting first ballot time again should not change it"))
+
+	// Clear the first ballot time
+	pidMap.ClearFirstBallotTime(pid1)
+	_, exists = pidMap.GetFirstBallotTime(pid1)
+	c.Assert(exists, qt.Equals, false, qt.Commentf("Should have no first ballot time after clearing it"))
+
+	// Setting it again after clearing should work
+	pidMap.SetFirstBallotTime(pid1)
+	time3, exists := pidMap.GetFirstBallotTime(pid1)
+	c.Assert(exists, qt.Equals, true, qt.Commentf("Should have a first ballot time after setting it again"))
+	c.Assert(time3.After(time1), qt.Equals, true, qt.Commentf("New first ballot time should be after the original"))
+}


### PR DESCRIPTION
Modified the aggregation process to only start the time window when the first ballot arrives, not from registration/last update

This change avoids processing single ballots after periods of inactivity, allowing more efficient batch utilization by accumulating votes before triggering aggregation.