### PR TITLE
feature: prevent fallen workers

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -32,6 +32,7 @@ type APIConfig struct {
 	WorkerEnabled bool          // Enable worker API endpoints
 	WorkerUrlSeed string        // URL seed for worker authentication
 	WorkerTimeout time.Duration // Worker job timeout
+	BanRules      *BanRules     // Custom ban rules for workers
 }
 
 // API type represents the API HTTP server with JWT authentication capabilities.
@@ -44,6 +45,7 @@ type API struct {
 	workerTimeout time.Duration
 	jobsManager   *jobsManager    // Manages worker jobs and timeouts
 	parentCtx     context.Context // Context to stop the API server
+	banRules      *BanRules       // Rules for banning workers based on job failures
 }
 
 // New creates a new API instance with the given configuration.
@@ -55,11 +57,15 @@ func New(ctx context.Context, conf *APIConfig) (*API, error) {
 	if conf.Storage == nil {
 		return nil, fmt.Errorf("missing storage instance")
 	}
+
 	a := &API{
 		storage:       conf.Storage,
 		network:       conf.Network,
 		workerTimeout: conf.WorkerTimeout,
 		parentCtx:     ctx,
+	}
+	if conf.BanRules != nil {
+		a.banRules = conf.BanRules
 	}
 
 	// Initialize worker UUID if enabled

--- a/api/errors_definition.go
+++ b/api/errors_definition.go
@@ -44,6 +44,7 @@ var (
 	ErrBallotAlreadyProcessing  = Error{Code: 40019, HTTPstatus: http.StatusConflict, Err: fmt.Errorf("ballot is already processing")}
 	ErrProcessNotAcceptingVotes = Error{Code: 40020, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("process is not accepting votes")}
 	ErrInvalidChainID           = Error{Code: 40021, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("not supported chain Id")}
+	ErrWorkerNotAvailable       = Error{Code: 40022, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("worker not available")}
 
 	ErrMarshalingServerJSONFailed = Error{Code: 50001, HTTPstatus: http.StatusInternalServerError, Err: fmt.Errorf("marshaling (server-side) JSON failed")}
 	ErrGenericInternalServerError = Error{Code: 50002, HTTPstatus: http.StatusInternalServerError, Err: fmt.Errorf("internal server error")}

--- a/api/helpers.go
+++ b/api/helpers.go
@@ -1,11 +1,14 @@
 package api
 
 import (
+	"crypto/sha256"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/vocdoni/davinci-node/log"
 )
 
@@ -48,4 +51,15 @@ func httpWriteOK(w http.ResponseWriter) {
 	if _, err := w.Write([]byte("\n")); err != nil {
 		log.Warnw("failed to write on response", "error", err)
 	}
+}
+
+func WorkerSeedToUUID(seed string) (*uuid.UUID, error) {
+	var err error
+	// Use the first 8 characters of the SHA256 hash of the seed as a UUID
+	hash := sha256.Sum256([]byte(seed))
+	u, err := uuid.FromBytes(hash[:16]) // Convert first 16 bytes to UUID
+	if err != nil {
+		return nil, fmt.Errorf("failed to create worker UUID: %w", err)
+	}
+	return &u, nil
 }

--- a/api/jobs_manager.go
+++ b/api/jobs_manager.go
@@ -1,0 +1,194 @@
+package api
+
+import (
+	"context"
+	"encoding/hex"
+	"sync"
+	"time"
+
+	"github.com/vocdoni/davinci-node/log"
+)
+
+// workerJob represents a job assigned to a worker. It contains the vote ID,
+// worker address, timestamp, and expiration time.
+type workerJob struct {
+	VoteID     []byte
+	Address    string
+	Timestamp  time.Time
+	Expiration time.Time // When the job should expire
+}
+
+// jobsManager manages worker jobs, including job registration, completion,
+// and timeout handling. It also interacts with the worker manager to track
+// worker availability and job results.
+type jobsManager struct {
+	pendingMtx     sync.RWMutex
+	pending        map[string]*workerJob
+	failedJobs     chan *workerJob // Channel to handle failed jobs
+	jobTimeout     time.Duration   // Duration after which a job is considered timed out
+	tickerInterval time.Duration   // Configurable ticker interval for timeout checking
+	closeOnce      sync.Once       // Ensures channel is closed only once
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	wm     *workerManager // Reference to the worker manager for job tracking
+}
+
+// newJobsManager creates a new jobs manager with the specified job timeout
+// and ticker interval. If no ticker interval is provided, it defaults to 10
+// seconds. It initializes an internal worker manager with default ban rules.
+func newJobsManager(jobTimeout time.Duration, tickerInterval ...time.Duration) *jobsManager {
+	interval := 10 * time.Second // default production interval
+	if len(tickerInterval) > 0 {
+		interval = tickerInterval[0]
+	}
+	return &jobsManager{
+		pending:        make(map[string]*workerJob),
+		wm:             newWorkerManager(defaultBanRules),
+		failedJobs:     make(chan *workerJob), // Unbuffered channel for failed jobs
+		jobTimeout:     jobTimeout,
+		tickerInterval: interval,
+	}
+}
+
+// start initializes the jobs manager, starts the worker manager, and begins
+// a goroutine to periodically check for job timeouts. It uses a context to
+// manage the lifecycle of the jobs manager, allowing it to be stopped
+// gracefully.
+func (jm *jobsManager) start(ctx context.Context) {
+	jm.ctx, jm.cancel = context.WithCancel(ctx)
+	jm.wm.start(ctx)
+
+	go func() {
+		ticker := time.NewTicker(jm.tickerInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				jm.stop() // Stop the jobs manager when context is done
+				return
+			case <-ticker.C:
+				jm.checkTimeouts()
+			}
+		}
+	}()
+	log.Info("Jobs manager started")
+}
+
+// stop gracefully stops the jobs manager, clearing all pending jobs and
+// stopping the worker manager. It also ensures that the failed jobs channel
+// is closed only once using sync.Once. This prevents any potential concurrent
+// write to a closed channel panic.
+func (jm *jobsManager) stop() {
+	if jm.cancel != nil {
+		jm.cancel()
+	}
+	jm.pendingMtx.Lock()
+	defer jm.pendingMtx.Unlock()
+	jm.pending = make(map[string]*workerJob) // Clear all pending jobs
+	jm.wm.stop()                             // Stop the worker manager
+
+	// Close the failed jobs channel safely using sync.Once
+	jm.closeOnce.Do(func() {
+		close(jm.failedJobs)
+	})
+}
+
+// checkTimeouts checks for any pending jobs that have expired based on their
+// expiration time. If a job has expired, it notifies the worker manager of
+// the timeout and sends the job to the failed jobs channel. It also removes
+// the expired job from the pending jobs map. This function is called
+// periodically by a ticker to ensure timely handling of job timeouts.
+func (jm *jobsManager) checkTimeouts() {
+	jm.pendingMtx.Lock()
+	defer jm.pendingMtx.Unlock()
+
+	now := time.Now()
+	for key, job := range jm.pending {
+		if now.After(job.Expiration) {
+			log.Debugf("Job with vote ID %s has expired", job.VoteID)
+			jm.wm.workerResult(job.Address, false) // Notify worker manager of timeout
+			jm.failedJobs <- job                   // Send to failed jobs channel (blocking)
+			delete(jm.pending, key)                // Remove expired job
+		}
+	}
+}
+
+// isWorkerAvailable checks if a worker is available for a new job. It verifies
+// if the worker exists, is not banned, and does not have any pending jobs.
+func (jm *jobsManager) isWorkerAvailable(workerAddr string) bool {
+	worker, ok := jm.wm.getWorker(workerAddr)
+	if !ok {
+		return true // Worker does not exist, consider available
+	}
+	// Check if worker is banned
+	if worker.isBanned(jm.wm.rules) {
+		log.Warnf("Worker %s is banned", workerAddr)
+		return false // Worker is banned
+	}
+	// Check if worker has pending jobs
+	jm.pendingMtx.RLock()
+	defer jm.pendingMtx.RUnlock()
+	for _, job := range jm.pending {
+		if job.Address == worker.ID {
+			log.Debugf("Worker %s has pending job for vote ID %s", workerAddr, job.VoteID)
+			return false // Worker has pending jobs
+		}
+	}
+	return true // Worker is available
+}
+
+// registerJob registers a new job for a worker. It checks if the worker is
+// available and not banned. If the worker is valid, it creates a new job
+// with the provided vote ID, assigns it to the worker, and sets an expiration
+// time for the job. The job is then added to the pending jobs map. If the
+// worker is banned returns nil.
+func (jm *jobsManager) registerJob(workerAddr string, voteID []byte) (*workerJob, bool) {
+	jm.pendingMtx.Lock()
+	defer jm.pendingMtx.Unlock()
+	// Check if worker exists in the worker manager
+	worker, ok := jm.wm.getWorker(workerAddr)
+	if !ok {
+		worker = jm.wm.addWorker(workerAddr) // Add worker if not exists
+	}
+	// Check if worker is available
+	if worker.isBanned(jm.wm.rules) {
+		log.Warnf("Worker %s is banned, cannot register job for vote ID %s", workerAddr, voteID)
+		return nil, false // Worker is banned
+	}
+	job := &workerJob{
+		VoteID:     voteID,
+		Address:    worker.ID,
+		Timestamp:  time.Now(),
+		Expiration: time.Now().Add(jm.jobTimeout), // Default expiration
+	}
+	jm.pending[hex.EncodeToString(voteID)] = job
+	log.Debugf("Job registered: %s for worker %s", voteID, workerAddr)
+	return job, true
+}
+
+// completeJob marks a job as completed, either successfully or with failure.
+// It looks up the job by its vote ID, updates the worker manager with the
+// result, and removes the job from the pending jobs map. If the job is not
+// found, it logs a warning and returns nil. If the job is marked as failed,
+// it sends the job to the failed jobs channel for further processing. This
+// function is called when a worker completes a job, either successfully or
+// with failure.
+func (jm *jobsManager) completeJob(voteID []byte, success bool) *workerJob {
+	jm.pendingMtx.Lock()
+	defer jm.pendingMtx.Unlock()
+	// Look up the job by vote ID
+	job, exists := jm.pending[hex.EncodeToString(voteID)]
+	if !exists {
+		log.Warnf("Job with vote ID %s not found", voteID)
+		return nil // Job not found
+	}
+	if !success {
+		jm.failedJobs <- job // Send to failed jobs channel (blocking)
+	}
+	jm.wm.workerResult(job.Address, success)       // Notify worker manager
+	delete(jm.pending, hex.EncodeToString(voteID)) // Remove the job from pending
+	log.Debugf("Job completed: %s, success: %t", voteID, success)
+	return job
+}

--- a/api/jobs_manager_test.go
+++ b/api/jobs_manager_test.go
@@ -1,0 +1,742 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestNewJobsManager(t *testing.T) {
+	c := qt.New(t)
+
+	t.Run("Default configuration", func(t *testing.T) {
+		jobTimeout := 5 * time.Minute
+		jm := newJobsManager(jobTimeout)
+
+		c.Assert(jm, qt.IsNotNil)
+		c.Assert(jm.jobTimeout, qt.Equals, jobTimeout)
+		c.Assert(jm.tickerInterval, qt.Equals, 10*time.Second) // Default interval
+		c.Assert(jm.pending, qt.IsNotNil)
+		c.Assert(len(jm.pending), qt.Equals, 0)
+		c.Assert(jm.failedJobs, qt.IsNotNil)
+		c.Assert(jm.wm, qt.IsNotNil)
+		c.Assert(jm.ctx, qt.IsNil) // Should be nil until start() is called
+		c.Assert(jm.cancel, qt.IsNil)
+	})
+
+	t.Run("Custom ticker interval", func(t *testing.T) {
+		jobTimeout := 2 * time.Minute
+		tickerInterval := 100 * time.Millisecond
+		jm := newJobsManager(jobTimeout, tickerInterval)
+
+		c.Assert(jm.jobTimeout, qt.Equals, jobTimeout)
+		c.Assert(jm.tickerInterval, qt.Equals, tickerInterval)
+	})
+}
+
+func TestJobsManagerStartStop(t *testing.T) {
+	c := qt.New(t)
+
+	jm := newJobsManager(1*time.Minute, 50*time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Test start
+	jm.start(ctx)
+	c.Assert(jm.ctx, qt.IsNotNil)
+	c.Assert(jm.cancel, qt.IsNotNil)
+
+	// Test stop
+	jm.stop()
+
+	// Verify cleanup
+	c.Assert(len(jm.pending), qt.Equals, 0)
+	
+	// Verify channel is closed by trying to receive (should not block)
+	select {
+	case _, ok := <-jm.failedJobs:
+		c.Assert(ok, qt.IsFalse) // Channel should be closed
+	default:
+		t.Error("Expected channel to be closed")
+	}
+}
+
+func TestJobsManagerRegisterJob(t *testing.T) {
+	c := qt.New(t)
+
+	t.Run("Register job for new worker", func(t *testing.T) {
+		jm := newJobsManager(1*time.Minute, 50*time.Millisecond)
+		workerAddr := "worker1"
+		voteID := []byte("vote123")
+
+		job, ok := jm.registerJob(workerAddr, voteID)
+
+		c.Assert(ok, qt.IsTrue)
+		c.Assert(job, qt.IsNotNil)
+		c.Assert(job.VoteID, qt.DeepEquals, voteID)
+		c.Assert(job.Address, qt.Equals, workerAddr)
+		c.Assert(job.Timestamp.IsZero(), qt.IsFalse)
+		c.Assert(job.Expiration.After(job.Timestamp), qt.IsTrue)
+
+		// Verify job is in pending map
+		c.Assert(len(jm.pending), qt.Equals, 1)
+		storedJob, exists := jm.pending[string(voteID)]
+		c.Assert(exists, qt.IsTrue)
+		c.Assert(storedJob, qt.Equals, job)
+	})
+
+	t.Run("Register job for existing worker", func(t *testing.T) {
+		jm := newJobsManager(1*time.Minute, 50*time.Millisecond)
+		workerAddr := "worker1"
+		
+		// Add worker first
+		jm.wm.addWorker(workerAddr)
+		
+		voteID := []byte("vote123")
+		job, ok := jm.registerJob(workerAddr, voteID)
+
+		c.Assert(ok, qt.IsTrue)
+		c.Assert(job, qt.IsNotNil)
+		c.Assert(job.Address, qt.Equals, workerAddr)
+	})
+
+	t.Run("Register job for banned worker", func(t *testing.T) {
+		jm := newJobsManager(1*time.Minute, 50*time.Millisecond)
+		workerAddr := "worker1"
+		
+		// Add worker and make it fail to get banned
+		jm.wm.addWorker(workerAddr)
+		for i := 0; i < 15; i++ { // Exceed default ban threshold
+			jm.wm.workerResult(workerAddr, false)
+		}
+		
+		voteID := []byte("vote123")
+		job, ok := jm.registerJob(workerAddr, voteID)
+
+		c.Assert(ok, qt.IsFalse)
+		c.Assert(job, qt.IsNil)
+		c.Assert(len(jm.pending), qt.Equals, 0)
+	})
+
+	t.Run("Register multiple jobs", func(t *testing.T) {
+		jm := newJobsManager(1*time.Minute, 50*time.Millisecond)
+		
+		jobs := []struct {
+			worker string
+			voteID []byte
+		}{
+			{"worker1", []byte("vote1")},
+			{"worker2", []byte("vote2")},
+			{"worker1", []byte("vote3")}, // Same worker, different vote
+		}
+
+		for _, jobData := range jobs {
+			job, ok := jm.registerJob(jobData.worker, jobData.voteID)
+			c.Assert(ok, qt.IsTrue)
+			c.Assert(job, qt.IsNotNil)
+		}
+
+		c.Assert(len(jm.pending), qt.Equals, 3)
+	})
+}
+
+func TestJobsManagerIsWorkerAvailable(t *testing.T) {
+	c := qt.New(t)
+
+	t.Run("New worker is available", func(t *testing.T) {
+		jm := newJobsManager(1*time.Minute, 50*time.Millisecond)
+		available := jm.isWorkerAvailable("new-worker")
+		c.Assert(available, qt.IsTrue)
+	})
+
+	t.Run("Banned worker is not available", func(t *testing.T) {
+		jm := newJobsManager(1*time.Minute, 50*time.Millisecond)
+		workerAddr := "worker1"
+		
+		// Add worker and ban it
+		jm.wm.addWorker(workerAddr)
+		for i := 0; i < 15; i++ { // Exceed ban threshold
+			jm.wm.workerResult(workerAddr, false)
+		}
+		
+		available := jm.isWorkerAvailable(workerAddr)
+		c.Assert(available, qt.IsFalse)
+	})
+
+	t.Run("Worker with pending job is not available", func(t *testing.T) {
+		jm := newJobsManager(1*time.Minute, 50*time.Millisecond)
+		workerAddr := "worker1"
+		voteID := []byte("vote123")
+		
+		// Register a job for the worker
+		_, ok := jm.registerJob(workerAddr, voteID)
+		c.Assert(ok, qt.IsTrue)
+		
+		// Worker should not be available
+		available := jm.isWorkerAvailable(workerAddr)
+		c.Assert(available, qt.IsFalse)
+	})
+
+	t.Run("Worker without pending jobs is available", func(t *testing.T) {
+		jm := newJobsManager(1*time.Minute, 50*time.Millisecond)
+		workerAddr := "worker1"
+		
+		// Add worker but no jobs
+		jm.wm.addWorker(workerAddr)
+		
+		available := jm.isWorkerAvailable(workerAddr)
+		c.Assert(available, qt.IsTrue)
+	})
+}
+
+func TestJobsManagerCompleteJob(t *testing.T) {
+	c := qt.New(t)
+
+	t.Run("Complete existing job successfully", func(t *testing.T) {
+		jm := newJobsManager(1*time.Minute, 50*time.Millisecond)
+		workerAddr := "worker1"
+		voteID := []byte("vote123")
+		
+		// Register job first
+		originalJob, ok := jm.registerJob(workerAddr, voteID)
+		c.Assert(ok, qt.IsTrue)
+		c.Assert(len(jm.pending), qt.Equals, 1)
+		
+		// Complete job successfully
+		completedJob := jm.completeJob(voteID, true)
+		
+		c.Assert(completedJob, qt.IsNotNil)
+		c.Assert(completedJob, qt.Equals, originalJob)
+		c.Assert(len(jm.pending), qt.Equals, 0) // Job should be removed
+		
+		// Verify no failed job was sent to channel
+		select {
+		case <-jm.failedJobs:
+			t.Error("No failed job should be sent for successful completion")
+		default:
+			// Expected - no failed job
+		}
+	})
+
+	t.Run("Complete existing job with failure", func(t *testing.T) {
+		jm := newJobsManager(1*time.Minute, 50*time.Millisecond)
+		workerAddr := "worker1"
+		voteID := []byte("vote123")
+		
+		// Register job first
+		originalJob, ok := jm.registerJob(workerAddr, voteID)
+		c.Assert(ok, qt.IsTrue)
+		
+		// Start a goroutine to consume the failed job to prevent blocking
+		var receivedJob *workerJob
+		done := make(chan bool)
+		go func() {
+			receivedJob = <-jm.failedJobs
+			done <- true
+		}()
+		
+		// Complete job with failure
+		completedJob := jm.completeJob(voteID, false)
+		
+		c.Assert(completedJob, qt.IsNotNil)
+		c.Assert(completedJob, qt.Equals, originalJob)
+		c.Assert(len(jm.pending), qt.Equals, 0) // Job should be removed
+		
+		// Wait for failed job to be received
+		select {
+		case <-done:
+			c.Assert(receivedJob, qt.Equals, originalJob)
+		case <-time.After(100 * time.Millisecond):
+			t.Error("Failed job should be sent to channel")
+		}
+	})
+
+	t.Run("Complete non-existent job", func(t *testing.T) {
+		jm := newJobsManager(1*time.Minute, 50*time.Millisecond)
+		voteID := []byte("nonexistent")
+		
+		completedJob := jm.completeJob(voteID, true)
+		
+		c.Assert(completedJob, qt.IsNil)
+	})
+}
+
+func TestJobsManagerCheckTimeouts(t *testing.T) {
+	c := qt.New(t)
+
+	t.Run("No expired jobs", func(t *testing.T) {
+		jm := newJobsManager(1*time.Hour, 50*time.Millisecond) // Long timeout
+		workerAddr := "worker1"
+		voteID := []byte("vote123")
+		
+		// Register job with long timeout
+		_, ok := jm.registerJob(workerAddr, voteID)
+		c.Assert(ok, qt.IsTrue)
+		
+		// Check timeouts
+		jm.checkTimeouts()
+		
+		// Job should still be pending
+		c.Assert(len(jm.pending), qt.Equals, 1)
+		
+		// No failed jobs should be sent
+		select {
+		case <-jm.failedJobs:
+			t.Error("No failed job should be sent for non-expired job")
+		default:
+			// Expected
+		}
+	})
+
+	t.Run("Expired jobs are removed and sent to failed channel", func(t *testing.T) {
+		jm := newJobsManager(1*time.Millisecond, 50*time.Millisecond) // Very short timeout
+		workerAddr := "worker1"
+		voteID := []byte("vote123")
+		
+		// Register job with short timeout
+		originalJob, ok := jm.registerJob(workerAddr, voteID)
+		c.Assert(ok, qt.IsTrue)
+		
+		// Wait for job to expire
+		time.Sleep(10 * time.Millisecond)
+		
+		// Start a goroutine to consume the failed job to prevent blocking
+		var receivedJob *workerJob
+		done := make(chan bool)
+		go func() {
+			receivedJob = <-jm.failedJobs
+			done <- true
+		}()
+		
+		// Check timeouts
+		jm.checkTimeouts()
+		
+		// Job should be removed from pending
+		c.Assert(len(jm.pending), qt.Equals, 0)
+		
+		// Wait for failed job to be received
+		select {
+		case <-done:
+			c.Assert(receivedJob, qt.Equals, originalJob)
+		case <-time.After(100 * time.Millisecond):
+			t.Error("Failed job should be sent to channel")
+		}
+	})
+
+	t.Run("Multiple expired jobs", func(t *testing.T) {
+		jm := newJobsManager(1*time.Millisecond, 50*time.Millisecond)
+		
+		// Register multiple jobs
+		jobs := [][]byte{
+			[]byte("vote1"),
+			[]byte("vote2"),
+			[]byte("vote3"),
+		}
+		
+		for _, voteID := range jobs {
+			_, ok := jm.registerJob("worker1", voteID)
+			c.Assert(ok, qt.IsTrue)
+		}
+		
+		c.Assert(len(jm.pending), qt.Equals, 3)
+		
+		// Wait for jobs to expire
+		time.Sleep(10 * time.Millisecond)
+		
+		// Start a goroutine to consume all failed jobs to prevent blocking
+		var receivedJobs []*workerJob
+		done := make(chan bool)
+		go func() {
+			for i := 0; i < 3; i++ {
+				job := <-jm.failedJobs
+				receivedJobs = append(receivedJobs, job)
+			}
+			done <- true
+		}()
+		
+		// Check timeouts
+		jm.checkTimeouts()
+		
+		// Wait for all jobs to be received
+		select {
+		case <-done:
+			// All jobs should be removed and received
+			c.Assert(len(jm.pending), qt.Equals, 0)
+			c.Assert(len(receivedJobs), qt.Equals, 3)
+		case <-time.After(100 * time.Millisecond):
+			t.Error("All failed jobs should be sent to channel")
+		}
+	})
+}
+
+func TestJobsManagerRealStartWithConfigurableTicker(t *testing.T) {
+	c := qt.New(t)
+
+	t.Run("Real start method with fast ticker - timeout detection", func(t *testing.T) {
+		jm := newJobsManager(100*time.Millisecond, 50*time.Millisecond) // Fast ticker and short timeout
+		
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		// Start a goroutine to consume failed jobs to prevent blocking
+		var receivedJob *workerJob
+		jobReceived := make(chan bool)
+		go func() {
+			receivedJob = <-jm.failedJobs
+			jobReceived <- true
+		}()
+
+		// Start the real jobs manager
+		jm.start(ctx)
+		defer jm.stop()
+
+		// Register a job that will expire
+		workerAddr := "worker1"
+		voteID := []byte("vote123")
+		originalJob, ok := jm.registerJob(workerAddr, voteID)
+		c.Assert(ok, qt.IsTrue)
+		
+		// Use thread-safe access to check pending jobs
+		jm.pendingMtx.RLock()
+		pendingCount := len(jm.pending)
+		jm.pendingMtx.RUnlock()
+		c.Assert(pendingCount, qt.Equals, 1)
+
+		// Wait for job to expire and ticker to process it
+		select {
+		case <-jobReceived:
+			// Job should be removed by the real ticker (thread-safe check)
+			jm.pendingMtx.RLock()
+			pendingCount = len(jm.pending)
+			jm.pendingMtx.RUnlock()
+			c.Assert(pendingCount, qt.Equals, 0)
+			c.Assert(receivedJob, qt.Equals, originalJob)
+		case <-time.After(500 * time.Millisecond):
+			t.Error("Failed job should be sent to channel by ticker")
+		}
+	})
+
+	t.Run("Context cancellation stops ticker", func(t *testing.T) {
+		jm := newJobsManager(1*time.Minute, 50*time.Millisecond)
+		
+		ctx, cancel := context.WithCancel(context.Background())
+
+		// Start jobs manager
+		jm.start(ctx)
+
+		// Register a job
+		_, ok := jm.registerJob("worker1", []byte("vote123"))
+		c.Assert(ok, qt.IsTrue)
+		
+		// Thread-safe check of pending jobs
+		jm.pendingMtx.RLock()
+		pendingCount := len(jm.pending)
+		jm.pendingMtx.RUnlock()
+		c.Assert(pendingCount, qt.Equals, 1)
+
+		// Cancel context
+		cancel()
+
+		// Give time for cleanup
+		time.Sleep(100 * time.Millisecond)
+
+		// Jobs should be cleared by stop() (thread-safe check)
+		jm.pendingMtx.RLock()
+		pendingCount = len(jm.pending)
+		jm.pendingMtx.RUnlock()
+		c.Assert(pendingCount, qt.Equals, 0)
+	})
+
+	t.Run("Ticker interval verification", func(t *testing.T) {
+		// Test with custom interval
+		customInterval := 25 * time.Millisecond
+		jm := newJobsManager(1*time.Minute, customInterval)
+		c.Assert(jm.tickerInterval, qt.Equals, customInterval)
+
+		// Test with default interval
+		jmDefault := newJobsManager(1 * time.Minute)
+		c.Assert(jmDefault.tickerInterval, qt.Equals, 10*time.Second)
+	})
+}
+
+func TestJobsManagerConcurrency(t *testing.T) {
+	c := qt.New(t)
+
+	t.Run("Concurrent job registration and completion", func(t *testing.T) {
+		jm := newJobsManager(1*time.Minute, 50*time.Millisecond)
+		
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		
+		jm.start(ctx)
+		defer jm.stop()
+
+		const numWorkers = 50
+		const numJobs = 10
+
+		var wg sync.WaitGroup
+
+		// Concurrent job registration
+		for i := 0; i < numWorkers; i++ {
+			wg.Add(1)
+			go func(workerID int) {
+				defer wg.Done()
+				workerAddr := fmt.Sprintf("worker-%d", workerID)
+				
+				for j := 0; j < numJobs; j++ {
+					voteID := []byte(fmt.Sprintf("vote-%d-%d", workerID, j))
+					job, ok := jm.registerJob(workerAddr, voteID)
+					if ok && job != nil {
+						// Randomly complete some jobs
+						if j%2 == 0 {
+							jm.completeJob(voteID, true)
+						}
+					}
+				}
+			}(i)
+		}
+
+		// Concurrent availability checks
+		for i := 0; i < 20; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				workerAddr := fmt.Sprintf("worker-%d", i%numWorkers)
+				jm.isWorkerAvailable(workerAddr)
+			}(i)
+		}
+
+		wg.Wait()
+
+		// Verify no race conditions occurred (test should not panic)
+		c.Assert(true, qt.IsTrue) // If we get here, no race conditions
+	})
+}
+
+func TestJobsManagerWorkerManagerIntegration(t *testing.T) {
+	c := qt.New(t)
+
+	t.Run("Job completion updates worker manager", func(t *testing.T) {
+		jm := newJobsManager(1*time.Minute, 50*time.Millisecond)
+		workerAddr := "worker1"
+		voteID := []byte("vote123")
+		
+		// Register and complete job successfully
+		_, ok := jm.registerJob(workerAddr, voteID)
+		c.Assert(ok, qt.IsTrue)
+		
+		// Get initial worker state
+		worker, exists := jm.wm.getWorker(workerAddr)
+		c.Assert(exists, qt.IsTrue)
+		initialFails := worker.getConsecutiveFails()
+		
+		// Complete job successfully
+		jm.completeJob(voteID, true)
+		
+		// Worker consecutive fails should be reset
+		worker, exists = jm.wm.getWorker(workerAddr)
+		c.Assert(exists, qt.IsTrue)
+		c.Assert(worker.getConsecutiveFails(), qt.Equals, 0)
+		
+		// Register and fail a job
+		voteID2 := []byte("vote456")
+		_, ok = jm.registerJob(workerAddr, voteID2)
+		c.Assert(ok, qt.IsTrue)
+		
+		// Start a goroutine to consume the failed job to prevent blocking
+		done := make(chan bool)
+		go func() {
+			<-jm.failedJobs // Consume the failed job
+			done <- true
+		}()
+		
+		jm.completeJob(voteID2, false)
+		
+		// Wait for failed job to be consumed
+		select {
+		case <-done:
+			// Worker consecutive fails should increase
+			worker, exists = jm.wm.getWorker(workerAddr)
+			c.Assert(exists, qt.IsTrue)
+			c.Assert(worker.getConsecutiveFails(), qt.Equals, initialFails+1)
+		case <-time.After(100 * time.Millisecond):
+			t.Error("Failed job should be sent to channel")
+		}
+	})
+
+	t.Run("Timeout updates worker manager", func(t *testing.T) {
+		jm := newJobsManager(1*time.Millisecond, 50*time.Millisecond)
+		workerAddr := "worker1"
+		voteID := []byte("vote123")
+		
+		// Register job that will timeout
+		_, ok := jm.registerJob(workerAddr, voteID)
+		c.Assert(ok, qt.IsTrue)
+		
+		// Get initial worker state
+		worker, exists := jm.wm.getWorker(workerAddr)
+		c.Assert(exists, qt.IsTrue)
+		initialFails := worker.getConsecutiveFails()
+		
+		// Wait for timeout and check
+		time.Sleep(10 * time.Millisecond)
+		
+		// Start a goroutine to consume the failed job to prevent blocking
+		done := make(chan bool)
+		go func() {
+			<-jm.failedJobs // Consume the failed job
+			done <- true
+		}()
+		
+		jm.checkTimeouts()
+		
+		// Wait for failed job to be consumed
+		select {
+		case <-done:
+			// Worker consecutive fails should increase due to timeout
+			worker, exists = jm.wm.getWorker(workerAddr)
+			c.Assert(exists, qt.IsTrue)
+			c.Assert(worker.getConsecutiveFails(), qt.Equals, initialFails+1)
+		case <-time.After(100 * time.Millisecond):
+			t.Error("Failed job should be sent to channel")
+		}
+	})
+}
+
+func TestJobsManagerEdgeCases(t *testing.T) {
+	c := qt.New(t)
+
+	t.Run("Zero timeout duration", func(t *testing.T) {
+		jm := newJobsManager(0, 50*time.Millisecond) // Zero timeout
+		workerAddr := "worker1"
+		voteID := []byte("vote123")
+		
+		// Register job with zero timeout (should expire immediately)
+		_, ok := jm.registerJob(workerAddr, voteID)
+		c.Assert(ok, qt.IsTrue)
+		
+		// Start a goroutine to consume the failed job to prevent blocking
+		done := make(chan bool)
+		go func() {
+			<-jm.failedJobs // Consume the failed job
+			done <- true
+		}()
+		
+		// Check timeouts immediately
+		jm.checkTimeouts()
+		
+		// Wait for failed job to be consumed
+		select {
+		case <-done:
+			// Job should be expired and removed
+			c.Assert(len(jm.pending), qt.Equals, 0)
+		case <-time.After(100 * time.Millisecond):
+			t.Error("Failed job should be sent to channel")
+		}
+	})
+
+	t.Run("Nil vote ID", func(t *testing.T) {
+		jm := newJobsManager(1*time.Minute, 50*time.Millisecond)
+		workerAddr := "worker1"
+		
+		// Register job with nil vote ID
+		job, ok := jm.registerJob(workerAddr, nil)
+		c.Assert(ok, qt.IsTrue)
+		c.Assert(job, qt.IsNotNil)
+		c.Assert(job.VoteID, qt.IsNil)
+		
+		// Should be able to complete it
+		completedJob := jm.completeJob(nil, true)
+		c.Assert(completedJob, qt.IsNotNil)
+	})
+
+	t.Run("Empty worker address", func(t *testing.T) {
+		jm := newJobsManager(1*time.Minute, 50*time.Millisecond)
+		voteID := []byte("vote123")
+		
+		// Register job with empty worker address
+		job, ok := jm.registerJob("", voteID)
+		c.Assert(ok, qt.IsTrue)
+		c.Assert(job, qt.IsNotNil)
+		c.Assert(job.Address, qt.Equals, "")
+	})
+
+	t.Run("Unbuffered channel behavior", func(t *testing.T) {
+		jm := newJobsManager(1*time.Millisecond, 50*time.Millisecond)
+		
+		// Register multiple jobs that will expire
+		for i := 0; i < 5; i++ {
+			voteID := []byte(fmt.Sprintf("vote%d", i))
+			jm.registerJob("worker1", voteID)
+		}
+		
+		// Wait for expiration
+		time.Sleep(10 * time.Millisecond)
+		
+		// Start a goroutine to consume failed jobs to prevent blocking
+		var receivedJobs []*workerJob
+		done := make(chan bool)
+		go func() {
+			for i := 0; i < 5; i++ {
+				job := <-jm.failedJobs
+				receivedJobs = append(receivedJobs, job)
+			}
+			done <- true
+		}()
+		
+		// Check timeouts - should not block with unbuffered channel since we have a consumer
+		jm.checkTimeouts()
+		
+		// Wait for all jobs to be received
+		<-done
+		
+		// All jobs should be removed and received
+		c.Assert(len(jm.pending), qt.Equals, 0)
+		c.Assert(len(receivedJobs), qt.Equals, 5)
+	})
+
+	t.Run("Blocking behavior with no consumer", func(t *testing.T) {
+		jm := newJobsManager(1*time.Millisecond, 50*time.Millisecond)
+		
+		// Register a job that will expire
+		voteID := []byte("vote123")
+		jm.registerJob("worker1", voteID)
+		
+		// Wait for expiration
+		time.Sleep(10 * time.Millisecond)
+		
+		// Start checkTimeouts in a goroutine since it will block
+		timeoutDone := make(chan bool)
+		go func() {
+			jm.checkTimeouts()
+			timeoutDone <- true
+		}()
+		
+		// Verify that checkTimeouts is blocked (timeout should not complete immediately)
+		select {
+		case <-timeoutDone:
+			t.Error("checkTimeouts should be blocked waiting for consumer")
+		case <-time.After(50 * time.Millisecond):
+			// Expected - checkTimeouts is blocked
+		}
+		
+		// Now consume the failed job to unblock checkTimeouts
+		failedJob := <-jm.failedJobs
+		c.Assert(failedJob, qt.IsNotNil)
+		
+		// checkTimeouts should now complete
+		select {
+		case <-timeoutDone:
+			// Expected - checkTimeouts completed
+		case <-time.After(100 * time.Millisecond):
+			t.Error("checkTimeouts should have completed after consuming failed job")
+		}
+		
+		// Job should be removed
+		c.Assert(len(jm.pending), qt.Equals, 0)
+	})
+}

