### PR TITLE
contracts: bump to v0.0.7

### DIFF
--- a/config/contracts.go
+++ b/config/contracts.go
@@ -11,16 +11,16 @@ type DavinciWeb3Config struct {
 // DefaultConfig contains the default smart contract addresses for Davinci by network.
 var DefaultConfig = map[string]DavinciWeb3Config{
 	"sep": {
-		ProcessRegistrySmartContract:      "0x178C9E0bceEa6535e13E370F1B3F69b881A2F554",
-		OrganizationRegistrySmartContract: "0x6f9e376fe682B7B21AAB9c62C5d2dc55B88Dd3C4",
-		ResultsZKVerifier:                 "0x6084fe520e7c6616be1C75713F63c5bBc31046FE",
-		StateTransitionZKVerifier:         "0x40EFFAC7c37Dfc162F92CBcE4E16ACbF8D695A72",
+		ProcessRegistrySmartContract:      "0xa536520468523BC0732396956BAa644D97B8A342",
+		OrganizationRegistrySmartContract: "0x4b8f6A584Beb64EC95ffc9E530E386B4770185bb",
+		ResultsZKVerifier:                 "0x3F879C7174F30856EBA6A86E15895eF47477F637",
+		StateTransitionZKVerifier:         "0x9e9aB32412c860ED67F5BAEeF6f75dd1FabBcb34",
 	},
 	"uzh": {
-		ProcessRegistrySmartContract:      "0xBC1A75100023add2E798f16790704372E2a36085",
-		OrganizationRegistrySmartContract: "0x4102a669FAAD42e6202b2c7bF5d6C5aB0F722217",
-		ResultsZKVerifier:                 "0xf6Fb4C1348dEBf52f7D5Fa59B920Ac403dbc4627",
-		StateTransitionZKVerifier:         "0xbae94CAFe76bAEcA335a8a338483957BB1E85Eb5",
+		ProcessRegistrySmartContract:      "0x04e823c0b2021E7976FAC2Ba8F8D9748CB800299",
+		OrganizationRegistrySmartContract: "0x08AA2EDF223935B0C5D68FC4E1E70Ab7DD46Ef36",
+		ResultsZKVerifier:                 "0x0D244BAC819e2C6E241c64438eeB42df38Be4297",
+		StateTransitionZKVerifier:         "0x2aa97d71EFDE7635512AF1be2b75eaB0F4Fa934A",
 	},
 }
 

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/testcontainers/testcontainers-go/modules/compose v0.35.0
 	github.com/vocdoni/arbo v0.0.0-20250610073604-aa44b532ffb3
 	github.com/vocdoni/circom2gnark v1.0.1-0.20241204100355-b93800bd88a4
-	github.com/vocdoni/contracts-z v0.0.0-20250612093142-37426b963f21
+	github.com/vocdoni/contracts-z v0.0.0-20250619130833-773389c87788
 	github.com/vocdoni/gnark-crypto-primitives v0.0.2-0.20250526071704-a5cc90e03181
 	go.vocdoni.io/dvote v1.10.2-0.20241024102542-c1ce6d744bc5
 	golang.org/x/sync v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -704,8 +704,8 @@ github.com/vocdoni/arbo v0.0.0-20250610073604-aa44b532ffb3 h1:7ks8Keny6y+2rY+S4m
 github.com/vocdoni/arbo v0.0.0-20250610073604-aa44b532ffb3/go.mod h1:T6qFH5QohdwZRG8N8st8WDPR4CLOL67fo9tYSNWIvCs=
 github.com/vocdoni/circom2gnark v1.0.1-0.20241204100355-b93800bd88a4 h1:aYeMlhWAW+/OQs9BinA8Yetjcf5IPoCsFFtxXx3uLdc=
 github.com/vocdoni/circom2gnark v1.0.1-0.20241204100355-b93800bd88a4/go.mod h1:A1WU0hL7rO9oZlvp82you2uCc4T3/ySi1UNW6N6hBJs=
-github.com/vocdoni/contracts-z v0.0.0-20250612093142-37426b963f21 h1:S+w2g2Nd7WO9+aSF4RNmgeI7sHKZ8NE/d2yL6hZvt+U=
-github.com/vocdoni/contracts-z v0.0.0-20250612093142-37426b963f21/go.mod h1:ztzA4TBwnswOKlgiBqbVqRcCa+XkHkfazFcx2ZQsc50=
+github.com/vocdoni/contracts-z v0.0.0-20250619130833-773389c87788 h1:MtyxKcwIYIrX85ZX8vATY1Z+FJnsmkdHb2wX/zl2uhY=
+github.com/vocdoni/contracts-z v0.0.0-20250619130833-773389c87788/go.mod h1:ztzA4TBwnswOKlgiBqbVqRcCa+XkHkfazFcx2ZQsc50=
 github.com/vocdoni/gnark-crypto-primitives v0.0.2-0.20250526071704-a5cc90e03181 h1:BDpJdwf11QzIn3V561dNkJHKobdcNO9kokBvtX6wxC8=
 github.com/vocdoni/gnark-crypto-primitives v0.0.2-0.20250526071704-a5cc90e03181/go.mod h1:tth1zQwq36tCCUJrq72y8gHEiwmJriJImlslLc1VQfQ=
 github.com/vocdoni/gnark-no-assert v0.0.0-20250430090134-56f68baa9b16 h1:XtdKB+e8woVMp58Rx3lUBb9FSbxwgDdToHZspd8EA5U=

--- a/web3/contracts.go
+++ b/web3/contracts.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"math/big"
 	"reflect"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -18,8 +17,8 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 
-	bindings "github.com/vocdoni/contracts-z/golang-types"
 	npbindings "github.com/vocdoni/contracts-z/golang-types/non-proxy"
+	vbindings "github.com/vocdoni/contracts-z/golang-types/verifiers"
 	"github.com/vocdoni/davinci-node/config"
 	"github.com/vocdoni/davinci-node/crypto/signatures/ethereum"
 	"github.com/vocdoni/davinci-node/log"
@@ -194,11 +193,11 @@ func (c *Contracts) LoadContracts(addresses *Addresses) error {
 	if err != nil {
 		return fmt.Errorf("failed to parse process registry ABI: %w", err)
 	}
-	stVerifierABI, err := abi.JSON(strings.NewReader(bindings.StateTransitionVerifierGroth16ABI))
+	stVerifierABI, err := abi.JSON(strings.NewReader(vbindings.StateTransitionVerifierGroth16ABI))
 	if err != nil {
 		return fmt.Errorf("failed to parse zk verifier ABI: %w", err)
 	}
-	rVerifierABI, err := abi.JSON(strings.NewReader(bindings.ResultsVerifierGroth16ABI))
+	rVerifierABI, err := abi.JSON(strings.NewReader(vbindings.ResultsVerifierGroth16ABI))
 	if err != nil {
 		return fmt.Errorf("failed to parse zk verifier ABI: %w", err)
 	}
@@ -255,7 +254,7 @@ func DeployContracts(web3rpc, privkey string) (*Contracts, error) {
 	if err != nil {
 		return nil, err
 	}
-	addr, tx, _, err = bindings.DeployStateTransitionVerifierGroth16(opts, cli)
+	addr, tx, _, err = vbindings.DeployStateTransitionVerifierGroth16(opts, cli)
 	if err != nil {
 		return nil, fmt.Errorf("failed to deploy state transition zkverifier contract: %w", err)
 	}
@@ -265,7 +264,7 @@ func DeployContracts(web3rpc, privkey string) (*Contracts, error) {
 	c.ContractsAddresses.StateTransitionZKVerifier = addr
 	log.Infow("deployed state transition ZKVerifier contract", "address", addr, "tx", tx.Hash().Hex())
 
-	addr, tx, _, err = bindings.DeployResultsVerifierGroth16(opts, cli)
+	addr, tx, _, err = vbindings.DeployResultsVerifierGroth16(opts, cli)
 	if err != nil {
 		return nil, fmt.Errorf("failed to deploy results zkverifier contract: %w", err)
 	}
@@ -282,8 +281,7 @@ func DeployContracts(web3rpc, privkey string) (*Contracts, error) {
 	c.ContractsAddresses.ProcessRegistry, tx, c.processes, err = npbindings.DeployProcessRegistry(
 		opts,
 		cli,
-		strconv.Itoa(int(chainID)),
-		c.ContractsAddresses.OrganizationRegistry,
+		uint32(chainID),
 		c.ContractsAddresses.StateTransitionZKVerifier,
 		c.ContractsAddresses.ResultsZKVerifier,
 	)
@@ -523,7 +521,7 @@ func (c *Contracts) OrganizationRegistryABI() (*abi.ABI, error) {
 
 // StateTransitionVerifierABI returns the ABI of the ZKVerifier contract.
 func (c *Contracts) StateTransitionVerifierABI() (*abi.ABI, error) {
-	stVerifierABI, err := abi.JSON(strings.NewReader(bindings.StateTransitionVerifierGroth16ABI))
+	stVerifierABI, err := abi.JSON(strings.NewReader(vbindings.StateTransitionVerifierGroth16ABI))
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse state transition zk verifier ABI: %w", err)
 	}
@@ -532,7 +530,7 @@ func (c *Contracts) StateTransitionVerifierABI() (*abi.ABI, error) {
 
 // ResultsVerifierABI returns the ABI of the ResultsVerifier contract.
 func (c *Contracts) ResultsVerifierABI() (*abi.ABI, error) {
-	resultsVerifierABI, err := abi.JSON(strings.NewReader(bindings.ResultsVerifierGroth16ABI))
+	resultsVerifierABI, err := abi.JSON(strings.NewReader(vbindings.ResultsVerifierGroth16ABI))
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse results zk verifier ABI: %w", err)
 	}

--- a/web3/organization.go
+++ b/web3/organization.go
@@ -17,7 +17,7 @@ func (c *Contracts) CreateOrganization(address common.Address, orgInfo *types.Or
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("failed to create transact options: %w", err)
 	}
-	tx, err := c.organizations.CreateOrganization(txOpts, address, orgInfo.Name, orgInfo.MetadataURI, []common.Address{c.signer.Address()})
+	tx, err := c.organizations.CreateOrganization(txOpts, orgInfo.Name, orgInfo.MetadataURI, []common.Address{c.signer.Address()})
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("failed to create organization: %w", err)
 	}
@@ -27,14 +27,14 @@ func (c *Contracts) CreateOrganization(address common.Address, orgInfo *types.Or
 // Organization returns the organization with the given address from the OrganizationRegistry contract.
 func (c *Contracts) Organization(address common.Address) (*types.OrganizationInfo, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), web3QueryTimeout)
-	name, uri, err := c.organizations.GetOrganization(&bind.CallOpts{Context: ctx}, address)
+	org, err := c.organizations.GetOrganization(&bind.CallOpts{Context: ctx}, address)
 	cancel()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get organization: %w", err)
 	}
 	return &types.OrganizationInfo{
-		Name:        name,
-		MetadataURI: uri,
+		Name:        org.Name,
+		MetadataURI: org.MetadataURI,
 	}, nil
 }
 
@@ -56,7 +56,7 @@ func (c *Contracts) MonitorOrganizationCreatedByPolling(ctx context.Context, int
 					continue
 				}
 				ctxQuery, cancel := context.WithTimeout(ctx, web3QueryTimeout)
-				iter, err := c.organizations.FilterOrganizationCreated(&bind.FilterOpts{Start: c.lastWatchOrgBlock, End: &end, Context: ctxQuery}, nil, nil)
+				iter, err := c.organizations.FilterOrganizationCreated(&bind.FilterOpts{Start: c.lastWatchOrgBlock, End: &end, Context: ctxQuery}, nil)
 				cancel()
 				if err != nil || iter == nil {
 					log.Warnw("failed to filter organization created, retrying", "err", err)


### PR DESCRIPTION
- ProcessId obtained from the contract.
- Decoupled organization registry from process registry contract.
- Creating a new process does not require processId and organizationId (now msg.sender).