### PR TITLE
web3: add results verifier contract

### DIFF
--- a/api/info.go
+++ b/api/info.go
@@ -30,9 +30,10 @@ func (a *API) info(w http.ResponseWriter, r *http.Request) {
 		WASMhelperExecJsURL:  config.BallotProofWasmExecJsURL,
 		WASMhelperExecJsHash: config.BallotProofWasmExecJsHash,
 		Contracts: ContractAddresses{
-			ProcessRegistry:      contracts.ProcessRegistrySmartContract,
-			OrganizationRegistry: contracts.OrganizationRegistrySmartContract,
-			Results:              contracts.ResultsSmartContract,
+			ProcessRegistry:           contracts.ProcessRegistrySmartContract,
+			OrganizationRegistry:      contracts.OrganizationRegistrySmartContract,
+			StateTransitionZKVerifier: contracts.StateTransitionZKVerifier,
+			ResultsZKVerifier:         contracts.ResultsZKVerifier,
 		},
 	}
 

--- a/api/info_test.go
+++ b/api/info_test.go
@@ -55,7 +55,8 @@ func TestInfo(t *testing.T) {
 		contracts := config.DefaultConfig["sep"]
 		c.Assert(response.Contracts.ProcessRegistry, qt.Equals, contracts.ProcessRegistrySmartContract)
 		c.Assert(response.Contracts.OrganizationRegistry, qt.Equals, contracts.OrganizationRegistrySmartContract)
-		c.Assert(response.Contracts.Results, qt.Equals, contracts.ResultsSmartContract)
+		c.Assert(response.Contracts.ResultsZKVerifier, qt.Equals, contracts.ResultsZKVerifier)
+		c.Assert(response.Contracts.StateTransitionZKVerifier, qt.Equals, contracts.StateTransitionZKVerifier)
 	})
 
 	// Test case 2: Invalid network

--- a/api/types.go
+++ b/api/types.go
@@ -44,9 +44,10 @@ type Vote struct {
 
 // ContractAddresses holds the smart contract addresses needed by the client
 type ContractAddresses struct {
-	ProcessRegistry      string `json:"process"`
-	OrganizationRegistry string `json:"organization"`
-	Results              string `json:"results"`
+	ProcessRegistry           string `json:"process"`
+	OrganizationRegistry      string `json:"organization"`
+	StateTransitionZKVerifier string `json:"stateTransitionVerifier"`
+	ResultsZKVerifier         string `json:"resultsVerifier"`
 }
 
 // BallotProofInfo contains all the information needed by a client to generate a ballot zkSNARK proof.

--- a/cmd/davinci-sequencer/config.go
+++ b/cmd/davinci-sequencer/config.go
@@ -44,7 +44,6 @@ type Web3Config struct {
 	Rpc               []string `mapstructure:"rpc"`
 	ProcessAddr       string   `mapstructure:"process"`
 	OrganizationsAddr string   `mapstructure:"orgs"`
-	ResultsAddr       string   `mapstructure:"results"`
 }
 
 // APIConfig holds the API-specific configuration

--- a/cmd/davinci-sequencer/main.go
+++ b/cmd/davinci-sequencer/main.go
@@ -90,23 +90,16 @@ func getContractAddresses(cfg *Config) (*web3.Addresses, error) {
 		orgRegistryAddr = cfg.Web3.OrganizationsAddr
 	}
 
-	resultsAddr := networkConfig.ResultsSmartContract
-	if cfg.Web3.ResultsAddr != "" {
-		resultsAddr = cfg.Web3.ResultsAddr
-	}
-
 	// Log the contract addresses being used
 	log.Infow("using contract addresses",
 		"network", cfg.Web3.Network,
 		"processRegistry", processRegistryAddr,
-		"orgRegistry", orgRegistryAddr,
-		"resultsRegistry", resultsAddr)
+		"orgRegistry", orgRegistryAddr)
 
 	// Create the addresses struct
 	return &web3.Addresses{
 		ProcessRegistry:      common.HexToAddress(processRegistryAddr),
 		OrganizationRegistry: common.HexToAddress(orgRegistryAddr),
-		ResultsRegistry:      common.HexToAddress(resultsAddr),
 	}, nil
 }
 