--- a/api/worker_manager.go
+++ b/api/worker_manager.go
@@ -1,0 +1,227 @@
+package api
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/vocdoni/davinci-node/log"
+)
+
+// banRules defines the rules for banning workers. It includes the duration
+// for which a worker is banned and the maximum number of consecutive failed
+// jobs before a worker is banned.
+type banRules struct {
+	timeout             time.Duration // Duration for which the worker is banned
+	maxConsecutiveFails int           // Maximum consecutive failed jobs before banning
+}
+
+// defaultBanRules provides the default ban rules for workers
+var defaultBanRules = banRules{
+	timeout:             3 * time.Minute, // Ban for 3 minutes
+	maxConsecutiveFails: 10,              // 3 consecutive failed jobs
+}
+
+// worker represents a worker that processes jobs
+type worker struct {
+	ID               string
+	consecutiveFails int64 // atomic counter
+	bannedUntilNanos int64 // atomic Unix nanoseconds, 0 = not banned
+}
+
+// isBanned checks if the worker is banned based on the provided rules
+func (w *worker) isBanned(rules banRules) bool {
+	consecutiveFails := atomic.LoadInt64(&w.consecutiveFails)
+	if consecutiveFails > int64(rules.maxConsecutiveFails) {
+		return true
+	}
+
+	// Check time-based ban
+	bannedUntil := atomic.LoadInt64(&w.bannedUntilNanos)
+	if bannedUntil == 0 {
+		return false // never been banned
+	}
+	return time.Now().UnixNano() < bannedUntil
+}
+
+// getBannedUntil returns the ban expiration time as a time.Time
+func (w *worker) getBannedUntil() time.Time {
+	nanos := atomic.LoadInt64(&w.bannedUntilNanos)
+	if nanos == 0 {
+		return time.Time{} // zero time
+	}
+	return time.Unix(0, nanos)
+}
+
+// setBannedUntil sets the ban expiration time atomically
+func (w *worker) setBannedUntil(t time.Time) {
+	var nanos int64
+	if !t.IsZero() {
+		nanos = t.UnixNano()
+	}
+	atomic.StoreInt64(&w.bannedUntilNanos, nanos)
+}
+
+// getConsecutiveFails returns the current consecutive failure count
+func (w *worker) getConsecutiveFails() int {
+	return int(atomic.LoadInt64(&w.consecutiveFails))
+}
+
+// workerManager manages workers and their ban status. It tracks workers, bans
+// them based on rules, and resets their status after the ban period.
+type workerManager struct {
+	workers        sync.Map
+	innerCtx       context.Context
+	cancelFunc     context.CancelFunc
+	rules          banRules
+	tickerInterval time.Duration
+}
+
+// newWorkerManager creates a new worker manager with the specified ban rules.
+// It initializes the worker map and sets up the context for managing workers.
+// An optional ticker interval can be provided; defaults to 10 seconds if not specified.
+func newWorkerManager(rules banRules, tickerInterval ...time.Duration) *workerManager {
+	interval := 10 * time.Second // default production interval
+	if len(tickerInterval) > 0 {
+		interval = tickerInterval[0]
+	}
+	return &workerManager{
+		workers:        sync.Map{},
+		rules:          rules,
+		tickerInterval: interval,
+	}
+}
+
+// start initializes the worker manager, setting up a context for managing
+// workers. It starts a goroutine that periodically checks for banned workers,
+// bans them if necessary, and resets their status after the ban period.
+func (wm *workerManager) start(ctx context.Context) {
+	wm.innerCtx, wm.cancelFunc = context.WithCancel(ctx)
+
+	go func() {
+		ticker := time.NewTicker(wm.tickerInterval)
+		for {
+			defer ticker.Stop()
+
+			select {
+			case <-ctx.Done():
+				// Stop the worker manager when the context is done
+				wm.stop()
+				return
+			case <-ticker.C:
+				banned := wm.bannedWorkers()
+				for _, w := range banned {
+					bannedUntil := w.getBannedUntil()
+					if bannedUntil.IsZero() {
+						// Ban the worker for the configured timeout
+						wm.setBanDuration(w.ID)
+					} else if time.Now().After(bannedUntil) {
+						// Unban the worker after the ban period
+						wm.resetWorker(w.ID)
+					}
+				}
+			}
+		}
+	}()
+	log.Info("Worker manager started")
+}
+
+// stop stops the worker manager, cancels the context, and clears all workers.
+// It ensures that all workers are removed and no further actions are taken.
+// This is typically called when the application is shutting down or when
+// the worker manager is no longer needed.
+func (wm *workerManager) stop() {
+	if wm.cancelFunc != nil {
+		wm.cancelFunc()
+	}
+	// clear workers safely
+	wm.workers.Range(func(key, value any) bool {
+		wm.workers.Delete(key)
+		return true // continue iteration
+	})
+}
+
+// addWorker adds a new worker to the manager. If the worker already exists,
+// it returns the existing worker without adding a new one. If it's a new
+// worker, it initializes a new worker instance, stores it in the worker map,
+// and returns the worker instance.
+func (wm *workerManager) addWorker(id string) *worker {
+	if w, exists := wm.getWorker(id); exists {
+		log.Warnf("Worker %s already exists, not adding again", id)
+		// Worker already exists, no need to add again
+		return w
+	}
+	w := &worker{ID: id}
+	wm.workers.Store(id, w)
+	log.Debugf("Worker added: %s", id)
+	return w
+}
+
+// getWorker retrieves a worker by its ID. If the worker exists, it returns
+// the worker instance and a boolean indicating success. If the worker does
+// not exist, it returns nil and false.
+func (wm *workerManager) getWorker(id string) (*worker, bool) {
+	if w, ok := wm.workers.Load(id); ok {
+		return w.(*worker), true
+	}
+	return nil, false
+}
+
+// bannedWorkers returns a slice of workers that are currently banned based on
+// the ban rules. It iterates through all workers in the manager, checks if
+// they are banned according to the rules, and collects them in a slice.
+func (wm *workerManager) bannedWorkers() []*worker {
+	var banned []*worker
+	wm.workers.Range(func(key, value any) bool {
+		if w, ok := value.(*worker); ok && w.isBanned(wm.rules) {
+			banned = append(banned, w)
+		}
+		return true // continue iteration
+	})
+	log.Debugf("Banned workers: %d", len(banned))
+	return banned
+}
+
+// resetWorker resets the worker's status by creating a new worker instance
+// with the same ID. This effectively clears the worker's consecutive fails
+// and banned status, allowing the worker to be reused without any previous
+// restrictions. It is typically called when a worker has been banned and
+// the ban period has expired, or when a worker needs to be reset for any
+// reason.
+func (wm *workerManager) resetWorker(id string) {
+	if _, ok := wm.getWorker(id); ok {
+		wm.workers.Store(id, &worker{ID: id})
+		log.Debugf("Worker %s reset", id)
+	}
+}
+
+// setBanDuration sets the ban duration for a worker. It updates the worker's
+// ban expiration time to the current time plus the ban timeout defined in the
+// rules. This effectively bans the worker for the specified duration,
+// preventing it from processing jobs until the ban period expires.
+func (wm *workerManager) setBanDuration(workerID string) {
+	if w, ok := wm.getWorker(workerID); ok {
+		banTime := time.Now().Add(wm.rules.timeout)
+		w.setBannedUntil(banTime)
+		log.Warnf("Worker %s banned until %s", workerID, banTime)
+	}
+}
+
+// workerResult updates the worker's status based on the result of a job.
+// If the job was successful, it resets the worker's consecutive fails to zero.
+// If the job failed, it increments the worker's consecutive fails count.
+// This method uses atomic operations to ensure thread safety.
+func (wm *workerManager) workerResult(id string, success bool) {
+	w, ok := wm.getWorker(id)
+	if !ok {
+		w = &worker{ID: id}
+		wm.workers.Store(id, w)
+	}
+
+	if success {
+		atomic.StoreInt64(&w.consecutiveFails, 0)
+	} else {
+		atomic.AddInt64(&w.consecutiveFails, 1)
+	}
+}

