### PR TITLE
fix: Internal marshal nested structs

### DIFF
--- a/storage/encode.go
+++ b/storage/encode.go
@@ -1,0 +1,80 @@
+package storage
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/fxamacker/cbor/v2"
+)
+
+// ArtifactEncoding defines the encoding formats for artifacts. There are two
+// supported formats: ArtifactEncodingCBOR and ArtifactEncodingJSON.
+type ArtifactEncoding int
+
+const (
+	// ArtifactEncodingCBOR is the CBOR encoding format.
+	ArtifactEncodingCBOR ArtifactEncoding = iota
+	// ArtifactEncodingJSON is the JSON encoding format.
+	ArtifactEncodingJSON
+)
+
+// EncodeArtifact encodes an artifact into the specified encoding format. If no
+// format is specified, CBOR is used by default. If a format is specified, it
+// will be used instead, only if it is supported.
+func EncodeArtifact(a any, encoding ...ArtifactEncoding) ([]byte, error) {
+	if len(encoding) > 0 {
+		switch encoding[0] {
+		case ArtifactEncodingCBOR:
+			return EncodeArtifactCBOR(a)
+		case ArtifactEncodingJSON:
+			return EncodeArtifactJSON(a)
+		default:
+			return nil, fmt.Errorf("unknown artifact encoding: %d", encoding)
+		}
+	}
+	return EncodeArtifactCBOR(a)
+}
+
+// DecodeArtifact decodes an artifact from the specified format. If no format
+// is specified, CBOR is used by default. If a format is specified, it will
+// be used instead, only if it is supported.
+func DecodeArtifact(data []byte, out any, encoding ...ArtifactEncoding) error {
+	if len(encoding) > 0 {
+		switch encoding[0] {
+		case ArtifactEncodingCBOR:
+			return DecodeArtifactCBOR(data, out)
+		case ArtifactEncodingJSON:
+			return DecodeArtifactJSON(data, out)
+		default:
+			return fmt.Errorf("unknown artifact encoding: %d", encoding)
+		}
+	}
+	return DecodeArtifactCBOR(data, out)
+}
+
+// EncodeArtifactCBOR encodes an artifact into CBOR format.
+func EncodeArtifactCBOR(a any) ([]byte, error) {
+	encOpts := cbor.CoreDetEncOptions()
+	em, err := encOpts.EncMode()
+	if err != nil {
+		return nil, fmt.Errorf("encode artifact: %w", err)
+	}
+	return em.Marshal(a)
+}
+
+// DecodeArtifactCBOR decodes a CBOR-encoded artifact into the provided output
+// variable.
+func DecodeArtifactCBOR(data []byte, out any) error {
+	return cbor.Unmarshal(data, out)
+}
+
+// EncodeArtifactJSON encodes an artifact into JSON format.
+func EncodeArtifactJSON(a any) ([]byte, error) {
+	return json.Marshal(a)
+}
+
+// DecodeArtifactJSON decodes a JSON-encoded artifact into the provided output
+// variable.
+func DecodeArtifactJSON(data []byte, out any) error {
+	return json.Unmarshal(data, out)
+}

--- a/storage/encode_test.go
+++ b/storage/encode_test.go
@@ -1,0 +1,74 @@
+package storage
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+type testEncodeData struct {
+	DataStr   string
+	DataInt   int
+	DataFloat float64
+	DataBool  bool
+	DataMap   map[string]string
+}
+
+func (a *testEncodeData) Equal(b testEncodeData) bool {
+	equalMap := false
+	for k, v := range a.DataMap {
+		if b.DataMap[k] != v {
+			equalMap = false
+			break
+		}
+		equalMap = true
+	}
+
+	return a.DataStr == b.DataStr &&
+		a.DataInt == b.DataInt &&
+		a.DataFloat == b.DataFloat &&
+		a.DataBool == b.DataBool &&
+		equalMap
+}
+
+func TestEncodeDecodeArtifact(t *testing.T) {
+	c := qt.New(t)
+	artifact := testEncodeData{
+		DataStr:   "test",
+		DataInt:   42,
+		DataFloat: 3.14,
+		DataBool:  true,
+		DataMap:   map[string]string{"key": "value"},
+	}
+
+	c.Run("default encoding", func(c *qt.C) {
+		encoded, err := EncodeArtifact(artifact)
+		c.Assert(err, qt.IsNil)
+		var decoded testEncodeData
+		c.Assert(DecodeArtifact(encoded, &decoded), qt.IsNil)
+		c.Assert(decoded.Equal(artifact), qt.IsTrue)
+	})
+
+	c.Run("cbor encoding", func(c *qt.C) {
+		encoded, err := EncodeArtifact(artifact, ArtifactEncodingCBOR)
+		c.Assert(err, qt.IsNil)
+		var decoded testEncodeData
+		c.Assert(DecodeArtifact(encoded, &decoded, ArtifactEncodingCBOR), qt.IsNil)
+		c.Assert(decoded.Equal(artifact), qt.IsTrue)
+	})
+
+	c.Run("json encoding", func(c *qt.C) {
+		encoded, err := EncodeArtifact(artifact, ArtifactEncodingJSON)
+		c.Assert(err, qt.IsNil)
+		var decoded testEncodeData
+		c.Assert(DecodeArtifact(encoded, &decoded, ArtifactEncodingJSON), qt.IsNil)
+		c.Assert(decoded.Equal(artifact), qt.IsTrue)
+	})
+
+	c.Run("invalid encoding", func(c *qt.C) {
+		encoded, err := EncodeArtifact(artifact, ArtifactEncoding(100))
+		c.Assert(err, qt.IsNotNil)
+		var decoded testEncodeData
+		c.Assert(DecodeArtifact(encoded, &decoded, ArtifactEncoding(100)), qt.IsNotNil)
+	})
+}

