### PR TITLE
api: fix encryptionKey handling and state initialization

### DIFF
--- a/storage/storage.go
+++ b/storage/storage.go
@@ -320,7 +320,6 @@ func (s *Storage) deleteArtifact(prefix, key []byte) error {
 // setArtifact helper function stores any kind of artifact in the storage. It
 // receives the prefix of the key, the key itself and the artifact to store. If
 // the key is not provided, it generates it by hashing the artifact itself.
-// It returns ErrKeyAlreadyExists if the key already exists.
 func (s *Storage) setArtifact(prefix []byte, key []byte, artifact any) error {
 	// encode the artifact
 	data, err := EncodeArtifact(artifact)


### PR DESCRIPTION
fixes bug where if the keys were found in storage,
they correct pubkey would be returned to the client
but the state would be initialized with a random pubkey anyway,
generating an invalid stateRoot and a process that could never
do state transition
