### PR TITLE
feature: integration test over remote rpc

### DIFF
--- a/sequencer/onchain.go
+++ b/sequencer/onchain.go
@@ -105,6 +105,7 @@ func (s *Sequencer) pushToContract(processID []byte,
 		return fmt.Errorf("failed to encode inputs: %w", err)
 	}
 	log.Debugw("proof ready to submit to the contract",
+		"pid", hex.EncodeToString(processID),
 		"commitments", proof.Commitments,
 		"commitmentPok", proof.CommitmentPok,
 		"proof", proof.Proof,
@@ -123,7 +124,9 @@ func (s *Sequencer) pushToContract(processID []byte,
 		abiProof,
 		abiInputs,
 	); err != nil {
-		return fmt.Errorf("failed to simulate state transition: %s", err.Error())
+		log.Warnw("failed to simulate state transition",
+			"error", err,
+			"pid", hex.EncodeToString(processID))
 	}
 
 	// submit the proof to the contract if simulation is successful

--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -24,9 +24,9 @@ services:
       - --dev
       - --ipcdisable
     ports:
-      - ${GETH_PORT_8545:-8545}:8545
-      - ${GETH_PORT_8546:-8546}:8546
-      - ${GETH_PORT_8551:-8551}:8551
+      - ${GETH_PORT_RPC_HTTP:-8545}:8545
+      - ${GETH_PORT_RPC_WS:-8546}:8546
+      - ${GETH_PORT_P2P:-8551}:8551
     depends_on:
       geth-genesis:
         condition: service_completed_successfully

--- a/tests/helpers_test.go
+++ b/tests/helpers_test.go
@@ -130,6 +130,9 @@ func setupWeb3(t *testing.T, ctx context.Context) *web3.Contracts {
 		qt.Assert(t, err, qt.IsNil)
 		log.Infow("contracts deployed", "chainId", contracts.ChainID)
 	} else {
+		// Set the private key for the sequencer
+		err = contracts.SetAccountPrivateKey(util.TrimHex(privKey))
+		qt.Assert(t, err, qt.IsNil)
 		// Create the contracts object with the addresses from the environment
 		err = contracts.LoadContracts(&web3.Addresses{
 			OrganizationRegistry: common.HexToAddress(orgRegistryAddr),

--- a/tests/helpers_test.go
+++ b/tests/helpers_test.go
@@ -95,9 +95,9 @@ func setupWeb3(t *testing.T, ctx context.Context) *web3.Contracts {
 		rpcUrl = fmt.Sprintf("http://localhost:%d", gethPort)
 		// Set environment variables for docker-compose in the process environment
 		composeEnv := make(map[string]string)
-		composeEnv["GETH_PORT_8545"] = fmt.Sprintf("%d", gethPort)
-		composeEnv["GETH_PORT_8546"] = fmt.Sprintf("%d", gethPort+1)
-		composeEnv["GETH_PORT_8551"] = fmt.Sprintf("%d", gethPort+6)
+		composeEnv["GETH_PORT_RPC_HTTP"] = fmt.Sprintf("%d", gethPort)
+		composeEnv["GETH_PORT_RPC_WS"] = fmt.Sprintf("%d", gethPort+1)
+		composeEnv["GETH_PORT_P2P"] = fmt.Sprintf("%d", gethPort+6)
 
 		// Create docker-compose instance
 		compose, err := tc.NewDockerCompose("docker/docker-compose.yml")
@@ -424,7 +424,7 @@ func checkProcessedVotes(t *testing.T, cli *client.HTTPclient, pid *types.Proces
 		c.Assert(statusResponse.Status, qt.Not(qt.Equals), "")
 
 		// Check if the vote is processed
-		if statusResponse.Status != "processed" {
+		if statusResponse.Status != storage.BallotStatusName(storage.BallotStatusProcessed) {
 			allProcessed = false
 		}
 

--- a/tests/helpers_test.go
+++ b/tests/helpers_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math/big"
 	"net/http"
+	"os"
 	"testing"
 	"time"
 
@@ -34,7 +35,17 @@ import (
 	"go.vocdoni.io/dvote/db/metadb"
 )
 
-const testLocalAccountPrivKey = "0cebebc37477f513cd8f946ffced46e368aa4f9430250ce4507851edbba86b20" // defined in docker/files/genesis.json
+const (
+	testLocalAccountPrivKey = "0cebebc37477f513cd8f946ffced46e368aa4f9430250ce4507851edbba86b20" // defined in docker/files/genesis.json
+	// envarionment variable names
+	privKeyEnvVarName         = "SEQUENCER_PRIV_KEY"              // environment variable name for private key
+	rpcUrlEnvVarName          = "SEQUENCER_RPC_URL"               // environment variable name for RPC URL
+	orgRegistryEnvVarName     = "SEQUENCER_ORGANIZATION_REGISTRY" // environment variable name for organization registry
+	processRegistryEnvVarName = "SEQUENCER_PROCESS_REGISTRY"      // environment variable name for process registry
+	resultsRegistryEnvVarName = "SEQUENCER_RESULTS_REGISTRY"      // environment variable name for results registry
+	zkVerifierEnvVarName      = "SEQUENCER_ZK_VERIFIER"           // environment variable name for zk verifier
+
+)
 
 // Services struct holds all test services
 type Services struct {
@@ -60,60 +71,137 @@ func setupAPI(ctx context.Context, db *storage.Storage) (*service.APIService, er
 	return api, nil
 }
 
+// setupWeb3 sets up the web3 contracts for testing. It deploys the contracts
+// if the environment variables are not set, if they are set it loads the
+// contracts from the environment variables. It returns the contracts object.
+func setupWeb3(t *testing.T, ctx context.Context) *web3.Contracts {
+	// Get the environment variables
+	var (
+		privKey             = os.Getenv(privKeyEnvVarName)
+		rpcUrl              = os.Getenv(rpcUrlEnvVarName)
+		orgRegistryAddr     = os.Getenv(orgRegistryEnvVarName)
+		processRegistryAddr = os.Getenv(processRegistryEnvVarName)
+		resultsRegistryAddr = os.Getenv(resultsRegistryEnvVarName)
+		zkVerifierAddr      = os.Getenv(zkVerifierEnvVarName)
+	)
+	// Check if the environment variables are set to run the tests over local
+	// geth node or remote blockchain environment
+	localEnv := privKey == "" || rpcUrl == "" || orgRegistryAddr == "" ||
+		processRegistryAddr == "" || resultsRegistryAddr == "" || zkVerifierAddr == ""
+	if localEnv {
+		// Generate a random port for geth HTTP RPC
+		gethPort := util.RandomInt(10000, 20000)
+		rpcUrl = fmt.Sprintf("http://localhost:%d", gethPort)
+		// Set environment variables for docker-compose in the process environment
+		composeEnv := make(map[string]string)
+		composeEnv["GETH_PORT_8545"] = fmt.Sprintf("%d", gethPort)
+		composeEnv["GETH_PORT_8546"] = fmt.Sprintf("%d", gethPort+1)
+		composeEnv["GETH_PORT_8551"] = fmt.Sprintf("%d", gethPort+6)
+
+		// Create docker-compose instance
+		compose, err := tc.NewDockerCompose("docker/docker-compose.yml")
+		qt.Assert(t, err, qt.IsNil)
+		t.Cleanup(func() {
+			err := compose.Down(ctx, tc.RemoveOrphans(true), tc.RemoveVolumes(true))
+			qt.Assert(t, err, qt.IsNil)
+		})
+		ctx2, cancel := context.WithCancel(ctx)
+		t.Cleanup(cancel)
+
+		// Start docker-compose
+		log.Infow("starting Geth docker compose", "gethPort", gethPort)
+		err = compose.WithEnv(composeEnv).Up(ctx2, tc.Wait(true), tc.RemoveOrphans(true))
+		qt.Assert(t, err, qt.IsNil)
+	}
+
+	// Wait for the RPC to be ready
+	err := web3.WaitReadyRPC(ctx, rpcUrl)
+	qt.Assert(t, err, qt.IsNil)
+
+	var contracts *web3.Contracts
+	if localEnv {
+		// Deploy the contracts using the local geth node
+		log.Infow("deploying contracts", "url", rpcUrl)
+		contracts, err = web3.DeployContracts(rpcUrl, testLocalAccountPrivKey)
+		qt.Assert(t, err, qt.IsNil)
+		log.Infow("contracts deployed", "chainId", contracts.ChainID)
+	} else {
+		// Create the contracts object with the addresses from the environment
+		err = contracts.LoadContracts(&web3.Addresses{
+			OrganizationRegistry: common.HexToAddress(orgRegistryAddr),
+			ProcessRegistry:      common.HexToAddress(processRegistryAddr),
+			ResultsRegistry:      common.HexToAddress(resultsRegistryAddr),
+			ZKVerifier:           common.HexToAddress(zkVerifierAddr),
+		})
+		qt.Assert(t, err, qt.IsNil)
+	}
+	// Set contracts ABIs
+	contracts.ContractABIs = &web3.ContractABIs{}
+	contracts.ContractABIs.ProcessRegistry, err = contracts.ProcessRegistryABI()
+	qt.Assert(t, err, qt.IsNil)
+	contracts.ContractABIs.OrganizationRegistry, err = contracts.OrganizationRegistryABI()
+	qt.Assert(t, err, qt.IsNil)
+	contracts.ContractABIs.ZKVerifier, err = contracts.ZKVerifierABI()
+	qt.Assert(t, err, qt.IsNil)
+	// Return the contracts object
+	return contracts
+}
+
 // NewTestClient creates a new API client for testing.
 func NewTestClient(port int) (*client.HTTPclient, error) {
 	return client.New(fmt.Sprintf("http://127.0.0.1:%d", port))
 }
 
 func NewTestService(t *testing.T, ctx context.Context) *Services {
-	// Generate a random port for geth HTTP RPC
-	gethPort := util.RandomInt(10000, 20000)
-	gethURL := fmt.Sprintf("http://localhost:%d", gethPort)
-	// Set environment variables for docker-compose in the process environment
-	composeEnv := make(map[string]string)
-	composeEnv["GETH_PORT_8545"] = fmt.Sprintf("%d", gethPort)
-	composeEnv["GETH_PORT_8546"] = fmt.Sprintf("%d", gethPort+1)
-	composeEnv["GETH_PORT_8551"] = fmt.Sprintf("%d", gethPort+6)
+	// // Generate a random port for geth HTTP RPC
+	// gethPort := util.RandomInt(10000, 20000)
+	// gethURL := fmt.Sprintf("http://localhost:%d", gethPort)
+	// // Set environment variables for docker-compose in the process environment
+	// composeEnv := make(map[string]string)
+	// composeEnv["GETH_PORT_8545"] = fmt.Sprintf("%d", gethPort)
+	// composeEnv["GETH_PORT_8546"] = fmt.Sprintf("%d", gethPort+1)
+	// composeEnv["GETH_PORT_8551"] = fmt.Sprintf("%d", gethPort+6)
 
-	// Create docker-compose instance
-	compose, err := tc.NewDockerCompose("docker/docker-compose.yml")
-	qt.Assert(t, err, qt.IsNil)
-	t.Cleanup(func() {
-		err := compose.Down(ctx, tc.RemoveOrphans(true), tc.RemoveVolumes(true))
-		qt.Assert(t, err, qt.IsNil)
-	})
-	ctx2, cancel := context.WithCancel(ctx)
-	t.Cleanup(cancel)
+	// // Create docker-compose instance
+	// compose, err := tc.NewDockerCompose("docker/docker-compose.yml")
+	// qt.Assert(t, err, qt.IsNil)
+	// t.Cleanup(func() {
+	// 	err := compose.Down(ctx, tc.RemoveOrphans(true), tc.RemoveVolumes(true))
+	// 	qt.Assert(t, err, qt.IsNil)
+	// })
+	// ctx2, cancel := context.WithCancel(ctx)
+	// t.Cleanup(cancel)
 
-	// Start docker-compose
-	log.Infow("starting Geth docker compose", "gethPort", gethPort)
-	err = compose.WithEnv(composeEnv).Up(ctx2, tc.Wait(true), tc.RemoveOrphans(true))
-	qt.Assert(t, err, qt.IsNil)
+	// // Start docker-compose
+	// log.Infow("starting Geth docker compose", "gethPort", gethPort)
+	// err = compose.WithEnv(composeEnv).Up(ctx2, tc.Wait(true), tc.RemoveOrphans(true))
+	// qt.Assert(t, err, qt.IsNil)
 
-	// Wait for the RPC to be ready
-	err = web3.WaitReadyRPC(ctx, gethURL)
-	qt.Assert(t, err, qt.IsNil)
+	// // Wait for the RPC to be ready
+	// err = web3.WaitReadyRPC(ctx, gethURL)
+	// qt.Assert(t, err, qt.IsNil)
 
-	log.Infow("deploying contracts", "url", gethURL)
-	contracts, err := web3.DeployContracts(gethURL, testLocalAccountPrivKey)
-	if err != nil {
-		log.Fatal(err)
-	}
-	log.Infow("contracts deployed", "chainId", contracts.ChainID)
+	// log.Infow("deploying contracts", "url", gethURL)
+	// contracts, err := web3.DeployContracts(gethURL, testLocalAccountPrivKey)
+	// if err != nil {
+	// 	log.Fatal(err)
+	// }
+	// log.Infow("contracts deployed", "chainId", contracts.ChainID)
 
-	contracts.ContractABIs = &web3.ContractABIs{}
-	contracts.ContractABIs.ProcessRegistry, err = contracts.ProcessRegistryABI()
-	if err != nil {
-		log.Fatal(err)
-	}
-	contracts.ContractABIs.OrganizationRegistry, err = contracts.OrganizationRegistryABI()
-	if err != nil {
-		log.Fatal(err)
-	}
-	contracts.ContractABIs.ZKVerifier, err = contracts.ZKVerifierABI()
-	if err != nil {
-		log.Fatal(err)
-	}
+	// contracts.ContractABIs = &web3.ContractABIs{}
+	// contracts.ContractABIs.ProcessRegistry, err = contracts.ProcessRegistryABI()
+	// if err != nil {
+	// 	log.Fatal(err)
+	// }
+	// contracts.ContractABIs.OrganizationRegistry, err = contracts.OrganizationRegistryABI()
+	// if err != nil {
+	// 	log.Fatal(err)
+	// }
+	// contracts.ContractABIs.ZKVerifier, err = contracts.ZKVerifierABI()
+	// if err != nil {
+	// 	log.Fatal(err)
+	// }
+	contracts := setupWeb3(t, ctx)
 
 	kv, err := metadb.New(db.TypePebble, t.TempDir())
 	qt.Assert(t, err, qt.IsNil)

--- a/tests/helpers_test.go
+++ b/tests/helpers_test.go
@@ -118,7 +118,11 @@ func setupWeb3(t *testing.T, ctx context.Context) *web3.Contracts {
 	err := web3.WaitReadyRPC(ctx, rpcUrl)
 	qt.Assert(t, err, qt.IsNil)
 
-	var contracts *web3.Contracts
+	// Initialize the contracts object
+	contracts, err := web3.New([]string{rpcUrl})
+	qt.Assert(t, err, qt.IsNil)
+
+	// Define contracts addresses or deploy them
 	if localEnv {
 		// Deploy the contracts using the local geth node
 		log.Infow("deploying contracts", "url", rpcUrl)
@@ -135,6 +139,7 @@ func setupWeb3(t *testing.T, ctx context.Context) *web3.Contracts {
 		})
 		qt.Assert(t, err, qt.IsNil)
 	}
+
 	// Set contracts ABIs
 	contracts.ContractABIs = &web3.ContractABIs{}
 	contracts.ContractABIs.ProcessRegistry, err = contracts.ProcessRegistryABI()

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -44,7 +44,7 @@ func TestIntegration(t *testing.T) {
 	services.Sequencer.SetBatchTimeWindow(time.Second * 50)
 
 	if os.Getenv("DEBUG") != "" && os.Getenv("DEBUG") != "false" {
-		// // Create a debug prover that will debug circuit execution during testing
+		// Create a debug prover that will debug circuit execution during testing
 		services.Sequencer.SetProver(sequencer.NewDebugProver(t))
 	} else {
 		t.Log("Debug prover is disabled! Set DEBUG=true to enable it.")

--- a/web3/process.go
+++ b/web3/process.go
@@ -62,15 +62,17 @@ func (c *Contracts) Process(processID []byte) (*types.Process, error) {
 	}
 
 	return contractProcess2Process(&ProcessRegistryProcess{
-		Status:          p.Status,
-		OrganizationId:  p.OrganizationId,
-		EncryptionKey:   p.EncryptionKey,
-		LatestStateRoot: p.LatestStateRoot,
-		StartTime:       p.StartTime,
-		Duration:        p.Duration,
-		MetadataURI:     p.MetadataURI,
-		BallotMode:      p.BallotMode,
-		Census:          p.Census,
+		Status:             p.Status,
+		OrganizationId:     p.OrganizationId,
+		EncryptionKey:      p.EncryptionKey,
+		LatestStateRoot:    p.LatestStateRoot,
+		StartTime:          p.StartTime,
+		Duration:           p.Duration,
+		MetadataURI:        p.MetadataURI,
+		BallotMode:         p.BallotMode,
+		Census:             p.Census,
+		VoteCount:          p.VoteCount,
+		VoteOverwriteCount: p.VoteOverwriteCount,
 	})
 }
 
@@ -245,26 +247,30 @@ func contractProcess2Process(p *ProcessRegistryProcess) (*types.Process, error) 
 			X: p.EncryptionKey.X,
 			Y: p.EncryptionKey.Y,
 		},
-		StateRoot:   (*types.BigInt)(p.LatestStateRoot),
-		StartTime:   time.Unix(int64(p.StartTime.Uint64()), 0),
-		Duration:    time.Duration(p.Duration.Uint64()) * time.Second,
-		MetadataURI: p.MetadataURI,
-		BallotMode:  &mode,
-		Census:      &census,
+		StateRoot:          (*types.BigInt)(p.LatestStateRoot),
+		StartTime:          time.Unix(int64(p.StartTime.Uint64()), 0),
+		Duration:           time.Duration(p.Duration.Uint64()) * time.Second,
+		MetadataURI:        p.MetadataURI,
+		BallotMode:         &mode,
+		Census:             &census,
+		VoteCount:          (*types.BigInt)(p.VoteCount),
+		VoteOverwriteCount: (*types.BigInt)(p.VoteOverwriteCount),
 	}, nil
 }
 
 // ProcessRegistryProcess is a mirror of the on-chain process tuple constructed with the auto-generated bindings
 type ProcessRegistryProcess struct {
-	Status          uint8
-	OrganizationId  common.Address
-	EncryptionKey   bindings.IProcessRegistryEncryptionKey
-	LatestStateRoot *big.Int
-	StartTime       *big.Int
-	Duration        *big.Int
-	MetadataURI     string
-	BallotMode      bindings.IProcessRegistryBallotMode
-	Census          bindings.IProcessRegistryCensus
+	Status             uint8
+	OrganizationId     common.Address
+	EncryptionKey      bindings.IProcessRegistryEncryptionKey
+	LatestStateRoot    *big.Int
+	StartTime          *big.Int
+	Duration           *big.Int
+	MetadataURI        string
+	BallotMode         bindings.IProcessRegistryBallotMode
+	Census             bindings.IProcessRegistryCensus
+	VoteCount          *big.Int
+	VoteOverwriteCount *big.Int
 }
 
 func process2ContractProcess(p *types.Process) ProcessRegistryProcess {
@@ -294,6 +300,8 @@ func process2ContractProcess(p *types.Process) ProcessRegistryProcess {
 	prp.Census.CensusOrigin = p.Census.CensusOrigin
 	prp.Census.MaxVotes = p.Census.MaxVotes.MathBigInt()
 	prp.Census.CensusURI = p.Census.CensusURI
+	prp.VoteCount = p.VoteCount.MathBigInt()
+	prp.VoteOverwriteCount = p.VoteOverwriteCount.MathBigInt()
 
 	return prp
 }


### PR DESCRIPTION
This PR includes some other related changes:
 * Include vote counters in `web3` package functions.
 * Include some helpers in the integration test to check if the casted votes are processed and published in the smart contract.
 * Fix the integration test to take the test timeout as deadline to reach the expected status.