--- a/storage/helpers.go
+++ b/storage/helpers.go
@@ -1,26 +1,6 @@
 package storage
 
-import (
-	"crypto/sha256"
-	"fmt"
-
-	"github.com/fxamacker/cbor/v2"
-)
-
-// EncodeArtifact encodes an artifact into CBOR format.
-func EncodeArtifact(a any) ([]byte, error) {
-	encOpts := cbor.CoreDetEncOptions()
-	em, err := encOpts.EncMode()
-	if err != nil {
-		return nil, fmt.Errorf("encode artifact: %w", err)
-	}
-	return em.Marshal(a)
-}
-
-// DecodeArtifact decodes a CBOR-encoded artifact into the provided output variable.
-func DecodeArtifact(data []byte, out any) error {
-	return cbor.Unmarshal(data, out)
-}
+import "crypto/sha256"
 
 func hashKey(data []byte) []byte {
 	hash := sha256.Sum256(data)

--- a/storage/process.go
+++ b/storage/process.go
@@ -139,7 +139,7 @@ func (s *Storage) SetMetadata(metadata *types.Metadata) ([]byte, error) {
 	hash := MetadataHash(metadata)
 
 	// Store the metadata with its hash as the key
-	return hash, s.setArtifact(metadataPrefix, hash, metadata)
+	return hash, s.setArtifact(metadataPrefix, hash, metadata, ArtifactEncodingJSON)
 }
 
 // GetMetadata retrieves the metadata from the storage using its hash.
@@ -161,7 +161,7 @@ func (s *Storage) Metadata(hash []byte) (*types.Metadata, error) {
 
 	// Retrieve the metadata from the storage
 	metadata := &types.Metadata{}
-	if err := s.getArtifact(metadataPrefix, hash, metadata); err != nil {
+	if err := s.getArtifact(metadataPrefix, hash, metadata, ArtifactEncodingJSON); err != nil {
 		return nil, err
 	}
 

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -300,9 +300,11 @@ func (s *Storage) deleteArtifact(prefix, key []byte) error {
 // setArtifact helper function stores any kind of artifact in the storage. It
 // receives the prefix of the key, the key itself and the artifact to store. If
 // the key is not provided, it generates it by hashing the artifact itself.
-func (s *Storage) setArtifact(prefix []byte, key []byte, artifact any) error {
+// It also can receive the an ArtifactEncoding format to be used for encoding,
+// by default ArtifactEncodingCBOR.
+func (s *Storage) setArtifact(prefix []byte, key []byte, artifact any, encoding ...ArtifactEncoding) error {
 	// encode the artifact
-	data, err := EncodeArtifact(artifact)
+	data, err := EncodeArtifact(artifact, encoding...)
 	if err != nil {
 		return err
 	}
@@ -325,10 +327,12 @@ func (s *Storage) setArtifact(prefix []byte, key []byte, artifact any) error {
 }
 
 // getArtifact helper function retrieves any kind of artifact from the storage.
-// It receives the prefix of the key and a pointer to the artifact to decode into.
-// If the key is not provided, it retrieves the first artifact found for the
-// prefix, and returns ErrNoMoreElements if there are no more elements.
-func (s *Storage) getArtifact(prefix []byte, key []byte, out any) error {
+// It receives the prefix of the key and a pointer to the artifact to decode
+// into. If the key is not provided, it retrieves the first artifact found for
+// the prefix, and returns ErrNoMoreElements if there are no more elements.
+// It also can receive the an ArtifactEncoding format to be used for decoding,
+// by default ArtifactEncodingCBOR.
+func (s *Storage) getArtifact(prefix []byte, key []byte, out any, encoding ...ArtifactEncoding) error {
 	var data []byte
 	var err error
 	db := prefixeddb.NewPrefixedDatabase(s.db, prefix)
@@ -349,7 +353,7 @@ func (s *Storage) getArtifact(prefix []byte, key []byte, out any) error {
 		}
 	}
 
-	if err := DecodeArtifact(data, out); err != nil {
+	if err := DecodeArtifact(data, out, encoding...); err != nil {
 		return fmt.Errorf("could not decode artifact: %w", err)
 	}
 


### PR DESCRIPTION
Some data accepted and returned from the API contains the `GenericMetadata` types. The `GenericMetadata` type supports to include nested `GenericMetadata` and it should be encoded and decoded to JSON (this already works). The problem is that these information are stored in the `storage`, but encoded as CBOR, and CBOR encoding and decoding fail.

This PR updates the `EncodeArtifact` and `DecodeArtifact` `storage` helpers to support a new optional input to define the encoding format, between `json` or `cbor` (by default).

This fixes the problem with the `Metadata` struct (closing #182)