--- a/config/contracts.go
+++ b/config/contracts.go
@@ -4,17 +4,17 @@ package config
 type DavinciWeb3Config struct {
 	ProcessRegistrySmartContract      string
 	OrganizationRegistrySmartContract string
-	ResultsSmartContract              string
+	ResultsZKVerifier                 string
 	StateTransitionZKVerifier         string
 }
 
 // DefaultConfig contains the default smart contract addresses for Davinci by network.
 var DefaultConfig = map[string]DavinciWeb3Config{
 	"sep": {
-		ProcessRegistrySmartContract:      "0x449598f6A4C53ABA99e6029f92757f110bFCEdB5",
-		OrganizationRegistrySmartContract: "0x799dF2b1AF3393d821b4552a28089282267403Be",
-		ResultsSmartContract:              "0x799dF2b1AF3393d821b4552a28089282267403Be", // duplicate for now
-		StateTransitionZKVerifier:         "0xb2e927353a99EF22E180BfA5F1BF10F86f124326",
+		ProcessRegistrySmartContract:      "0xB538d3fBF4C9cF3A31d6c6E2d15B405Ff66c3B15",
+		OrganizationRegistrySmartContract: "0x159630c26381AB98867E4A3f631fB69fE6b48DBF",
+		ResultsZKVerifier:                 "0xE2046392a389795Fe6F2b15C8A8Fc1582554828E", // duplicate for now
+		StateTransitionZKVerifier:         "0x13249EF15BEa50736b46BF8fF4d2DC2b4B32F151",
 	},
 }
 

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/testcontainers/testcontainers-go/modules/compose v0.35.0
 	github.com/vocdoni/arbo v0.0.0-20250513133053-b35dcc9c1f00
 	github.com/vocdoni/circom2gnark v1.0.1-0.20241204100355-b93800bd88a4
-	github.com/vocdoni/contracts-z v0.0.0-20250528091312-fd290e5ae19f
+	github.com/vocdoni/contracts-z v0.0.0-20250528135410-3179277098c3
 	github.com/vocdoni/gnark-crypto-primitives v0.0.2-0.20250526071704-a5cc90e03181
 	go.vocdoni.io/dvote v1.10.2-0.20241024102542-c1ce6d744bc5
 	golang.org/x/sync v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -705,8 +705,8 @@ github.com/vocdoni/arbo v0.0.0-20250513133053-b35dcc9c1f00 h1:Xi9lW+nTiKoDSJ/hfe
 github.com/vocdoni/arbo v0.0.0-20250513133053-b35dcc9c1f00/go.mod h1:2EyGpN1IgziTvCxkosVQj2sdEJaWJxe8vwgWG1BIHbw=
 github.com/vocdoni/circom2gnark v1.0.1-0.20241204100355-b93800bd88a4 h1:aYeMlhWAW+/OQs9BinA8Yetjcf5IPoCsFFtxXx3uLdc=
 github.com/vocdoni/circom2gnark v1.0.1-0.20241204100355-b93800bd88a4/go.mod h1:A1WU0hL7rO9oZlvp82you2uCc4T3/ySi1UNW6N6hBJs=
-github.com/vocdoni/contracts-z v0.0.0-20250528091312-fd290e5ae19f h1:yo3zW9Pv5yCusrjXRsoi8fOo7JHNGMsPopaDFkl7fgI=
-github.com/vocdoni/contracts-z v0.0.0-20250528091312-fd290e5ae19f/go.mod h1:ztzA4TBwnswOKlgiBqbVqRcCa+XkHkfazFcx2ZQsc50=
+github.com/vocdoni/contracts-z v0.0.0-20250528135410-3179277098c3 h1:M8vMVwBPNHcdmqHO7vzB1xQXGoJ+BDTKVOWlIhZ5Uo4=
+github.com/vocdoni/contracts-z v0.0.0-20250528135410-3179277098c3/go.mod h1:ztzA4TBwnswOKlgiBqbVqRcCa+XkHkfazFcx2ZQsc50=
 github.com/vocdoni/gnark-crypto-primitives v0.0.2-0.20250526071704-a5cc90e03181 h1:BDpJdwf11QzIn3V561dNkJHKobdcNO9kokBvtX6wxC8=
 github.com/vocdoni/gnark-crypto-primitives v0.0.2-0.20250526071704-a5cc90e03181/go.mod h1:tth1zQwq36tCCUJrq72y8gHEiwmJriJImlslLc1VQfQ=
 github.com/vocdoni/gnark-no-assert v0.0.0-20250430090134-56f68baa9b16 h1:XtdKB+e8woVMp58Rx3lUBb9FSbxwgDdToHZspd8EA5U=

