### PR TITLE
service: MonitorProcessFinalization -> MonitorProcessStatusChanges

### DIFF
--- a/service/mock_web3.go
+++ b/service/mock_web3.go
@@ -9,6 +9,8 @@ import (
 	"github.com/vocdoni/davinci-node/types"
 )
 
+var _ ContractsService = &MockContracts{}
+
 // MockContracts implements a mock version of web3.Contracts for testing
 type MockContracts struct {
 	processes []*types.Process
@@ -46,8 +48,8 @@ func (m *MockContracts) MonitorProcessCreation(ctx context.Context, interval tim
 	return ch, nil
 }
 
-func (m *MockContracts) MonitorProcessFinalization(ctx context.Context, interval time.Duration) (<-chan *types.Process, error) {
-	return make(chan *types.Process), nil
+func (m *MockContracts) MonitorProcessStatusChanges(ctx context.Context, interval time.Duration) (<-chan *types.ProcessWithStatusChange, error) {
+	return make(chan *types.ProcessWithStatusChange), nil
 }
 
 func (m *MockContracts) CreateProcess(process *types.Process) (*types.ProcessID, *common.Hash, error) {

--- a/types/process.go
+++ b/types/process.go
@@ -128,6 +128,13 @@ type Process struct {
 	SequencerStats       SequencerProcessStats `json:"sequencerStats"           cbor:"16,keyasint"`
 }
 
+// ProcessWithStatusChange extends types.Process to add OldStatus and NewStatus fields
+type ProcessWithStatusChange struct {
+	*Process
+	OldStatus ProcessStatus
+	NewStatus ProcessStatus
+}
+
 type SequencerProcessStats struct {
 	StateTransitionCount        int       `json:"stateTransitionCount" cbor:"0,keyasint,omitempty"`
 	LastStateTransitionDate     time.Time `json:"lastStateTransitionDate" cbor:"1,keyasint,omitempty"`


### PR DESCRIPTION

service: MonitorProcessFinalization -> MonitorProcessStatusChanges

until now, any status change was assumed to be of finalization but this is wrong,
so now this monitor now passes OldStatus and NewStatus to receivers, and lets them
decide how to best handle each change.

includes:
* types: new type ProcessWithStatusChange


- **web3: contracts.Process now fills in process.ID before returning**