### PR TITLE
bug: different voteID between API and wasm

### DIFF
--- a/storage/types.go
+++ b/storage/types.go
@@ -116,7 +116,7 @@ func (b *Ballot) VoteID() []byte {
 	if b.BallotInputsHash == nil {
 		return nil
 	}
-	return crypto.BigIntToFFwithPadding(b.BallotInputsHash, circuits.BallotProofCurve.ScalarField())
+	return crypto.BigIntToFFwithPadding(b.BallotInputsHash, circuits.VoteVerifierCurve.ScalarField())
 }
 
 func (b *Ballot) String() string {


### PR DESCRIPTION
format the ballot hash properly as voteID in the storage