--- a/api/worker_manager_test.go
+++ b/api/worker_manager_test.go
@@ -13,9 +13,9 @@ import (
 func TestNewWorkerManager(t *testing.T) {
 	c := qt.New(t)
 
-	rules := banRules{
-		timeout:             5 * time.Minute,
-		maxConsecutiveFails: 5,
+	rules := &BanRules{
+		BanTimeout:          5 * time.Minute,
+		FailuresToGetBanned: 5,
 	}
 
 	wm := newWorkerManager(rules)
@@ -29,9 +29,9 @@ func TestNewWorkerManager(t *testing.T) {
 func TestWorkerIsBanned(t *testing.T) {
 	c := qt.New(t)
 
-	rules := banRules{
-		timeout:             3 * time.Minute,
-		maxConsecutiveFails: 3,
+	rules := &BanRules{
+		BanTimeout:          3 * time.Minute,
+		FailuresToGetBanned: 3,
 	}
 
 	tests := []struct {
@@ -82,7 +82,7 @@ func TestWorkerIsBanned(t *testing.T) {
 func TestWorkerManagerAddWorker(t *testing.T) {
 	c := qt.New(t)
 
-	wm := newWorkerManager(defaultBanRules)
+	wm := newWorkerManager(DefaultBanRules)
 
 	// Test adding a new worker
 	worker1 := wm.addWorker("worker1")
@@ -105,7 +105,7 @@ func TestWorkerManagerAddWorker(t *testing.T) {
 func TestWorkerManagerGetWorker(t *testing.T) {
 	c := qt.New(t)
 
-	wm := newWorkerManager(defaultBanRules)
+	wm := newWorkerManager(DefaultBanRules)
 
 	// Test getting non-existent worker
 	worker, exists := wm.getWorker("nonexistent")
@@ -123,7 +123,7 @@ func TestWorkerManagerGetWorker(t *testing.T) {
 func TestWorkerManagerWorkerResult(t *testing.T) {
 	c := qt.New(t)
 
-	wm := newWorkerManager(defaultBanRules)
+	wm := newWorkerManager(DefaultBanRules)
 
 	// Test success result on new worker
 	wm.workerResult("worker1", true)
@@ -154,9 +154,9 @@ func TestWorkerManagerWorkerResult(t *testing.T) {
 func TestWorkerManagerBannedWorkers(t *testing.T) {
 	c := qt.New(t)
 
-	rules := banRules{
-		timeout:             3 * time.Minute,
-		maxConsecutiveFails: 2,
+	rules := &BanRules{
+		BanTimeout:          3 * time.Minute,
+		FailuresToGetBanned: 2,
 	}
 	wm := newWorkerManager(rules)
 
@@ -185,7 +185,7 @@ func TestWorkerManagerBannedWorkers(t *testing.T) {
 func TestWorkerManagerResetWorker(t *testing.T) {
 	c := qt.New(t)
 
-	wm := newWorkerManager(defaultBanRules)
+	wm := newWorkerManager(DefaultBanRules)
 
 	// Add worker with failures
 	wm.addWorker("worker1")
@@ -210,9 +210,9 @@ func TestWorkerManagerResetWorker(t *testing.T) {
 func TestWorkerManagerSetBanDuration(t *testing.T) {
 	c := qt.New(t)
 
-	rules := banRules{
-		timeout:             5 * time.Minute,
-		maxConsecutiveFails: 3,
+	rules := &BanRules{
+		BanTimeout:          5 * time.Minute,
+		FailuresToGetBanned: 3,
 	}
 	wm := newWorkerManager(rules)
 
@@ -237,7 +237,7 @@ func TestWorkerManagerSetBanDuration(t *testing.T) {
 func TestWorkerManagerStartStop(t *testing.T) {
 	c := qt.New(t)
 
-	wm := newWorkerManager(defaultBanRules)
+	wm := newWorkerManager(DefaultBanRules)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -265,9 +265,9 @@ func TestWorkerManagerBanUnbanCycle(t *testing.T) {
 	c := qt.New(t)
 
 	// Use short timeout for testing
-	rules := banRules{
-		timeout:             100 * time.Millisecond,
-		maxConsecutiveFails: 2,
+	rules := &BanRules{
+		BanTimeout:          100 * time.Millisecond,
+		FailuresToGetBanned: 2,
 	}
 	wm := newWorkerManager(rules)
 
@@ -311,9 +311,9 @@ func TestWorkerManagerRealStartMethodWithConfigurableTicker(t *testing.T) {
 
 	t.Run("Real start method with fast ticker - complete ban/unban cycle", func(t *testing.T) {
 		// Test the actual start() method with configurable fast ticker
-		rules := banRules{
-			timeout:             200 * time.Millisecond, // Short timeout for testing
-			maxConsecutiveFails: 1,
+		rules := &BanRules{
+			BanTimeout:          200 * time.Millisecond, // Short timeout for testing
+			FailuresToGetBanned: 1,
 		}
 		// Use REAL start method with fast ticker interval
 		wm := newWorkerManager(rules, 100*time.Millisecond)
@@ -336,7 +336,7 @@ func TestWorkerManagerRealStartMethodWithConfigurableTicker(t *testing.T) {
 		// Verify workers are banned but no ban duration set yet
 		banned := wm.bannedWorkers()
 		c.Assert(len(banned), qt.Equals, 2)
-		
+
 		worker1, exists1 := wm.getWorker("worker1")
 		worker2, exists2 := wm.getWorker("worker2")
 		c.Assert(exists1, qt.IsTrue)
@@ -369,9 +369,9 @@ func TestWorkerManagerRealStartMethodWithConfigurableTicker(t *testing.T) {
 
 	t.Run("Real start method - context cancellation behavior", func(t *testing.T) {
 		// Test real start method context cancellation
-		rules := banRules{
-			timeout:             1 * time.Second,
-			maxConsecutiveFails: 1,
+		rules := &BanRules{
+			BanTimeout:          1 * time.Second,
+			FailuresToGetBanned: 1,
 		}
 		wm := newWorkerManager(rules, 50*time.Millisecond) // Fast ticker
 
@@ -387,7 +387,7 @@ func TestWorkerManagerRealStartMethodWithConfigurableTicker(t *testing.T) {
 		// Add workers
 		wm.addWorker("worker1")
 		wm.addWorker("worker2")
-		
+
 		// Verify workers exist
 		_, exists1 := wm.getWorker("worker1")
 		_, exists2 := wm.getWorker("worker2")
@@ -409,9 +409,9 @@ func TestWorkerManagerRealStartMethodWithConfigurableTicker(t *testing.T) {
 
 	t.Run("Real start method - ticker interval verification", func(t *testing.T) {
 		// Test that different ticker intervals work correctly
-		rules := banRules{
-			timeout:             100 * time.Millisecond,
-			maxConsecutiveFails: 1,
+		rules := &BanRules{
+			BanTimeout:          100 * time.Millisecond,
+			FailuresToGetBanned: 1,
 		}
 
 		// Test with custom interval
@@ -449,9 +449,9 @@ func TestWorkerManagerRealStartMethodWithConfigurableTicker(t *testing.T) {
 
 	t.Run("Real start method - no banned workers scenario", func(t *testing.T) {
 		// Test ticker behavior when no workers are banned
-		rules := banRules{
-			timeout:             200 * time.Millisecond,
-			maxConsecutiveFails: 5, // High threshold
+		rules := &BanRules{
+			BanTimeout:          200 * time.Millisecond,
+			FailuresToGetBanned: 5, // High threshold
 		}
 		wm := newWorkerManager(rules, 50*time.Millisecond)
 
@@ -489,7 +489,7 @@ func TestWorkerManagerRealStartMethodWithConfigurableTicker(t *testing.T) {
 func TestWorkerManagerConcurrency(t *testing.T) {
 	c := qt.New(t)
 
-	wm := newWorkerManager(defaultBanRules)
+	wm := newWorkerManager(DefaultBanRules)
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
@@ -510,7 +510,7 @@ func TestWorkerManagerConcurrency(t *testing.T) {
 			wm.addWorker(workerID)
 
 			// Perform some operations on the worker
-			for j := 0; j < numOperations; j++ {
+			for j := range numOperations {
 				wm.workerResult(workerID, j%2 == 0) // Alternate success/failure
 			}
 		}(i)
@@ -539,7 +539,7 @@ func TestWorkerManagerConcurrency(t *testing.T) {
 func TestWorkerManagerContextCancellation(t *testing.T) {
 	c := qt.New(t)
 
-	wm := newWorkerManager(defaultBanRules)
+	wm := newWorkerManager(DefaultBanRules)
 	ctx, cancel := context.WithCancel(context.Background())
 
 	wm.start(ctx)
@@ -565,9 +565,9 @@ func TestWorkerManagerEdgeCases(t *testing.T) {
 	c := qt.New(t)
 
 	t.Run("Zero max consecutive fails", func(t *testing.T) {
-		rules := banRules{
-			timeout:             1 * time.Minute,
-			maxConsecutiveFails: 0,
+		rules := &BanRules{
+			BanTimeout:          1 * time.Minute,
+			FailuresToGetBanned: 0,
 		}
 		wm := newWorkerManager(rules)
 
@@ -579,9 +579,9 @@ func TestWorkerManagerEdgeCases(t *testing.T) {
 	})
 
 	t.Run("Negative max consecutive fails", func(t *testing.T) {
-		rules := banRules{
-			timeout:             1 * time.Minute,
-			maxConsecutiveFails: -1,
+		rules := &BanRules{
+			BanTimeout:          1 * time.Minute,
+			FailuresToGetBanned: -1,
 		}
 		wm := newWorkerManager(rules)
 
@@ -591,7 +591,7 @@ func TestWorkerManagerEdgeCases(t *testing.T) {
 	})
 
 	t.Run("Empty worker ID", func(t *testing.T) {
-		wm := newWorkerManager(defaultBanRules)
+		wm := newWorkerManager(DefaultBanRules)
 
 		worker := wm.addWorker("")
 		c.Assert(worker.ID, qt.Equals, "")

--- a/api/worker_manager_test.go
+++ b/api/worker_manager_test.go
@@ -1,0 +1,603 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestNewWorkerManager(t *testing.T) {
+	c := qt.New(t)
+
+	rules := banRules{
+		timeout:             5 * time.Minute,
+		maxConsecutiveFails: 5,
+	}
+
+	wm := newWorkerManager(rules)
+
+	c.Assert(wm, qt.IsNotNil)
+	c.Assert(wm.rules, qt.Equals, rules)
+	c.Assert(wm.innerCtx, qt.IsNil) // Should be nil until start() is called
+	c.Assert(wm.cancelFunc, qt.IsNil)
+}
+
+func TestWorkerIsBanned(t *testing.T) {
+	c := qt.New(t)
+
+	rules := banRules{
+		timeout:             3 * time.Minute,
+		maxConsecutiveFails: 3,
+	}
+
+	tests := []struct {
+		name             string
+		consecutiveFails int
+		expected         bool
+	}{
+		{
+			name:             "No failures",
+			consecutiveFails: 0,
+			expected:         false,
+		},
+		{
+			name:             "Below threshold",
+			consecutiveFails: 2,
+			expected:         false,
+		},
+		{
+			name:             "At threshold",
+			consecutiveFails: 3,
+			expected:         false,
+		},
+		{
+			name:             "Above threshold",
+			consecutiveFails: 4,
+			expected:         true,
+		},
+		{
+			name:             "Well above threshold",
+			consecutiveFails: 10,
+			expected:         true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			worker := &worker{
+				ID:               "test-worker",
+				consecutiveFails: int64(tt.consecutiveFails),
+			}
+
+			result := worker.isBanned(rules)
+			c.Assert(result, qt.Equals, tt.expected)
+		})
+	}
+}
+
+func TestWorkerManagerAddWorker(t *testing.T) {
+	c := qt.New(t)
+
+	wm := newWorkerManager(defaultBanRules)
+
+	// Test adding a new worker
+	worker1 := wm.addWorker("worker1")
+	c.Assert(worker1, qt.IsNotNil)
+	c.Assert(worker1.ID, qt.Equals, "worker1")
+	c.Assert(worker1.getConsecutiveFails(), qt.Equals, 0)
+	c.Assert(worker1.getBannedUntil().IsZero(), qt.IsTrue)
+
+	// Test adding the same worker again (should return existing)
+	worker1Again := wm.addWorker("worker1")
+	c.Assert(worker1Again, qt.Equals, worker1)
+
+	// Test adding a different worker
+	worker2 := wm.addWorker("worker2")
+	c.Assert(worker2, qt.IsNotNil)
+	c.Assert(worker2.ID, qt.Equals, "worker2")
+	c.Assert(worker2, qt.Not(qt.Equals), worker1)
+}
+
+func TestWorkerManagerGetWorker(t *testing.T) {
+	c := qt.New(t)
+
+	wm := newWorkerManager(defaultBanRules)
+
+	// Test getting non-existent worker
+	worker, exists := wm.getWorker("nonexistent")
+	c.Assert(worker, qt.IsNil)
+	c.Assert(exists, qt.IsFalse)
+
+	// Add a worker and test getting it
+	addedWorker := wm.addWorker("test-worker")
+	retrievedWorker, exists := wm.getWorker("test-worker")
+	c.Assert(retrievedWorker, qt.IsNotNil)
+	c.Assert(exists, qt.IsTrue)
+	c.Assert(retrievedWorker, qt.Equals, addedWorker)
+}
+
+func TestWorkerManagerWorkerResult(t *testing.T) {
+	c := qt.New(t)
+
+	wm := newWorkerManager(defaultBanRules)
+
+	// Test success result on new worker
+	wm.workerResult("worker1", true)
+	worker, exists := wm.getWorker("worker1")
+	c.Assert(exists, qt.IsTrue)
+	c.Assert(worker.getConsecutiveFails(), qt.Equals, 0)
+
+	// Test failure result
+	wm.workerResult("worker1", false)
+	worker, exists = wm.getWorker("worker1")
+	c.Assert(exists, qt.IsTrue)
+	c.Assert(worker.getConsecutiveFails(), qt.Equals, 1)
+
+	// Test multiple failures
+	wm.workerResult("worker1", false)
+	wm.workerResult("worker1", false)
+	worker, exists = wm.getWorker("worker1")
+	c.Assert(exists, qt.IsTrue)
+	c.Assert(worker.getConsecutiveFails(), qt.Equals, 3)
+
+	// Test success resets failures
+	wm.workerResult("worker1", true)
+	worker, exists = wm.getWorker("worker1")
+	c.Assert(exists, qt.IsTrue)
+	c.Assert(worker.getConsecutiveFails(), qt.Equals, 0)
+}
+
+func TestWorkerManagerBannedWorkers(t *testing.T) {
+	c := qt.New(t)
+
+	rules := banRules{
+		timeout:             3 * time.Minute,
+		maxConsecutiveFails: 2,
+	}
+	wm := newWorkerManager(rules)
+
+	// Initially no banned workers
+	banned := wm.bannedWorkers()
+	c.Assert(len(banned), qt.Equals, 0)
+
+	// Add workers with different failure counts
+	wm.addWorker("worker1")
+	wm.workerResult("worker1", false) // 1 failure
+	wm.workerResult("worker1", false) // 2 failures
+
+	wm.addWorker("worker2")
+	wm.workerResult("worker2", false) // 1 failure
+	wm.workerResult("worker2", false) // 2 failures
+	wm.workerResult("worker2", false) // 3 failures - should be banned
+
+	wm.addWorker("worker3")
+	wm.workerResult("worker3", true) // success
+
+	banned = wm.bannedWorkers()
+	c.Assert(len(banned), qt.Equals, 1)
+	c.Assert(banned[0].ID, qt.Equals, "worker2")
+}
+
+func TestWorkerManagerResetWorker(t *testing.T) {
+	c := qt.New(t)
+
+	wm := newWorkerManager(defaultBanRules)
+
+	// Add worker with failures
+	wm.addWorker("worker1")
+	wm.workerResult("worker1", false)
+	wm.workerResult("worker1", false)
+
+	worker, _ := wm.getWorker("worker1")
+	c.Assert(worker.getConsecutiveFails(), qt.Equals, 2)
+
+	// Reset worker
+	wm.resetWorker("worker1")
+
+	worker, exists := wm.getWorker("worker1")
+	c.Assert(exists, qt.IsTrue)
+	c.Assert(worker.getConsecutiveFails(), qt.Equals, 0)
+	c.Assert(worker.getBannedUntil().IsZero(), qt.IsTrue)
+
+	// Test resetting non-existent worker (should not panic)
+	wm.resetWorker("nonexistent")
+}
+
+func TestWorkerManagerSetBanDuration(t *testing.T) {
+	c := qt.New(t)
+
+	rules := banRules{
+		timeout:             5 * time.Minute,
+		maxConsecutiveFails: 3,
+	}
+	wm := newWorkerManager(rules)
+
+	// Add worker
+	wm.addWorker("worker1")
+
+	// Set ban duration
+	beforeBan := time.Now()
+	wm.setBanDuration("worker1")
+	afterBan := time.Now()
+
+	worker, exists := wm.getWorker("worker1")
+	c.Assert(exists, qt.IsTrue)
+	bannedUntil := worker.getBannedUntil()
+	c.Assert(bannedUntil.After(beforeBan.Add(4*time.Minute)), qt.IsTrue)
+	c.Assert(bannedUntil.Before(afterBan.Add(6*time.Minute)), qt.IsTrue)
+
+	// Test setting ban on non-existent worker (should not panic)
+	wm.setBanDuration("nonexistent")
+}
+
+func TestWorkerManagerStartStop(t *testing.T) {
+	c := qt.New(t)
+
+	wm := newWorkerManager(defaultBanRules)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Test start
+	wm.start(ctx)
+	c.Assert(wm.innerCtx, qt.IsNotNil)
+	c.Assert(wm.cancelFunc, qt.IsNotNil)
+
+	// Add a worker to verify it exists
+	wm.addWorker("test-worker")
+	worker, exists := wm.getWorker("test-worker")
+	c.Assert(exists, qt.IsTrue)
+	c.Assert(worker, qt.IsNotNil)
+
+	// Test stop
+	wm.stop()
+
+	// Verify workers are cleared
+	worker, exists = wm.getWorker("test-worker")
+	c.Assert(exists, qt.IsFalse)
+	c.Assert(worker, qt.IsNil)
+}
+
+func TestWorkerManagerBanUnbanCycle(t *testing.T) {
+	c := qt.New(t)
+
+	// Use short timeout for testing
+	rules := banRules{
+		timeout:             100 * time.Millisecond,
+		maxConsecutiveFails: 2,
+	}
+	wm := newWorkerManager(rules)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	wm.start(ctx)
+	defer wm.stop()
+
+	// Add worker and make it fail enough to be banned
+	wm.addWorker("worker1")
+	wm.workerResult("worker1", false) // 1 failure
+	wm.workerResult("worker1", false) // 2 failures
+	wm.workerResult("worker1", false) // 3 failures - should be banned
+
+	// Verify worker is banned
+	banned := wm.bannedWorkers()
+	c.Assert(len(banned), qt.Equals, 1)
+
+	// Manually trigger ban duration setting (since ticker runs every 10 seconds)
+	wm.setBanDuration("worker1")
+
+	worker, exists := wm.getWorker("worker1")
+	c.Assert(exists, qt.IsTrue)
+	c.Assert(worker.getBannedUntil().IsZero(), qt.IsFalse)
+
+	// Wait for ban to expire
+	time.Sleep(150 * time.Millisecond)
+
+	// Manually trigger worker reset (since ticker runs every 10 seconds)
+	wm.resetWorker("worker1")
+
+	worker, exists = wm.getWorker("worker1")
+	c.Assert(exists, qt.IsTrue)
+	c.Assert(worker.getConsecutiveFails(), qt.Equals, 0)
+	c.Assert(worker.getBannedUntil().IsZero(), qt.IsTrue)
+}
+
+func TestWorkerManagerRealStartMethodWithConfigurableTicker(t *testing.T) {
+	c := qt.New(t)
+
+	t.Run("Real start method with fast ticker - complete ban/unban cycle", func(t *testing.T) {
+		// Test the actual start() method with configurable fast ticker
+		rules := banRules{
+			timeout:             200 * time.Millisecond, // Short timeout for testing
+			maxConsecutiveFails: 1,
+		}
+		// Use REAL start method with fast ticker interval
+		wm := newWorkerManager(rules, 100*time.Millisecond)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		// Use the REAL start method - no modifications, just fast ticker
+		wm.start(ctx)
+		defer wm.stop()
+
+		// Set up workers in banned state
+		wm.addWorker("worker1")
+		wm.addWorker("worker2")
+		wm.workerResult("worker1", false) // 1 failure
+		wm.workerResult("worker1", false) // 2 failures - should be banned
+		wm.workerResult("worker2", false) // 1 failure
+		wm.workerResult("worker2", false) // 2 failures - should be banned
+
+		// Verify workers are banned but no ban duration set yet
+		banned := wm.bannedWorkers()
+		c.Assert(len(banned), qt.Equals, 2)
+		
+		worker1, exists1 := wm.getWorker("worker1")
+		worker2, exists2 := wm.getWorker("worker2")
+		c.Assert(exists1, qt.IsTrue)
+		c.Assert(exists2, qt.IsTrue)
+		c.Assert(worker1.getBannedUntil().IsZero(), qt.IsTrue) // No ban duration set yet
+		c.Assert(worker2.getBannedUntil().IsZero(), qt.IsTrue) // No ban duration set yet
+
+		// Wait for the REAL ticker to fire (100ms + buffer)
+		time.Sleep(150 * time.Millisecond)
+
+		// Verify ban durations were set by the real background logic
+		worker1, _ = wm.getWorker("worker1")
+		worker2, _ = wm.getWorker("worker2")
+		c.Assert(worker1.getBannedUntil().IsZero(), qt.IsFalse, qt.Commentf("Ban duration should be set after ticker"))
+		c.Assert(worker2.getBannedUntil().IsZero(), qt.IsFalse, qt.Commentf("Ban duration should be set after ticker"))
+
+		// Wait for bans to expire (200ms) + next ticker (100ms)
+		time.Sleep(350 * time.Millisecond)
+
+		// Verify workers were reset by the real background logic
+		worker1, exists1 = wm.getWorker("worker1")
+		worker2, exists2 = wm.getWorker("worker2")
+		c.Assert(exists1, qt.IsTrue)
+		c.Assert(exists2, qt.IsTrue)
+		c.Assert(worker1.getConsecutiveFails(), qt.Equals, 0, qt.Commentf("Worker should be reset after ban expiry"))
+		c.Assert(worker2.getConsecutiveFails(), qt.Equals, 0, qt.Commentf("Worker should be reset after ban expiry"))
+		c.Assert(worker1.getBannedUntil().IsZero(), qt.IsTrue, qt.Commentf("Ban should be cleared after reset"))
+		c.Assert(worker2.getBannedUntil().IsZero(), qt.IsTrue, qt.Commentf("Ban should be cleared after reset"))
+	})
+
+	t.Run("Real start method - context cancellation behavior", func(t *testing.T) {
+		// Test real start method context cancellation
+		rules := banRules{
+			timeout:             1 * time.Second,
+			maxConsecutiveFails: 1,
+		}
+		wm := newWorkerManager(rules, 50*time.Millisecond) // Fast ticker
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		// Use the REAL start method
+		wm.start(ctx)
+
+		// Verify initialization
+		c.Assert(wm.innerCtx, qt.IsNotNil)
+		c.Assert(wm.cancelFunc, qt.IsNotNil)
+
+		// Add workers
+		wm.addWorker("worker1")
+		wm.addWorker("worker2")
+		
+		// Verify workers exist
+		_, exists1 := wm.getWorker("worker1")
+		_, exists2 := wm.getWorker("worker2")
+		c.Assert(exists1, qt.IsTrue)
+		c.Assert(exists2, qt.IsTrue)
+
+		// Cancel context - this should trigger the real ctx.Done() case
+		cancel()
+
+		// Give time for the real goroutine to process cancellation
+		time.Sleep(100 * time.Millisecond)
+
+		// Verify the real stop() was called and workers cleared
+		_, exists1 = wm.getWorker("worker1")
+		_, exists2 = wm.getWorker("worker2")
+		c.Assert(exists1, qt.IsFalse)
+		c.Assert(exists2, qt.IsFalse)
+	})
+
+	t.Run("Real start method - ticker interval verification", func(t *testing.T) {
+		// Test that different ticker intervals work correctly
+		rules := banRules{
+			timeout:             100 * time.Millisecond,
+			maxConsecutiveFails: 1,
+		}
+
+		// Test with custom interval
+		wm := newWorkerManager(rules, 50*time.Millisecond)
+		c.Assert(wm.tickerInterval, qt.Equals, 50*time.Millisecond)
+
+		// Test with default interval
+		wmDefault := newWorkerManager(rules)
+		c.Assert(wmDefault.tickerInterval, qt.Equals, 10*time.Second)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		defer cancel()
+
+		// Start the fast ticker version
+		wm.start(ctx)
+		defer wm.stop()
+
+		// Add banned worker
+		wm.addWorker("worker1")
+		wm.workerResult("worker1", false)
+		wm.workerResult("worker1", false) // Should be banned
+
+		// Verify banned
+		banned := wm.bannedWorkers()
+		c.Assert(len(banned), qt.Equals, 1)
+
+		// Wait for ticker to process (should happen within 50ms + buffer)
+		time.Sleep(100 * time.Millisecond)
+
+		// Verify ban duration was set by real ticker
+		worker, exists := wm.getWorker("worker1")
+		c.Assert(exists, qt.IsTrue)
+		c.Assert(worker.getBannedUntil().IsZero(), qt.IsFalse)
+	})
+
+	t.Run("Real start method - no banned workers scenario", func(t *testing.T) {
+		// Test ticker behavior when no workers are banned
+		rules := banRules{
+			timeout:             200 * time.Millisecond,
+			maxConsecutiveFails: 5, // High threshold
+		}
+		wm := newWorkerManager(rules, 50*time.Millisecond)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+		defer cancel()
+
+		wm.start(ctx)
+		defer wm.stop()
+
+		// Add workers with some failures but not enough to ban
+		wm.addWorker("worker1")
+		wm.addWorker("worker2")
+		wm.workerResult("worker1", false) // 1 failure
+		wm.workerResult("worker2", false) // 1 failure
+
+		// Wait for multiple ticker cycles
+		time.Sleep(200 * time.Millisecond)
+
+		// Verify workers are still active and not banned
+		worker1, exists1 := wm.getWorker("worker1")
+		worker2, exists2 := wm.getWorker("worker2")
+		c.Assert(exists1, qt.IsTrue)
+		c.Assert(exists2, qt.IsTrue)
+		c.Assert(worker1.getConsecutiveFails(), qt.Equals, 1)
+		c.Assert(worker2.getConsecutiveFails(), qt.Equals, 1)
+		c.Assert(worker1.getBannedUntil().IsZero(), qt.IsTrue)
+		c.Assert(worker2.getBannedUntil().IsZero(), qt.IsTrue)
+
+		// Verify no workers are banned
+		banned := wm.bannedWorkers()
+		c.Assert(len(banned), qt.Equals, 0)
+	})
+}
+
+func TestWorkerManagerConcurrency(t *testing.T) {
+	c := qt.New(t)
+
+	wm := newWorkerManager(defaultBanRules)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	wm.start(ctx)
+	defer wm.stop()
+
+	const numWorkers = 100
+	const numOperations = 10
+
+	var wg sync.WaitGroup
+
+	// Concurrent worker additions
+	for i := range numWorkers {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			workerID := fmt.Sprintf("worker-%d", id)
+			wm.addWorker(workerID)
+
+			// Perform some operations on the worker
+			for j := 0; j < numOperations; j++ {
+				wm.workerResult(workerID, j%2 == 0) // Alternate success/failure
+			}
+		}(i)
+	}
+
+	// Concurrent banned workers checks
+	for range 10 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			wm.bannedWorkers()
+		}()
+	}
+
+	wg.Wait()
+
+	// Verify all workers were added
+	for i := range numWorkers {
+		workerID := fmt.Sprintf("worker-%d", i)
+		worker, exists := wm.getWorker(workerID)
+		c.Assert(exists, qt.IsTrue)
+		c.Assert(worker.ID, qt.Equals, workerID)
+	}
+}
+
+func TestWorkerManagerContextCancellation(t *testing.T) {
+	c := qt.New(t)
+
+	wm := newWorkerManager(defaultBanRules)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	wm.start(ctx)
+	c.Assert(wm.innerCtx, qt.IsNotNil)
+
+	// Add a worker
+	wm.addWorker("test-worker")
+	_, exists := wm.getWorker("test-worker")
+	c.Assert(exists, qt.IsTrue)
+
+	// Cancel context
+	cancel()
+
+	// Give some time for the goroutine to process the cancellation
+	time.Sleep(50 * time.Millisecond)
+
+	// Worker should be cleared because context cancellation calls stop() which clears workers
+	_, exists = wm.getWorker("test-worker")
+	c.Assert(exists, qt.IsFalse)
+}
+
+func TestWorkerManagerEdgeCases(t *testing.T) {
+	c := qt.New(t)
+
+	t.Run("Zero max consecutive fails", func(t *testing.T) {
+		rules := banRules{
+			timeout:             1 * time.Minute,
+			maxConsecutiveFails: 0,
+		}
+		wm := newWorkerManager(rules)
+
+		wm.addWorker("worker1")
+		wm.workerResult("worker1", false) // 1 failure
+
+		worker, _ := wm.getWorker("worker1")
+		c.Assert(worker.isBanned(rules), qt.IsTrue) // Should be banned immediately
+	})
+
+	t.Run("Negative max consecutive fails", func(t *testing.T) {
+		rules := banRules{
+			timeout:             1 * time.Minute,
+			maxConsecutiveFails: -1,
+		}
+		wm := newWorkerManager(rules)
+
+		wm.addWorker("worker1")
+		worker, _ := wm.getWorker("worker1")
+		c.Assert(worker.isBanned(rules), qt.IsTrue) // Should be banned immediately
+	})
+
+	t.Run("Empty worker ID", func(t *testing.T) {
+		wm := newWorkerManager(defaultBanRules)
+
+		worker := wm.addWorker("")
+		c.Assert(worker.ID, qt.Equals, "")
+
+		retrievedWorker, exists := wm.getWorker("")
+		c.Assert(exists, qt.IsTrue)
+		c.Assert(retrievedWorker, qt.Equals, worker)
+	})
+}

--- a/api/worker_manager_time_ban_test.go
+++ b/api/worker_manager_time_ban_test.go
@@ -1,0 +1,111 @@
+package api
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestWorkerTimeBanCoverage(t *testing.T) {
+	c := qt.New(t)
+
+	rules := banRules{
+		timeout:             3 * time.Minute,
+		maxConsecutiveFails: 3,
+	}
+
+	t.Run("Time-based banning scenarios", func(t *testing.T) {
+		worker := &worker{
+			ID:               "test-worker",
+			consecutiveFails: 0, // No consecutive fails
+		}
+
+		// Test worker with no ban time set (bannedUntilNanos = 0)
+		c.Assert(worker.isBanned(rules), qt.IsFalse)
+
+		// Test worker with future ban time (still banned)
+		futureTime := time.Now().Add(1 * time.Hour)
+		worker.setBannedUntil(futureTime)
+		c.Assert(worker.isBanned(rules), qt.IsTrue)
+
+		// Test worker with past ban time (ban expired)
+		pastTime := time.Now().Add(-1 * time.Hour)
+		worker.setBannedUntil(pastTime)
+		c.Assert(worker.isBanned(rules), qt.IsFalse)
+
+		// Test worker with ban time very close to now (edge case)
+		almostNow := time.Now().Add(1 * time.Millisecond)
+		worker.setBannedUntil(almostNow)
+		c.Assert(worker.isBanned(rules), qt.IsTrue)
+
+		// Wait for the ban to expire and test again
+		time.Sleep(2 * time.Millisecond)
+		c.Assert(worker.isBanned(rules), qt.IsFalse)
+	})
+
+	t.Run("Combined consecutive fails and time-based banning", func(t *testing.T) {
+		// Test worker that is banned by consecutive fails AND has a time-based ban
+		worker := &worker{
+			ID:               "test-worker",
+			consecutiveFails: 5, // Above threshold
+		}
+
+		// Should be banned due to consecutive fails, regardless of time ban
+		c.Assert(worker.isBanned(rules), qt.IsTrue)
+
+		// Set a future ban time - should still be banned
+		futureTime := time.Now().Add(1 * time.Hour)
+		worker.setBannedUntil(futureTime)
+		c.Assert(worker.isBanned(rules), qt.IsTrue)
+
+		// Set a past ban time - should still be banned due to consecutive fails
+		pastTime := time.Now().Add(-1 * time.Hour)
+		worker.setBannedUntil(pastTime)
+		c.Assert(worker.isBanned(rules), qt.IsTrue)
+
+		// Reset consecutive fails but keep future ban time
+		atomic.StoreInt64(&worker.consecutiveFails, 0)
+		worker.setBannedUntil(time.Now().Add(1*time.Hour))
+		c.Assert(worker.isBanned(rules), qt.IsTrue) // Still banned due to time
+
+		// Clear ban time - should not be banned
+		worker.setBannedUntil(time.Time{})
+		c.Assert(worker.isBanned(rules), qt.IsFalse)
+	})
+
+	t.Run("Edge cases for time comparison", func(t *testing.T) {
+		worker := &worker{
+			ID:               "test-worker",
+			consecutiveFails: 0,
+		}
+
+		// Test with zero time (should not be banned)
+		worker.setBannedUntil(time.Time{})
+		c.Assert(worker.isBanned(rules), qt.IsFalse)
+
+		// Test with exactly current time (should be banned by a tiny margin)
+		now := time.Now()
+		worker.setBannedUntil(now)
+		// This might be banned or not depending on timing, but it exercises the code path
+		_ = worker.isBanned(rules)
+
+		// Test with time well in the future (more reliable than nanoseconds)
+		futureMicro := time.Now().Add(100 * time.Microsecond)
+		worker.setBannedUntil(futureMicro)
+		c.Assert(worker.isBanned(rules), qt.IsTrue)
+
+		// Test with time well in the past
+		pastMicro := time.Now().Add(-100 * time.Microsecond)
+		worker.setBannedUntil(pastMicro)
+		c.Assert(worker.isBanned(rules), qt.IsFalse)
+
+		// Test the specific code path where bannedUntil != 0 but time has passed
+		// This ensures we cover the `return time.Now().UnixNano() < bannedUntil` line
+		pastTime := time.Now().Add(-1 * time.Second)
+		worker.setBannedUntil(pastTime)
+		banned := worker.isBanned(rules)
+		c.Assert(banned, qt.IsFalse) // Should not be banned since time has passed
+	})
+}

--- a/api/worker_manager_time_ban_test.go
+++ b/api/worker_manager_time_ban_test.go
@@ -11,9 +11,9 @@ import (
 func TestWorkerTimeBanCoverage(t *testing.T) {
 	c := qt.New(t)
 
-	rules := banRules{
-		timeout:             3 * time.Minute,
-		maxConsecutiveFails: 3,
+	rules := &BanRules{
+		BanTimeout:          3 * time.Minute,
+		FailuresToGetBanned: 3,
 	}
 
 	t.Run("Time-based banning scenarios", func(t *testing.T) {
@@ -67,7 +67,7 @@ func TestWorkerTimeBanCoverage(t *testing.T) {
 
 		// Reset consecutive fails but keep future ban time
 		atomic.StoreInt64(&worker.consecutiveFails, 0)
-		worker.setBannedUntil(time.Now().Add(1*time.Hour))
+		worker.setBannedUntil(time.Now().Add(1 * time.Hour))
 		c.Assert(worker.isBanned(rules), qt.IsTrue) // Still banned due to time
 
 		// Clear ban time - should not be banned

--- a/api/workers.go
+++ b/api/workers.go
@@ -14,7 +14,7 @@ import (
 
 // startWorkerTimeoutMonitor starts the timeout monitor for worker jobs
 func (a *API) startWorkerTimeoutMonitor() {
-	a.jobsManager = newJobsManager(a.workerTimeout)
+	a.jobsManager = newJobsManager(a.workerTimeout, a.banRules)
 	a.jobsManager.start(a.parentCtx)
 
 	go func() {
@@ -46,11 +46,11 @@ func (a *API) workerGetJob(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Check if worker is available
-	if !a.jobsManager.isWorkerAvailable(workerAddress) {
+	if available, err := a.jobsManager.isWorkerAvailable(workerAddress); !available {
 		log.Warnw("worker not available",
 			"worker", workerAddress,
 			"uuid", uuid)
-		ErrWorkerNotAvailable.Write(w)
+		ErrWorkerNotAvailable.WithErr(err).Write(w)
 		return
 	}
 

--- a/cmd/davinci-sequencer/config.go
+++ b/cmd/davinci-sequencer/config.go
@@ -50,9 +50,11 @@ type Web3Config struct {
 
 // APIConfig holds the API-specific configuration
 type APIConfig struct {
-	Host          string `mapstructure:"host"`       // API host address
-	Port          int    `mapstructure:"port"`       // API port number
-	WorkerUrlSeed string `mapstructure:"workerSeed"` // URL seed for worker authentication
+	Host                      string        `mapstructure:"host"`                      // API host address
+	Port                      int           `mapstructure:"port"`                      // API port number
+	WorkerUrlSeed             string        `mapstructure:"workerSeed"`                // URL seed for worker authentication
+	WorkerBanTimeout          time.Duration `mapstructure:"workerBanTimeout"`          // Timeout for worker ban
+	WorkerFailuresToGetBanned int           `mapstructure:"workerFailuresToGetBanned"` // Number of failed jobs to get banned
 }
 
 // BatchConfig holds batch processing configuration
@@ -115,6 +117,8 @@ func loadConfig() (*Config, error) {
 	flag.Duration("worker.timeout", 1*time.Minute, "worker job timeout duration")
 	flag.StringP("worker.address", "a", "", "worker Ethereum address (auto-generated if empty)")
 	flag.StringP("worker.masterURL", "w", "", "master worker URL (required for running in worker mode)")
+	flag.Duration("api.workerBanTimeout", 5*time.Minute, "timeout for worker ban in seconds")
+	flag.Int("api.workerFailuresToGetBanned", 5, "number of failed jobs to get banned")
 
 	// Configure usage information
 	flag.Usage = func() {

--- a/cmd/davinci-sequencer/main.go
+++ b/cmd/davinci-sequencer/main.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/vocdoni/davinci-node/api"
 	"github.com/vocdoni/davinci-node/config"
 	"github.com/vocdoni/davinci-node/log"
 	"github.com/vocdoni/davinci-node/sequencer"
@@ -237,7 +238,10 @@ func setupServices(ctx context.Context, cfg *Config, addresses *web3.Addresses) 
 
 	// Configure worker API if enabled
 	if cfg.API.WorkerUrlSeed != "" {
-		services.API.SetWorkerConfig(cfg.API.WorkerUrlSeed, cfg.Worker.Timeout)
+		services.API.SetWorkerConfig(cfg.API.WorkerUrlSeed, cfg.Worker.Timeout, &api.BanRules{
+			BanTimeout:          cfg.API.WorkerBanTimeout,
+			FailuresToGetBanned: cfg.API.WorkerFailuresToGetBanned,
+		})
 	}
 
 	// Start API service

--- a/sequencer/ballot.go
+++ b/sequencer/ballot.go
@@ -72,51 +72,58 @@ func (s *Sequencer) processAvailableBallots() bool {
 	processed := false
 
 	for {
-		// Try to fetch the next ballot
-		ballot, key, err := s.stg.NextBallot()
-		if err != nil {
-			if !errors.Is(err, storage.ErrNoMoreElements) {
-				log.Errorw(err, "failed to get next ballot")
-			}
+		select {
+		case <-s.ctx.Done():
+			log.Infow("ballot processor stopped")
 			return processed
-		}
-
-		// Skip processing if the process is not registered
-		if !s.ExistsProcessID(ballot.ProcessID) {
-			log.Debugw("skipping ballot, process not registered", "processID", ballot.ProcessID.String())
-			continue
-		}
-
-		log.Infow("processing ballot",
-			"address", ballot.Address.String(),
-			"queued", s.stg.TotalPendingBallots(),
-			"voteID", hex.EncodeToString(ballot.VoteID),
-			"processID", fmt.Sprintf("%x", ballot.ProcessID),
-		)
-
-		verifiedBallot, err := s.processBallot(ballot)
-		if err != nil {
-			log.Warnw("invalid ballot",
-				"error", err.Error(),
-				"ballot", ballot.String(),
-			)
-			if err := s.stg.RemoveBallot(ballot.ProcessID, key); err != nil {
-				log.Warnw("failed to remove invalid ballot", "error", err.Error())
+		default:
+			// Continue processing ballots
+			// Try to fetch the next ballot
+			ballot, key, err := s.stg.NextBallot()
+			if err != nil {
+				if !errors.Is(err, storage.ErrNoMoreElements) {
+					log.Errorw(err, "failed to get next ballot")
+				}
+				return processed
 			}
-			continue
-		}
 
-		// Mark the ballot as processed
-		if err := s.stg.MarkBallotDone(key, verifiedBallot); err != nil {
-			log.Warnw("failed to mark ballot as processed",
-				"error", err.Error(),
+			// Skip processing if the process is not registered
+			if !s.ExistsProcessID(ballot.ProcessID) {
+				log.Debugw("skipping ballot, process not registered", "processID", ballot.ProcessID.String())
+				continue
+			}
+
+			log.Infow("processing ballot",
 				"address", ballot.Address.String(),
+				"queued", s.stg.TotalPendingBallots(),
+				"voteID", hex.EncodeToString(ballot.VoteID),
 				"processID", fmt.Sprintf("%x", ballot.ProcessID),
 			)
-			continue
-		}
 
-		processed = true
+			verifiedBallot, err := s.processBallot(ballot)
+			if err != nil {
+				log.Warnw("invalid ballot",
+					"error", err.Error(),
+					"ballot", ballot.String(),
+				)
+				if err := s.stg.RemoveBallot(ballot.ProcessID, key); err != nil {
+					log.Warnw("failed to remove invalid ballot", "error", err.Error())
+				}
+				continue
+			}
+
+			// Mark the ballot as processed
+			if err := s.stg.MarkBallotDone(key, verifiedBallot); err != nil {
+				log.Warnw("failed to mark ballot as processed",
+					"error", err.Error(),
+					"address", ballot.Address.String(),
+					"processID", fmt.Sprintf("%x", ballot.ProcessID),
+				)
+				continue
+			}
+
+			processed = true
+		}
 	}
 }
 

--- a/service/api_service.go
+++ b/service/api_service.go
@@ -22,6 +22,7 @@ type APIService struct {
 	network       string
 	workerUrlSeed string
 	workerTimeout time.Duration
+	banRules      *api.BanRules // Custom ban rules for workers
 }
 
 // NewAPI creates a new APIService instance.
@@ -39,7 +40,7 @@ func NewAPI(storage *storage.Storage, host string, port int, network string, dis
 }
 
 // SetWorkerConfig configures the worker settings for the API service.
-func (as *APIService) SetWorkerConfig(urlSeed string, timeout time.Duration) {
+func (as *APIService) SetWorkerConfig(urlSeed string, timeout time.Duration, banRules *api.BanRules) {
 	log.Debugw("Setting worker configuration",
 		"urlSeed", urlSeed,
 		"timeout", timeout)
@@ -47,6 +48,7 @@ func (as *APIService) SetWorkerConfig(urlSeed string, timeout time.Duration) {
 	defer as.mu.Unlock()
 	as.workerUrlSeed = urlSeed
 	as.workerTimeout = timeout
+	as.banRules = banRules
 }
 
 // Start begins the API server. It returns an error if the service
@@ -70,6 +72,7 @@ func (as *APIService) Start(ctx context.Context) error {
 		Network:       as.network,
 		WorkerUrlSeed: as.workerUrlSeed,
 		WorkerTimeout: as.workerTimeout,
+		BanRules:      as.banRules,
 	})
 	if err != nil {
 		as.cancel = nil

--- a/service/api_service.go
+++ b/service/api_service.go
@@ -40,6 +40,9 @@ func NewAPI(storage *storage.Storage, host string, port int, network string, dis
 
 // SetWorkerConfig configures the worker settings for the API service.
 func (as *APIService) SetWorkerConfig(urlSeed string, timeout time.Duration) {
+	log.Debugw("Setting worker configuration",
+		"urlSeed", urlSeed,
+		"timeout", timeout)
 	as.mu.Lock()
 	defer as.mu.Unlock()
 	as.workerUrlSeed = urlSeed
@@ -60,7 +63,7 @@ func (as *APIService) Start(ctx context.Context) error {
 
 	// Create API instance with existing storage
 	var err error
-	as.API, err = api.New(&api.APIConfig{
+	as.API, err = api.New(ctx, &api.APIConfig{
 		Host:          as.host,
 		Port:          as.port,
 		Storage:       as.storage,

--- a/storage/ballot_queue.go
+++ b/storage/ballot_queue.go
@@ -10,6 +10,7 @@ import (
 	"github.com/vocdoni/arbo"
 	"github.com/vocdoni/davinci-node/log"
 	"github.com/vocdoni/davinci-node/types"
+	"github.com/vocdoni/davinci-node/util"
 	"go.vocdoni.io/dvote/db/prefixeddb"
 )
 
@@ -40,6 +41,7 @@ func (s *Storage) PushBallot(b *Ballot) error {
 	if err != nil {
 		return fmt.Errorf("encode ballot: %w", err)
 	}
+	defer util.HandleClosedDBPanic()
 	wTx := prefixeddb.NewPrefixedWriteTx(s.db.WriteTx(), ballotPrefix)
 	if _, err := wTx.Get(b.VoteID); err == nil {
 		wTx.Discard()
@@ -92,6 +94,7 @@ func (s *Storage) NextBallotForWorker() (*Ballot, []byte, error) {
 }
 
 func (s *Storage) nextBallot() (*Ballot, []byte, error) {
+	defer util.HandleClosedDBPanic()
 	pr := prefixeddb.NewPrefixedReader(s.db, ballotPrefix)
 	var chosenKey, chosenVal []byte
 	if err := pr.Iterate(nil, func(k, v []byte) bool {
@@ -199,6 +202,7 @@ func (s *Storage) MarkBallotDone(voteID []byte, vb *VerifiedBallot) error {
 	if err != nil {
 		return fmt.Errorf("encode verified ballot: %w", err)
 	}
+	defer util.HandleClosedDBPanic()
 	wTx := prefixeddb.NewPrefixedWriteTx(s.db.WriteTx(), verifiedBallotPrefix)
 	// key with processID as prefix + unique portion from original key
 	combKey := append(slices.Clone(vb.ProcessID), voteID...)
@@ -235,6 +239,7 @@ func (s *Storage) PullVerifiedBallots(processID []byte, maxCount int) ([]*Verifi
 		return []*VerifiedBallot{}, nil, nil
 	}
 
+	defer util.HandleClosedDBPanic()
 	rd := prefixeddb.NewPrefixedReader(s.db, verifiedBallotPrefix)
 	var res []*VerifiedBallot
 	var keys [][]byte
@@ -299,6 +304,7 @@ func (s *Storage) CountPendingBallots() int {
 	s.globalLock.Lock()
 	defer s.globalLock.Unlock()
 
+	defer util.HandleClosedDBPanic()
 	rd := prefixeddb.NewPrefixedReader(s.db, ballotPrefix)
 	count := 0
 	if err := rd.Iterate(nil, func(k, _ []byte) bool {
@@ -320,6 +326,7 @@ func (s *Storage) CountVerifiedBallots(processID []byte) int {
 	s.globalLock.Lock()
 	defer s.globalLock.Unlock()
 
+	defer util.HandleClosedDBPanic()
 	rd := prefixeddb.NewPrefixedReader(s.db, verifiedBallotPrefix)
 	count := 0
 	if err := rd.Iterate(processID, func(k, _ []byte) bool {
@@ -455,6 +462,7 @@ func (s *Storage) PushBallotBatch(abb *AggregatorBallotBatch) error {
 	if err != nil {
 		return fmt.Errorf("encode batch: %w", err)
 	}
+	defer util.HandleClosedDBPanic()
 	wTx := prefixeddb.NewPrefixedWriteTx(s.db.WriteTx(), aggregBatchPrefix)
 	key := hashKey(val)
 	if err := wTx.Set(append(slices.Clone(abb.ProcessID), key...), val); err != nil {
@@ -493,6 +501,7 @@ func (s *Storage) MarkBallotBatchFailed(key []byte) error {
 	s.globalLock.Lock()
 	defer s.globalLock.Unlock()
 
+	defer util.HandleClosedDBPanic()
 	pr := prefixeddb.NewPrefixedReader(s.db, aggregBatchPrefix)
 	val, err := pr.Get(key)
 	if err != nil {
@@ -571,6 +580,7 @@ func (s *Storage) NextBallotBatch(processID []byte) (*AggregatorBallotBatch, []b
 	s.globalLock.Lock()
 	defer s.globalLock.Unlock()
 
+	defer util.HandleClosedDBPanic()
 	pr := prefixeddb.NewPrefixedReader(s.db, aggregBatchPrefix)
 	var chosenKey, chosenVal []byte
 	if err := pr.Iterate(processID, func(k, v []byte) bool {
@@ -629,6 +639,7 @@ func (s *Storage) PushStateTransitionBatch(stb *StateTransitionBatch) error {
 	}
 
 	// initialize the write transaction over the state transition prefix
+	defer util.HandleClosedDBPanic()
 	wTx := prefixeddb.NewPrefixedWriteTx(s.db.WriteTx(), stateTransitionPrefix)
 
 	// create the key by hashing the value
@@ -665,6 +676,7 @@ func (s *Storage) NextStateTransitionBatch(processID []byte) (*StateTransitionBa
 	s.globalLock.Lock()
 	defer s.globalLock.Unlock()
 	// initialize the read transaction over the state transition prefix
+	defer util.HandleClosedDBPanic()
 	pr := prefixeddb.NewPrefixedReader(s.db, stateTransitionPrefix)
 	var chosenKey, chosenVal []byte
 	if err := pr.Iterate(processID, func(k, v []byte) bool {
@@ -706,6 +718,7 @@ func (s *Storage) MarkStateTransitionBatchDone(k []byte, pid []byte) error {
 	defer s.globalLock.Unlock()
 
 	// Get the state transition batch before deleting it to extract vote IDs
+	defer util.HandleClosedDBPanic()
 	pr := prefixeddb.NewPrefixedReader(s.db, stateTransitionPrefix)
 	val, err := pr.Get(k)
 	if err != nil {
@@ -788,6 +801,7 @@ func (s *Storage) PushVerifiedResults(res *VerifiedResults) error {
 	}
 
 	// initialize the write transaction over the results prefix
+	defer util.HandleClosedDBPanic()
 	wTx := prefixeddb.NewPrefixedWriteTx(s.db.WriteTx(), verifiedResultPrefix)
 	defer wTx.Discard()
 
@@ -815,6 +829,7 @@ func (s *Storage) NextVerifiedResults() (*VerifiedResults, error) {
 	s.globalLock.Lock()
 	defer s.globalLock.Unlock()
 
+	defer util.HandleClosedDBPanic()
 	pr := prefixeddb.NewPrefixedReader(s.db, verifiedResultPrefix)
 	var chosenVal []byte
 	if err := pr.Iterate(nil, func(k, v []byte) bool {
@@ -845,6 +860,7 @@ func (s *Storage) MarkVerifiedResultsDone(processID []byte) error {
 	defer s.globalLock.Unlock()
 
 	// initialize the read transaction over the results prefix
+	defer util.HandleClosedDBPanic()
 	tx := s.db.WriteTx()
 	pr := prefixeddb.NewPrefixedWriteTx(tx, verifiedResultPrefix)
 	// remove the value for the given processID
@@ -865,6 +881,7 @@ func (s *Storage) HasVerifiedResults(processID []byte) bool {
 	s.globalLock.Lock()
 	defer s.globalLock.Unlock()
 
+	defer util.HandleClosedDBPanic()
 	pr := prefixeddb.NewPrefixedReader(s.db, verifiedResultPrefix)
 	_, err := pr.Get(processID)
 	return err == nil

--- a/storage/cleanup.go
+++ b/storage/cleanup.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/vocdoni/davinci-node/log"
+	"github.com/vocdoni/davinci-node/util"
 	"go.vocdoni.io/dvote/db/prefixeddb"
 )
 
@@ -70,6 +71,7 @@ func (s *Storage) cleanupEndedProcess(processID []byte) error {
 // Since pending ballots are keyed by voteID only, we must iterate through all
 // pending ballots and check their ProcessID field.
 func (s *Storage) cleanPendingBallotsForProcess(processID []byte) error {
+	defer util.HandleClosedDBPanic()
 	pr := prefixeddb.NewPrefixedReader(s.db, ballotPrefix)
 	var keysToDelete [][]byte
 
@@ -112,6 +114,7 @@ func (s *Storage) cleanPendingBallotsForProcess(processID []byte) error {
 // cleanVerifiedBallotsForProcess removes all verified ballots for a given processID.
 // Verified ballots are efficiently accessible using processID prefix.
 func (s *Storage) cleanVerifiedBallotsForProcess(processID []byte) error {
+	defer util.HandleClosedDBPanic()
 	rd := prefixeddb.NewPrefixedReader(s.db, verifiedBallotPrefix)
 	var keysToDelete [][]byte
 
@@ -150,6 +153,7 @@ func (s *Storage) cleanVerifiedBallotsForProcess(processID []byte) error {
 
 // cleanAggregatorBatchesForProcess removes all aggregator batches for a given processID.
 func (s *Storage) cleanAggregatorBatchesForProcess(processID []byte) error {
+	defer util.HandleClosedDBPanic()
 	pr := prefixeddb.NewPrefixedReader(s.db, aggregBatchPrefix)
 	var keysToDelete [][]byte
 
@@ -187,6 +191,7 @@ func (s *Storage) cleanAggregatorBatchesForProcess(processID []byte) error {
 
 // cleanStateTransitionsForProcess removes all state transitions for a given processID.
 func (s *Storage) cleanStateTransitionsForProcess(processID []byte) error {
+	defer util.HandleClosedDBPanic()
 	pr := prefixeddb.NewPrefixedReader(s.db, stateTransitionPrefix)
 	var keysToDelete [][]byte
 
@@ -226,6 +231,7 @@ func (s *Storage) cleanStateTransitionsForProcess(processID []byte) error {
 // all reservation entries. This ensures that no item remains "reserved" after
 // a crash.
 func (s *Storage) cleanAllReservations(prefix []byte) error {
+	defer util.HandleClosedDBPanic()
 	wTx := prefixeddb.NewPrefixedDatabase(s.db, prefix).WriteTx()
 	defer wTx.Discard()
 	var keysToDelete [][]byte

--- a/storage/stale_reservations_test.go
+++ b/storage/stale_reservations_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	qt "github.com/frankban/quicktest"
+	"github.com/vocdoni/davinci-node/util"
 	"go.vocdoni.io/dvote/db"
 	"go.vocdoni.io/dvote/db/metadb"
 )
@@ -183,6 +184,7 @@ func TestRecoverClearsAllReservations(t *testing.T) {
 
 // Helper function to set test reservations directly
 func (s *Storage) setTestReservation(prefix, key, data []byte) error {
+	defer util.HandleClosedDBPanic()
 	wTx := s.db.WriteTx()
 	defer wTx.Discard()
 

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -66,6 +66,7 @@ import (
 
 	"github.com/vocdoni/davinci-node/log"
 	"github.com/vocdoni/davinci-node/storage/census"
+	"github.com/vocdoni/davinci-node/util"
 	"go.vocdoni.io/dvote/db"
 	"go.vocdoni.io/dvote/db/prefixeddb"
 )
@@ -202,15 +203,7 @@ func (s *Storage) setAllProcessesAsNotAcceptingVotes() error {
 func (s *Storage) Close() {
 	s.cancel() // Cancel the context to stop any ongoing operations
 	// recover panic to check if the database is already closed
-	defer func() {
-		if r := recover(); r != nil {
-			if strings.Contains(fmt.Sprintf("%v", r), "closed") {
-				log.Warn("storage database already closed")
-				return
-			}
-			log.Errorf("storage close panic: %v", r)
-		}
-	}()
+	defer util.HandleClosedDBPanic()
 	if err := s.db.Close(); err != nil {
 		fmt.Printf("failed to close storage: %v", err)
 	}
@@ -247,6 +240,7 @@ func (s *Storage) releaseStaleReservations(maxAge time.Duration) error {
 }
 
 func (s *Storage) releaseStaleInPrefix(prefix []byte, now int64, maxAge time.Duration) error {
+	defer util.HandleClosedDBPanic()
 	wTx := prefixeddb.NewPrefixedDatabase(s.db, prefix).WriteTx()
 	defer wTx.Discard()
 	var staleKeys [][]byte
@@ -291,6 +285,7 @@ func (s *Storage) setReservation(prefix, key []byte) error {
 	if err != nil {
 		return err
 	}
+	defer util.HandleClosedDBPanic()
 	wTx := prefixeddb.NewPrefixedDatabase(s.db, prefix).WriteTx()
 	defer wTx.Discard()
 	if _, err := wTx.Get(key); err == nil {
@@ -303,12 +298,14 @@ func (s *Storage) setReservation(prefix, key []byte) error {
 }
 
 func (s *Storage) isReserved(prefix, key []byte) bool {
+	defer util.HandleClosedDBPanic()
 	_, err := prefixeddb.NewPrefixedReader(s.db, prefix).Get(key)
 	return err == nil
 }
 
 func (s *Storage) deleteArtifact(prefix, key []byte) error {
 	// instance a write transaction with the prefix provided
+	defer util.HandleClosedDBPanic()
 	wTx := prefixeddb.NewPrefixedDatabase(s.db, prefix).WriteTx()
 	defer wTx.Discard()
 	if err := wTx.Delete(key); err != nil {
@@ -334,6 +331,7 @@ func (s *Storage) setArtifact(prefix []byte, key []byte, artifact any) error {
 	}
 
 	// instance a write transaction with the prefix provided
+	defer util.HandleClosedDBPanic()
 	wTx := prefixeddb.NewPrefixedDatabase(s.db, prefix).WriteTx()
 	defer wTx.Discard()
 
@@ -352,6 +350,7 @@ func (s *Storage) setArtifact(prefix []byte, key []byte, artifact any) error {
 func (s *Storage) getArtifact(prefix []byte, key []byte, out any) error {
 	var data []byte
 	var err error
+	defer util.HandleClosedDBPanic()
 	db := prefixeddb.NewPrefixedDatabase(s.db, prefix)
 	if key != nil {
 		data, err = db.Get(key)
@@ -379,6 +378,7 @@ func (s *Storage) getArtifact(prefix []byte, key []byte, out any) error {
 
 // listArtifacts retrieves all the keys for a given prefix.
 func (s *Storage) listArtifacts(prefix []byte) ([][]byte, error) {
+	defer util.HandleClosedDBPanic()
 	var keys [][]byte
 	if err := prefixeddb.NewPrefixedReader(s.db, prefix).Iterate(nil, func(k, _ []byte) bool {
 		kcopy := make([]byte, len(k))
@@ -429,6 +429,7 @@ func (s *Storage) monitorStaleReservations() {
 // This method should be called after locking the global lock to ensure
 // thread safety.
 func (s *Storage) recoverNullifiers() error {
+	defer util.HandleClosedDBPanic()
 	// Recover nullifiers from verified ballots
 	var outerErr error
 	verifiedBallotsReader := prefixeddb.NewPrefixedReader(s.db, verifiedBallotPrefix)

--- a/storage/vote_id_status.go
+++ b/storage/vote_id_status.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/vocdoni/davinci-node/log"
+	"github.com/vocdoni/davinci-node/util"
 	"go.vocdoni.io/dvote/db/prefixeddb"
 )
 
@@ -47,6 +48,7 @@ func (s *Storage) voteIDStatusUnsafe(processID, voteID []byte) (int, error) {
 	key := createVoteIDStatusKey(processID, voteID)
 
 	// Get the status value
+	defer util.HandleClosedDBPanic()
 	reader := prefixeddb.NewPrefixedReader(s.db, voteIDStatusPrefix)
 	statusBytes, err := reader.Get(key)
 	if err != nil || statusBytes == nil {
@@ -82,6 +84,7 @@ func (s *Storage) MarkVoteIDsSettled(processID []byte, voteIDs [][]byte) error {
 // This method assumes the caller already holds the globalLock.
 func (s *Storage) markVoteIDsSettled(processID []byte, voteIDs [][]byte) error {
 	// Use a transaction for better atomicity
+	defer util.HandleClosedDBPanic()
 	wTx := prefixeddb.NewPrefixedWriteTx(s.db.WriteTx(), voteIDStatusPrefix)
 	defer wTx.Discard()
 
@@ -109,6 +112,7 @@ func (s *Storage) MarkProcessVoteIDsTimeout(processID []byte) (int, error) {
 // markProcessVoteIDsTimeoutUnsafe marks all unsettled vote IDs for a process as timeout
 // without acquiring locks. This method assumes the caller already holds the globalLock.
 func (s *Storage) markProcessVoteIDsTimeout(processID []byte) (int, error) {
+	defer util.HandleClosedDBPanic()
 	prefixedDB := prefixeddb.NewPrefixedDatabase(s.db, voteIDStatusPrefix)
 	wTx := prefixedDB.WriteTx()
 	defer wTx.Discard()
@@ -153,6 +157,7 @@ func (s *Storage) markProcessVoteIDsTimeout(processID []byte) (int, error) {
 
 // setVoteIDStatus is an internal helper to set the status of a vote ID.
 func (s *Storage) setVoteIDStatus(processID, voteID []byte, status int) error {
+	defer util.HandleClosedDBPanic()
 	wTx := prefixeddb.NewPrefixedWriteTx(s.db.WriteTx(), voteIDStatusPrefix)
 	defer wTx.Discard()
 

--- a/storage/worker_stats.go
+++ b/storage/worker_stats.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"fmt"
 
+	"github.com/vocdoni/davinci-node/util"
 	"go.vocdoni.io/dvote/db/prefixeddb"
 )
 
@@ -53,6 +54,7 @@ func (s *Storage) ListWorkerJobCount() (map[string][2]int64, error) {
 
 	result := make(map[string][2]int64)
 
+	defer util.HandleClosedDBPanic()
 	pr := prefixeddb.NewPrefixedReader(s.db, workerStatsPrefix)
 	err := pr.Iterate(nil, func(k, v []byte) bool {
 		var stats WorkerStats

--- a/tests/helpers_test.go
+++ b/tests/helpers_test.go
@@ -66,13 +66,12 @@ func setupAPI(
 	db *storage.Storage,
 	workerSeed string,
 	workerTimeout time.Duration,
+	banRules *api.BanRules,
 ) (*service.APIService, error) {
 	tmpPort := util.RandomInt(40000, 60000)
 
 	api := service.NewAPI(db, "127.0.0.1", tmpPort, "test", false)
-
-	api.SetWorkerConfig(workerSeed, workerTimeout)
-
+	api.SetWorkerConfig(workerSeed, workerTimeout, banRules)
 	if err := api.Start(ctx); err != nil {
 		return nil, err
 	}
@@ -242,14 +241,13 @@ func NewTestClient(port int) (*client.HTTPclient, error) {
 	return client.New(fmt.Sprintf("http://127.0.0.1:%d", port))
 }
 
-func NewTestService(t *testing.T, ctx context.Context, workerSecret string, workerTimeout time.Duration) *Services {
+func NewTestService(t *testing.T, ctx context.Context, workerSecret string, workerTimeout time.Duration, banRules *api.BanRules) *Services {
 	// Initialize the web3 contracts
 	contracts := setupWeb3(t, ctx)
 
 	kv, err := metadb.New(db.TypePebble, t.TempDir())
 	qt.Assert(t, err, qt.IsNil)
 	stg := storage.New(kv)
-	t.Cleanup(stg.Close)
 
 	services := &Services{
 		Storage:   stg,
@@ -263,7 +261,6 @@ func NewTestService(t *testing.T, ctx context.Context, workerSecret string, work
 	if err := vp.Start(ctx); err != nil {
 		log.Fatal(err)
 	}
-	t.Cleanup(vp.Stop)
 	services.Sequencer = vp.Sequencer
 
 	// Start process monitor
@@ -271,14 +268,18 @@ func NewTestService(t *testing.T, ctx context.Context, workerSecret string, work
 	if err := pm.Start(ctx); err != nil {
 		log.Fatal(err)
 	}
-	t.Cleanup(pm.Stop)
 
 	// Start API service
-	api, err := setupAPI(ctx, stg, workerSecret, workerTimeout)
+	api, err := setupAPI(ctx, stg, workerSecret, workerTimeout, banRules)
 	qt.Assert(t, err, qt.IsNil)
-	t.Cleanup(api.Stop)
 	services.API = api
 
+	t.Cleanup(func() {
+		api.Stop()
+		pm.Stop()
+		vp.Stop()
+		stg.Close()
+	})
 	return services
 }
 
@@ -346,10 +347,10 @@ func createOrganization(c *qt.C, contracts *web3.Contracts) common.Address {
 		Name:        fmt.Sprintf("Vocdoni test %x", orgAddr[:4]),
 		MetadataURI: "https://vocdoni.io",
 	})
-	c.Assert(err, qt.IsNil)
+	c.Assert(err, qt.IsNil, qt.Commentf("Failed to create organization: %v", err))
 
 	err = contracts.WaitTx(txHash, time.Second*30)
-	c.Assert(err, qt.IsNil)
+	c.Assert(err, qt.IsNil, qt.Commentf("Failed to wait for organization creation transaction: %v", err))
 	return orgAddr
 }
 
@@ -387,6 +388,7 @@ func createProcess(c *qt.C, contracts *web3.Contracts, cli *client.HTTPclient, c
 
 	pid, txHash, err := contracts.CreateProcess(&types.Process{
 		Status:         0,
+		ID:             processID.Marshal(),
 		OrganizationId: contracts.AccountAddress(),
 		EncryptionKey:  encryptionKeys,
 		StateRoot:      resp.StateRoot.BigInt(),

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -31,9 +31,12 @@ func TestIntegration(t *testing.T) {
 	numBallots := 5
 	c := qt.New(t)
 
+	testWorkerSeed := "test-seed"
+	testWorkerTimeout := time.Second * 5
+
 	// Setup
 	ctx := t.Context()
-	services := NewTestService(t, ctx)
+	services := NewTestService(t, ctx, testWorkerSeed, testWorkerTimeout)
 	_, port := services.API.HostPort()
 	cli, err := NewTestClient(port)
 	c.Assert(err, qt.IsNil)

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -36,7 +36,7 @@ func TestIntegration(t *testing.T) {
 
 	// Setup
 	ctx := t.Context()
-	services := NewTestService(t, ctx, testWorkerSeed, testWorkerTimeout)
+	services := NewTestService(t, ctx, testWorkerSeed, testWorkerTimeout, api.DefaultBanRules)
 	_, port := services.API.HostPort()
 	cli, err := NewTestClient(port)
 	c.Assert(err, qt.IsNil)

--- a/tests/workers_test.go
+++ b/tests/workers_test.go
@@ -1,0 +1,164 @@
+package tests
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/vocdoni/davinci-node/api"
+	"github.com/vocdoni/davinci-node/circuits"
+	"github.com/vocdoni/davinci-node/crypto/signatures/ethereum"
+	"github.com/vocdoni/davinci-node/types"
+)
+
+func TestWorkerIntegration(t *testing.T) {
+	c := qt.New(t)
+	workerTimeout := time.Second * 5
+	testSeed := "test-seed"
+	// Setup
+	ctx := t.Context()
+	services := NewTestService(t, ctx, testSeed, workerTimeout)
+	_, port := services.API.HostPort()
+	mainAPIUUID, err := api.WorkerSeedToUUID(testSeed)
+	c.Assert(err, qt.IsNil)
+
+	cli, err := NewTestClient(port)
+	c.Assert(err, qt.IsNil)
+	// Start sequencer batch time window
+	services.Sequencer.SetBatchTimeWindow(time.Second * 120)
+	var (
+		pid           *types.ProcessID
+		encryptionKey *types.EncryptionKey
+		ballotMode    *types.BallotMode
+		signers       []*ethereum.Signer
+		proof         *types.CensusProof
+		root          []byte
+	)
+
+	c.Run("create organization", func(c *qt.C) {
+		orgAddr := createOrganization(c, services.Contracts)
+		t.Logf("Organization address: %s", orgAddr.String())
+	})
+
+	c.Run("launch a ghost worker", func(c *qt.C) {
+		getJobEndpoint := api.EndpointWithParam(api.WorkerGetJobEndpoint, api.WorkerUUIDParam, mainAPIUUID.String())
+		getJobEndpoint = api.EndpointWithParam(getJobEndpoint, api.WorkerAddressParam, services.Contracts.AccountAddress().String())
+		body, status, err := cli.Request(http.MethodGet, nil, nil, getJobEndpoint)
+		c.Assert(err, qt.IsNil, qt.Commentf("Failed to get job: %v", err))
+		c.Assert(status, qt.Equals, http.StatusNoContent, qt.Commentf("Expected 204 No Content, got %d: %s", status, string(body)))
+		c.Log("Ghost worker job request successful, no job available yet")
+	})
+
+	c.Run("launch a ghost worker", func(c *qt.C) {
+		ticker := time.NewTicker(500 * time.Millisecond)
+		defer ticker.Stop()
+		ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+		defer cancel()
+		// make a request to the api to get a job until get banned
+		for {
+			select {
+			case <-ctx.Done():
+				c.Fatal("Timeout waiting for ghost worker job request")
+				c.FailNow()
+			case <-ticker.C:
+				getJobEndpoint := api.EndpointWithParam(api.WorkerGetJobEndpoint, api.WorkerUUIDParam, mainAPIUUID.String())
+				getJobEndpoint = api.EndpointWithParam(getJobEndpoint, api.WorkerAddressParam, services.Contracts.AccountAddress().String())
+				body, status, err := cli.Request(http.MethodGet, nil, nil, getJobEndpoint)
+				c.Assert(err, qt.IsNil, qt.Commentf("Failed to get job: %v", err))
+				c.Assert(status, qt.Equals, http.StatusNoContent, qt.Commentf("Expected 204 No Content, got %d: %s", status, string(body)))
+				c.Log("Ghost worker job request successful, no job available yet")
+			}
+		}
+	})
+
+	c.Run("create process", func(c *qt.C) {
+		// Create census with numBallot participants
+		var participants []*api.CensusParticipant
+		root, participants, signers = createCensus(c, cli, 1)
+		c.Assert(participants, qt.Not(qt.IsNil))
+		c.Assert(signers, qt.Not(qt.IsNil))
+		c.Assert(len(participants), qt.Equals, 1)
+
+		// Generate proof for first participant
+		proof = generateCensusProof(c, cli, root, participants[0].Key)
+		c.Assert(proof, qt.Not(qt.IsNil))
+		c.Assert(proof.Siblings, qt.IsNotNil)
+		// Check the first proof key is the same as the participant key and signer address
+		qt.Assert(t, proof.Key.String(), qt.DeepEquals, participants[0].Key.String())
+		qt.Assert(t, string(proof.Key), qt.DeepEquals, string(signers[0].Address().Bytes()))
+
+		ballotMode = &types.BallotMode{
+			MaxCount:        circuits.MockMaxCount,
+			ForceUniqueness: circuits.MockForceUniqueness == 1,
+			MaxValue:        new(types.BigInt).SetUint64(circuits.MockMaxValue),
+			MinValue:        new(types.BigInt).SetUint64(circuits.MockMinValue),
+			MaxTotalCost:    new(types.BigInt).SetUint64(circuits.MockMaxTotalCost),
+			MinTotalCost:    new(types.BigInt).SetUint64(circuits.MockMinTotalCost),
+			CostFromWeight:  circuits.MockCostFromWeight == 1,
+			CostExponent:    circuits.MockCostExp,
+		}
+
+		pid, encryptionKey = createProcess(c, services.Contracts, cli, root, *ballotMode)
+		// create a timeout for the process creation, if it is greater than the test timeout
+		// use the test timeout
+		createProcessTimeout := time.Minute * 2
+		if timeout, hasDeadline := t.Deadline(); hasDeadline {
+			remainingTime := time.Until(timeout)
+			if remainingTime < createProcessTimeout {
+				createProcessTimeout = remainingTime
+			}
+		}
+		// Wait for the process to be registered
+		createProcessCtx, cancel := context.WithTimeout(ctx, createProcessTimeout)
+		defer cancel()
+
+	CreateProcessLoop:
+		for {
+			select {
+			case <-createProcessCtx.Done():
+				c.Fatal("Timeout waiting for process to be created and registered")
+				c.FailNow()
+			default:
+				if _, err := services.Storage.Process(pid); err == nil {
+					break CreateProcessLoop
+				}
+				time.Sleep(time.Millisecond * 200)
+			}
+		}
+		t.Logf("Process ID: %s", pid.String())
+
+		// Wait for the process to be registered in the sequencer
+		for {
+			select {
+			case <-createProcessCtx.Done():
+				c.Fatal("Timeout waiting for process to be registered in sequencer")
+				c.FailNow()
+			default:
+				if services.Sequencer.ExistsProcessID(pid.Marshal()) {
+					t.Logf("Process ID %s registered in sequencer", pid.String())
+					return
+				}
+				time.Sleep(time.Millisecond * 200)
+			}
+		}
+	})
+
+	c.Run("send a vote", func(c *qt.C) {
+		for _, signer := range signers {
+			// generate a vote for the first participant
+			vote, _ := createVote(c, pid, ballotMode, encryptionKey, signer, nil)
+			// generate census proof for first participant
+			censusProof := generateCensusProof(c, cli, root, signer.Address().Bytes())
+			c.Assert(censusProof, qt.Not(qt.IsNil))
+			c.Assert(censusProof.Siblings, qt.IsNotNil)
+			vote.CensusProof = *censusProof
+			// Make the request to cast the vote
+			_, status, err := cli.Request("POST", vote, nil, api.VotesEndpoint)
+			c.Assert(err, qt.IsNil)
+			c.Assert(status, qt.Equals, 200)
+		}
+	})
+	time.Sleep(5 * time.Minute)
+}

--- a/util/db.go
+++ b/util/db.go
@@ -1,0 +1,41 @@
+package util
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+
+	"github.com/vocdoni/davinci-node/log"
+)
+
+// HandleClosedDBPanic wraps the commit operation to handle panic scenarios
+// about already closed database. It should be deferred in any storage
+// operation that might read, write or commit to the database that can be
+// closed during the operation.
+func HandleClosedDBPanic() {
+	if r := recover(); r != nil {
+		// Collect stack trace
+		stack := []string{}
+		for i := range 32 {
+			pc, file, line, ok := runtime.Caller(i)
+			if !ok {
+				break
+			}
+			fn := runtime.FuncForPC(pc)
+			funcName := ""
+			if fn != nil {
+				funcName = fn.Name()
+			}
+			stack = append(stack, fmt.Sprintf("%s\n\t%s:%d", funcName, file, line))
+		}
+
+		// Check if the panic is due to a closed database
+		if strings.Contains(fmt.Sprintf("%v", r), "closed") {
+			// Log the warning with the stack trace
+			log.Warnw("database already closed", "error", r, "stack", stack)
+			return
+		}
+		// If it's not a closed database panic, re-panic with the stack trace
+		panic(fmt.Sprintf("panic during storage operation: %v: %s", r, strings.Join(stack, "\n")))
+	}
+}


### PR DESCRIPTION
This PR introduces a comprehensive worker management system to prevent "fallen workers" - unreliable workers that fail to complete jobs or become unresponsive. 

### 1. Worker Management System
**Purpose**: Tracks worker health and availability, preventing unreliable workers from receiving new jobs.

**Key Components**:
- **Worker State Tracking**: Each worker maintains consecutive failure count and ban status using atomic operations for thread safety.
- **Automatic Ban Management**: Workers are automatically banned when they exceed failure thresholds or during time-based bans.
- **Worker Lifecycle**: Automatic worker registration, status updates, and cleanup.

**Configurable Parameters**:
- `BanTimeout` (default: 3 minutes; prod: 5 minutes) - Duration a worker remains banned after exceeding failure threshold.
- `FailuresToGetBanned` (default: 5) - Number of consecutive job failures before automatic ban.
- `tickerInterval` (default: 10 seconds) - How frequently the system checks for ban status updates.

### 2. Job Management System
**Purpose**: Handles job assignment, tracking, and timeout management to ensure reliable job processing.

**Key Components**:
- **Job Registration**: Assigns jobs to available workers with expiration times.
- **Timeout Handling**: Automatically fails jobs that exceed their timeout duration.
- **Job Completion Tracking**: Records success/failure and updates worker statistics.
- **Failed Job Channel**: Unbuffered channel for handling failed jobs.

**Configurable Parameters**:
- `jobTimeout` - Maximum time a job can run before being considered failed.
- `tickerInterval` (default: 10 seconds) - Frequency of timeout checks.

### 3. Worker Banning Logic
**Purpose**: Implements a sophisticated banning system to handle unreliable workers.

**Banning Triggers**:
- **Consecutive Failures**: Worker banned after N consecutive job failures.
- **Job Timeouts**: Jobs that exceed their timeout count as failures.
- **Time-based Bans**: Workers remain banned for a configurable duration.

**Recovery Mechanism**:
- Workers are automatically unbanned after the ban timeout expires.
- Worker statistics are reset upon unbanning, giving them a fresh start.

### 4. Integration Tests
**Purpose**: Comprehensive testing of the worker management lifecycle.

**Test Coverage**:
- Worker job assignment and completion
- Automatic banning after consecutive failures
- Automatic unbanning after timeout period
- Integration with the full API stack

### *Extra:* Database Safety Utilities
**Purpose**: Prevents application crashes due to database closure race conditions.

**Implementation**:
- `HandleClosedDBPanic()` - Recovers from panics caused by operations on closed databases
- Provides detailed stack traces for non-database panics
- Graceful degradation when database is unavailable