--- a/web3/process.go
+++ b/web3/process.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-	bindings "github.com/vocdoni/contracts-z/golang-types/non-proxy"
+	npbindings "github.com/vocdoni/contracts-z/golang-types/non-proxy"
 	"github.com/vocdoni/vocdoni-z-sandbox/log"
 	"github.com/vocdoni/vocdoni-z-sandbox/types"
 )
@@ -166,7 +166,7 @@ func (c *Contracts) MonitorProcessCreation(ctx context.Context, interval time.Du
 // MonitorProcessCreationBySubscription monitors the creation of new processes by subscribing to the ProcessRegistry contract.
 // Requires the web3 rpc endpoint to support subscriptions on websockets.
 func (c *Contracts) MonitorProcessCreationBySubscription(ctx context.Context) (<-chan *types.Process, error) {
-	ch1 := make(chan *bindings.ProcessRegistryProcessCreated)
+	ch1 := make(chan *npbindings.ProcessRegistryProcessCreated)
 	ch2 := make(chan *types.Process)
 
 	sub, err := c.processes.WatchProcessCreated(nil, ch1, nil, nil)
@@ -262,13 +262,13 @@ func contractProcess2Process(p *ProcessRegistryProcess) (*types.Process, error) 
 type ProcessRegistryProcess struct {
 	Status             uint8
 	OrganizationId     common.Address
-	EncryptionKey      bindings.IProcessRegistryEncryptionKey
+	EncryptionKey      npbindings.IProcessRegistryEncryptionKey
 	LatestStateRoot    *big.Int
 	StartTime          *big.Int
 	Duration           *big.Int
 	MetadataURI        string
-	BallotMode         bindings.IProcessRegistryBallotMode
-	Census             bindings.IProcessRegistryCensus
+	BallotMode         npbindings.IProcessRegistryBallotMode
+	Census             npbindings.IProcessRegistryCensus
 	VoteCount          *big.Int
 	VoteOverwriteCount *big.Int
 }
@@ -278,14 +278,14 @@ func process2ContractProcess(p *types.Process) ProcessRegistryProcess {
 
 	prp.Status = p.Status
 	prp.OrganizationId = p.OrganizationId
-	prp.EncryptionKey = bindings.IProcessRegistryEncryptionKey{X: p.EncryptionKey.X, Y: p.EncryptionKey.Y}
+	prp.EncryptionKey = npbindings.IProcessRegistryEncryptionKey{X: p.EncryptionKey.X, Y: p.EncryptionKey.Y}
 
 	prp.LatestStateRoot = p.StateRoot.MathBigInt()
 	prp.StartTime = big.NewInt(p.StartTime.Unix())
 	prp.Duration = big.NewInt(int64(p.Duration.Seconds()))
 	prp.MetadataURI = p.MetadataURI
 
-	prp.BallotMode = bindings.IProcessRegistryBallotMode{
+	prp.BallotMode = npbindings.IProcessRegistryBallotMode{
 		CostFromWeight:  p.BallotMode.CostFromWeight,
 		ForceUniqueness: p.BallotMode.ForceUniqueness,
 		MaxCount:        p.BallotMode.MaxCount,


### PR DESCRIPTION
Results are stored in the process registry contract. The process registry contract points to the state transition ZK verifier and to the results zk verifier.
Both addresses can be obtained from the process registry contract.

Refactored all required code from ResultsRegistry to ResultsVerifier and StateTransitionVerifier.

Bump @vocdoni/contracts-z version to 0.0.3.