### PR TITLE
feature: new process ID

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/cors"
 	"github.com/google/uuid"
+	"github.com/vocdoni/davinci-node/config"
 	"github.com/vocdoni/davinci-node/crypto/signatures/ethereum"
 	"github.com/vocdoni/davinci-node/log"
 	stg "github.com/vocdoni/davinci-node/storage"
@@ -26,10 +27,11 @@ const (
 // APIConfig type represents the configuration for the API HTTP server.
 // It includes the host, port and optionally an existing storage instance.
 type APIConfig struct {
-	Host    string
-	Port    int
-	Storage *stg.Storage // Optional: use existing storage instance
-	Network string       // Optional: web3 network shortname
+	Host       string
+	Port       int
+	Storage    *stg.Storage // Optional: use existing storage instance
+	Network    string       // Optional: web3 network shortname
+	Web3Config config.DavinciWeb3Config
 	// Worker configuration
 	SequencerWorkersSeed       string                  // Seed for workers authentication over current sequencer
 	WorkersAuthtokenExpiration time.Duration           // Expiration time for worker authentication tokens
@@ -39,9 +41,10 @@ type APIConfig struct {
 
 // API type represents the API HTTP server with JWT authentication capabilities.
 type API struct {
-	router  *chi.Mux
-	storage *stg.Storage
-	network string
+	router     *chi.Mux
+	storage    *stg.Storage
+	network    string
+	web3Config config.DavinciWeb3Config
 	// Workers API stuff
 	sequencerSigner            *ethereum.Signer        // Signer for workers authentication
 	sequencerUUID              *uuid.UUID              // UUID to keep the workers endpoints hidden
@@ -66,6 +69,7 @@ func New(ctx context.Context, conf *APIConfig) (*API, error) {
 	a := &API{
 		storage:                    conf.Storage,
 		network:                    conf.Network,
+		web3Config:                 conf.Web3Config,
 		workersJobTimeout:          conf.WorkerJobTimeout,
 		workersAuthtokenExpiration: conf.WorkersAuthtokenExpiration,
 		parentCtx:                  ctx,

--- a/api/errors_definition.go
+++ b/api/errors_definition.go
@@ -43,7 +43,7 @@ var (
 	ErrBallotAlreadySubmitted   = Error{Code: 40018, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("ballot already submitted")}
 	ErrBallotAlreadyProcessing  = Error{Code: 40019, HTTPstatus: http.StatusConflict, Err: fmt.Errorf("ballot is already processing")}
 	ErrProcessNotAcceptingVotes = Error{Code: 40020, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("process is not accepting votes")}
-	ErrInvalidChainID           = Error{Code: 40021, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("not supported chain Id")}
+	ErrInvalidChainPrefix       = Error{Code: 40021, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("not supported chain prefix")}
 	// Worker errors
 	ErrWorkerNotAvailable     = Error{Code: 40022, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("worker not available")}
 	ErrMalformedWorkerInfo    = Error{Code: 40023, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("malformed worker info")}

--- a/api/errors_definition.go
+++ b/api/errors_definition.go
@@ -43,7 +43,7 @@ var (
 	ErrBallotAlreadySubmitted   = Error{Code: 40018, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("ballot already submitted")}
 	ErrBallotAlreadyProcessing  = Error{Code: 40019, HTTPstatus: http.StatusConflict, Err: fmt.Errorf("ballot is already processing")}
 	ErrProcessNotAcceptingVotes = Error{Code: 40020, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("process is not accepting votes")}
-	ErrInvalidChainPrefix       = Error{Code: 40021, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("not supported chain prefix")}
+	ErrInvalidContractVersion   = Error{Code: 40021, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("not supported contract version")}
 	// Worker errors
 	ErrWorkerNotAvailable     = Error{Code: 40022, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("worker not available")}
 	ErrMalformedWorkerInfo    = Error{Code: 40023, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("malformed worker info")}

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -2,13 +2,17 @@ package api
 
 import (
 	"bytes"
+	"encoding/hex"
 	"io"
 	"net/http"
 	"regexp"
 	"strings"
 	"time"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/vocdoni/davinci-node/log"
+	"github.com/vocdoni/davinci-node/types"
+	"github.com/vocdoni/davinci-node/util"
 )
 
 // DisabledLogging is a global flag to disable logging middleware
@@ -142,6 +146,48 @@ func loggingMiddlewareWithConfig(config LoggingConfig) func(http.Handler) http.H
 				"status", wrapped.statusCode,
 				"took", duration.String(),
 			)
+		})
+	}
+}
+
+// skipUnknownProcessIDMiddleware allows to skip requests with unknown
+// ProcessID versions. It checks the "processID" URL parameter and compares
+// its version against the provided currentVersion. If they don't match, it
+// responds with 404 Not Found. If the path does not contain a processID
+// parameter, it simply calls the next handler.
+func skipUnknownProcessIDMiddleware(currentVersion []byte) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Check if the route contains a process id
+			pidStr := chi.URLParam(r, ProcessURLParam)
+			if pidStr == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+			// Decode the process id from hex string
+			pidBytes, err := hex.DecodeString(util.TrimHex(pidStr))
+			if err != nil {
+				ErrMalformedProcessID.Withf("could not decode process ID: %v", err).Write(w)
+				return
+			}
+			// Unmarshal the process id
+			pid := new(types.ProcessID)
+			if err := pid.Unmarshal(pidBytes); err != nil {
+				ErrMalformedProcessID.Withf("could not unmarshal process ID: %v", err).Write(w)
+				return
+			}
+			// Check if the process id is valid
+			if !pid.IsValid() {
+				ErrMalformedProcessID.Withf("invalid process ID: %s", pidStr).Write(w)
+				return
+			}
+			// Check if the version matches the current expected version
+			if !pid.HasVersion(currentVersion) {
+				http.NotFound(w, r)
+				return
+			}
+			// Continue to the next handler
+			next.ServeHTTP(w, r)
 		})
 	}
 }

--- a/circuits/test/cache.go
+++ b/circuits/test/cache.go
@@ -229,7 +229,7 @@ func NewCircuitCache() (*CircuitCache, error) {
 // GenerateCacheKey creates a deterministic cache key based on circuit type and parameters
 func (c *CircuitCache) GenerateCacheKey(circuitType string, processID *types.ProcessID, params ...interface{}) string {
 	// Build cache key with circuit type, ProcessID, and additional parameters
-	keyData := fmt.Sprintf("%s-%s-%d-%x", circuitType, processID.Address.Hex(), processID.Nonce, processID.Prefix)
+	keyData := fmt.Sprintf("%s-%s-%d-%x", circuitType, processID.Address.Hex(), processID.Nonce, processID.Version)
 
 	// Append additional parameters
 	for _, param := range params {
@@ -449,8 +449,8 @@ func (dg *DeterministicGenerator) BigInt(nValidVoters int) *big.Int {
 // This ensures the same ProcessID + index always generates the same seed
 func GenerateDeterministicSeed(processID *types.ProcessID, index int) int64 {
 	// Create a simple deterministic seed from ProcessID and index
-	seed := int64(processID.Prefix[0])<<24 | int64(processID.Prefix[1])<<16 |
-		int64(processID.Prefix[2])<<8 | int64(processID.Prefix[3])
+	seed := int64(processID.Version[0])<<24 | int64(processID.Version[1])<<16 |
+		int64(processID.Version[2])<<8 | int64(processID.Version[3])
 	seed = seed*1000000 + int64(processID.Nonce)*1000 + int64(index)
 
 	// Add some variation based on the address

--- a/circuits/test/cache.go
+++ b/circuits/test/cache.go
@@ -229,7 +229,7 @@ func NewCircuitCache() (*CircuitCache, error) {
 // GenerateCacheKey creates a deterministic cache key based on circuit type and parameters
 func (c *CircuitCache) GenerateCacheKey(circuitType string, processID *types.ProcessID, params ...interface{}) string {
 	// Build cache key with circuit type, ProcessID, and additional parameters
-	keyData := fmt.Sprintf("%s-%s-%d-%d", circuitType, processID.Address.Hex(), processID.Nonce, processID.ChainID)
+	keyData := fmt.Sprintf("%s-%s-%d-%x", circuitType, processID.Address.Hex(), processID.Nonce, processID.Prefix)
 
 	// Append additional parameters
 	for _, param := range params {
@@ -449,7 +449,9 @@ func (dg *DeterministicGenerator) BigInt(nValidVoters int) *big.Int {
 // This ensures the same ProcessID + index always generates the same seed
 func GenerateDeterministicSeed(processID *types.ProcessID, index int) int64 {
 	// Create a simple deterministic seed from ProcessID and index
-	seed := int64(processID.ChainID)*1000000 + int64(processID.Nonce)*1000 + int64(index)
+	seed := int64(processID.Prefix[0])<<24 | int64(processID.Prefix[1])<<16 |
+		int64(processID.Prefix[2])<<8 | int64(processID.Prefix[3])
+	seed = seed*1000000 + int64(processID.Nonce)*1000 + int64(index)
 
 	// Add some variation based on the address
 	if len(processID.Address) >= 8 {

--- a/cmd/davinci-sequencer/main.go
+++ b/cmd/davinci-sequencer/main.go
@@ -244,7 +244,7 @@ func setupServices(ctx context.Context, cfg *Config, addresses *web3.Addresses) 
 
 	// Start API service
 	log.Infow("starting API service", "host", cfg.API.Host, "port", cfg.API.Port)
-	services.API = service.NewAPI(services.Storage, cfg.API.Host, cfg.API.Port, cfg.Web3.Network, cfg.Log.DisableAPI)
+	services.API = service.NewAPI(services.Storage, cfg.API.Host, cfg.API.Port, cfg.Web3.Network, config.DefaultConfig[cfg.Web3.Network], cfg.Log.DisableAPI)
 
 	// Configure worker API if enabled
 	if cfg.API.SequencerWorkersSeed != "" {

--- a/cmd/e2e-test/main.go
+++ b/cmd/e2e-test/main.go
@@ -301,7 +301,7 @@ func (s *localService) Start(ctx context.Context, contracts *web3.Contracts, net
 		return fmt.Errorf("failed to start sequencer: %v", err)
 	}
 	// Start API service
-	s.api = service.NewAPI(s.storage, defaultSequencerHost, defaultSequencerPort, network, false)
+	s.api = service.NewAPI(s.storage, defaultSequencerHost, defaultSequencerPort, network, config.DefaultConfig[network], false)
 	if err := s.api.Start(ctx); err != nil {
 		return fmt.Errorf("failed to start API: %v", err)
 	}

--- a/crypto/csp/csp_example_test.go
+++ b/crypto/csp/csp_example_test.go
@@ -26,7 +26,7 @@ func TestExampleCSP(t *testing.T) {
 	// Mock process ID for the example
 	processID := &types.ProcessID{
 		Address: orgAddress,
-		Prefix:  []byte{0x00, 0x00, 0x00, 0x01}, // Example prefix
+		Version: []byte{0x00, 0x00, 0x00, 0x01}, // Example prefix
 		Nonce:   rand.Uint64(),                  // Random nonce for the process
 	}
 	// Random Ethereum address for the voter

--- a/crypto/csp/csp_example_test.go
+++ b/crypto/csp/csp_example_test.go
@@ -26,8 +26,8 @@ func TestExampleCSP(t *testing.T) {
 	// Mock process ID for the example
 	processID := &types.ProcessID{
 		Address: orgAddress,
-		ChainID: 1,             // Example chain ID
-		Nonce:   rand.Uint64(), // Random nonce for the process
+		Prefix:  []byte{0x00, 0x00, 0x00, 0x01}, // Example prefix
+		Nonce:   rand.Uint64(),                  // Random nonce for the process
 	}
 	// Random Ethereum address for the voter
 	voterAddress := common.BytesToAddress(util.RandomBytes(20))

--- a/crypto/csp/eddsa/eddsa_test.go
+++ b/crypto/csp/eddsa/eddsa_test.go
@@ -20,7 +20,7 @@ func TestGenerateVerifyProof(t *testing.T) {
 	processID := &types.ProcessID{
 		Address: orgAddress,
 		Nonce:   rand.Uint64(),
-		ChainID: rand.Uint32(),
+		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	csp, err := CSP(twistededwards.BLS12_377)

--- a/crypto/csp/eddsa/eddsa_test.go
+++ b/crypto/csp/eddsa/eddsa_test.go
@@ -20,7 +20,7 @@ func TestGenerateVerifyProof(t *testing.T) {
 	processID := &types.ProcessID{
 		Address: orgAddress,
 		Nonce:   rand.Uint64(),
-		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
+		Version: []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	csp, err := CSP(twistededwards.BLS12_377)

--- a/crypto/csp/gnark_test.go
+++ b/crypto/csp/gnark_test.go
@@ -44,7 +44,7 @@ func TestCSPProofCircuit(t *testing.T) {
 	processID := &types.ProcessID{
 		Address: orgAddress,
 		Nonce:   rand.Uint64(),
-		ChainID: rand.Uint32(),
+		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	proof, err := csp.GenerateProof(processID, userAddress)

--- a/crypto/csp/gnark_test.go
+++ b/crypto/csp/gnark_test.go
@@ -44,7 +44,7 @@ func TestCSPProofCircuit(t *testing.T) {
 	processID := &types.ProcessID{
 		Address: orgAddress,
 		Nonce:   rand.Uint64(),
-		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
+		Version: []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	proof, err := csp.GenerateProof(processID, userAddress)

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/syndtr/goleveldb v1.0.1-0.20220614013038-64ee5596c38a
 	github.com/testcontainers/testcontainers-go/modules/compose v0.35.0
 	github.com/vocdoni/arbo v0.0.0-20250904220709-07ccfd3090b5
-	github.com/vocdoni/davinci-contracts v0.0.0-20250916085905-53587f422ea5
+	github.com/vocdoni/davinci-contracts v0.0.0-20250923115042-0d3180699a7a
 	github.com/vocdoni/gnark-crypto-primitives v0.0.2-0.20250721114051-04061c85ab97
 	go.mongodb.org/mongo-driver v1.12.1
 	golang.org/x/mod v0.26.0

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/syndtr/goleveldb v1.0.1-0.20220614013038-64ee5596c38a
 	github.com/testcontainers/testcontainers-go/modules/compose v0.35.0
 	github.com/vocdoni/arbo v0.0.0-20250904220709-07ccfd3090b5
-	github.com/vocdoni/davinci-contracts v0.0.0-20250925080605-1656dd7ef452
+	github.com/vocdoni/davinci-contracts v0.0.0-20250929131147-7bac0a286418
 	github.com/vocdoni/gnark-crypto-primitives v0.0.2-0.20250721114051-04061c85ab97
 	go.mongodb.org/mongo-driver v1.12.1
 	golang.org/x/mod v0.26.0

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/syndtr/goleveldb v1.0.1-0.20220614013038-64ee5596c38a
 	github.com/testcontainers/testcontainers-go/modules/compose v0.35.0
 	github.com/vocdoni/arbo v0.0.0-20250904220709-07ccfd3090b5
-	github.com/vocdoni/davinci-contracts v0.0.0-20250923115042-0d3180699a7a
+	github.com/vocdoni/davinci-contracts v0.0.0-20250925080605-1656dd7ef452
 	github.com/vocdoni/gnark-crypto-primitives v0.0.2-0.20250721114051-04061c85ab97
 	go.mongodb.org/mongo-driver v1.12.1
 	golang.org/x/mod v0.26.0

--- a/go.sum
+++ b/go.sum
@@ -724,8 +724,8 @@ github.com/vbatts/tar-split v0.11.5 h1:3bHCTIheBm1qFTcgh9oPu+nNBtX+XJIupG/vacinC
 github.com/vbatts/tar-split v0.11.5/go.mod h1:yZbwRsSeGjusneWgA781EKej9HF8vme8okylkAeNKLk=
 github.com/vocdoni/arbo v0.0.0-20250904220709-07ccfd3090b5 h1:wtUK5E131x07zdxnAGRIt2wl5BzwmfoXZ1V4s+kPQc8=
 github.com/vocdoni/arbo v0.0.0-20250904220709-07ccfd3090b5/go.mod h1:SUsNx5GJJunlEMBo6ETTmys88B4bkTgqNV5N1jN3iic=
-github.com/vocdoni/davinci-contracts v0.0.0-20250916085905-53587f422ea5 h1:XE757v7ML30GqRUDfL4Sw/9lX/tXYf4mYTNALeHRihI=
-github.com/vocdoni/davinci-contracts v0.0.0-20250916085905-53587f422ea5/go.mod h1:RgIZ/8KfR5GfS54l59Tbmm33krj8+HL19ZJRpWcVB4g=
+github.com/vocdoni/davinci-contracts v0.0.0-20250923115042-0d3180699a7a h1:oYpBZzIpE35YNanyl462W7wWEwyrPjrUqhcXNlZA5PU=
+github.com/vocdoni/davinci-contracts v0.0.0-20250923115042-0d3180699a7a/go.mod h1:RgIZ/8KfR5GfS54l59Tbmm33krj8+HL19ZJRpWcVB4g=
 github.com/vocdoni/gnark-crypto-primitives v0.0.2-0.20250721114051-04061c85ab97 h1:85N0hCD0MxBH7P76m7TJB+6JwxzT2ajxrn5qutemTGs=
 github.com/vocdoni/gnark-crypto-primitives v0.0.2-0.20250721114051-04061c85ab97/go.mod h1:BOS7k/ifqwicL1CgLiq1NylPnMLCuNRBHU2HHHtnWOE=
 github.com/vocdoni/gnark-no-assert v0.0.0-20250723103948-9e2777846d75 h1:CiaS9DIFLgLplyamifm0wG5obinb4+BSoVfjRbv36SA=

--- a/go.sum
+++ b/go.sum
@@ -724,8 +724,8 @@ github.com/vbatts/tar-split v0.11.5 h1:3bHCTIheBm1qFTcgh9oPu+nNBtX+XJIupG/vacinC
 github.com/vbatts/tar-split v0.11.5/go.mod h1:yZbwRsSeGjusneWgA781EKej9HF8vme8okylkAeNKLk=
 github.com/vocdoni/arbo v0.0.0-20250904220709-07ccfd3090b5 h1:wtUK5E131x07zdxnAGRIt2wl5BzwmfoXZ1V4s+kPQc8=
 github.com/vocdoni/arbo v0.0.0-20250904220709-07ccfd3090b5/go.mod h1:SUsNx5GJJunlEMBo6ETTmys88B4bkTgqNV5N1jN3iic=
-github.com/vocdoni/davinci-contracts v0.0.0-20250923115042-0d3180699a7a h1:oYpBZzIpE35YNanyl462W7wWEwyrPjrUqhcXNlZA5PU=
-github.com/vocdoni/davinci-contracts v0.0.0-20250923115042-0d3180699a7a/go.mod h1:RgIZ/8KfR5GfS54l59Tbmm33krj8+HL19ZJRpWcVB4g=
+github.com/vocdoni/davinci-contracts v0.0.0-20250925080605-1656dd7ef452 h1:CF5KCR+6bqQ9UMkaN79AahTR40sKHxD/zf20C5WZQkw=
+github.com/vocdoni/davinci-contracts v0.0.0-20250925080605-1656dd7ef452/go.mod h1:RgIZ/8KfR5GfS54l59Tbmm33krj8+HL19ZJRpWcVB4g=
 github.com/vocdoni/gnark-crypto-primitives v0.0.2-0.20250721114051-04061c85ab97 h1:85N0hCD0MxBH7P76m7TJB+6JwxzT2ajxrn5qutemTGs=
 github.com/vocdoni/gnark-crypto-primitives v0.0.2-0.20250721114051-04061c85ab97/go.mod h1:BOS7k/ifqwicL1CgLiq1NylPnMLCuNRBHU2HHHtnWOE=
 github.com/vocdoni/gnark-no-assert v0.0.0-20250723103948-9e2777846d75 h1:CiaS9DIFLgLplyamifm0wG5obinb4+BSoVfjRbv36SA=

--- a/go.sum
+++ b/go.sum
@@ -724,8 +724,8 @@ github.com/vbatts/tar-split v0.11.5 h1:3bHCTIheBm1qFTcgh9oPu+nNBtX+XJIupG/vacinC
 github.com/vbatts/tar-split v0.11.5/go.mod h1:yZbwRsSeGjusneWgA781EKej9HF8vme8okylkAeNKLk=
 github.com/vocdoni/arbo v0.0.0-20250904220709-07ccfd3090b5 h1:wtUK5E131x07zdxnAGRIt2wl5BzwmfoXZ1V4s+kPQc8=
 github.com/vocdoni/arbo v0.0.0-20250904220709-07ccfd3090b5/go.mod h1:SUsNx5GJJunlEMBo6ETTmys88B4bkTgqNV5N1jN3iic=
-github.com/vocdoni/davinci-contracts v0.0.0-20250925080605-1656dd7ef452 h1:CF5KCR+6bqQ9UMkaN79AahTR40sKHxD/zf20C5WZQkw=
-github.com/vocdoni/davinci-contracts v0.0.0-20250925080605-1656dd7ef452/go.mod h1:RgIZ/8KfR5GfS54l59Tbmm33krj8+HL19ZJRpWcVB4g=
+github.com/vocdoni/davinci-contracts v0.0.0-20250929131147-7bac0a286418 h1:Z+7ONFAwhC2T3ZgIxWjFDOt+T+3OPKJpwvFcxaLImA8=
+github.com/vocdoni/davinci-contracts v0.0.0-20250929131147-7bac0a286418/go.mod h1:RgIZ/8KfR5GfS54l59Tbmm33krj8+HL19ZJRpWcVB4g=
 github.com/vocdoni/gnark-crypto-primitives v0.0.2-0.20250721114051-04061c85ab97 h1:85N0hCD0MxBH7P76m7TJB+6JwxzT2ajxrn5qutemTGs=
 github.com/vocdoni/gnark-crypto-primitives v0.0.2-0.20250721114051-04061c85ab97/go.mod h1:BOS7k/ifqwicL1CgLiq1NylPnMLCuNRBHU2HHHtnWOE=
 github.com/vocdoni/gnark-no-assert v0.0.0-20250723103948-9e2777846d75 h1:CiaS9DIFLgLplyamifm0wG5obinb4+BSoVfjRbv36SA=

--- a/sequencer/finalizer_test.go
+++ b/sequencer/finalizer_test.go
@@ -90,7 +90,7 @@ func setupTestEnvironment(t *testing.T, addValue, subValue int64) (
 	pid := &types.ProcessID{
 		Address: common.Address{},
 		Nonce:   42,
-		ChainID: 1,
+		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	// Create encryption keys

--- a/sequencer/finalizer_test.go
+++ b/sequencer/finalizer_test.go
@@ -90,7 +90,7 @@ func setupTestEnvironment(t *testing.T, addValue, subValue int64) (
 	pid := &types.ProcessID{
 		Address: common.Address{},
 		Nonce:   42,
-		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
+		Version: []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	// Create encryption keys

--- a/service/api_service.go
+++ b/service/api_service.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/vocdoni/davinci-node/api"
+	"github.com/vocdoni/davinci-node/config"
 	"github.com/vocdoni/davinci-node/log"
 	"github.com/vocdoni/davinci-node/storage"
 	"github.com/vocdoni/davinci-node/workers"
@@ -21,6 +22,7 @@ type APIService struct {
 	host                       string
 	port                       int
 	network                    string
+	web3Config                 config.DavinciWeb3Config
 	sequencerWorkersSeed       string
 	workersAuthtokenExpiration time.Duration
 	workersJobTimeout          time.Duration
@@ -28,16 +30,17 @@ type APIService struct {
 }
 
 // NewAPI creates a new APIService instance.
-func NewAPI(storage *storage.Storage, host string, port int, network string, disableLogging bool) *APIService {
+func NewAPI(storage *storage.Storage, host string, port int, network string, web3Config config.DavinciWeb3Config, disableLogging bool) *APIService {
 	if disableLogging {
 		api.DisabledLogging = disableLogging
 		log.Debugw("API logging is disabled")
 	}
 	return &APIService{
-		storage: storage,
-		host:    host,
-		port:    port,
-		network: network,
+		storage:    storage,
+		host:       host,
+		port:       port,
+		network:    network,
+		web3Config: web3Config,
 	}
 }
 
@@ -71,6 +74,7 @@ func (as *APIService) Start(ctx context.Context) error {
 		Port:                       as.port,
 		Storage:                    as.storage,
 		Network:                    as.network,
+		Web3Config:                 as.web3Config,
 		SequencerWorkersSeed:       as.sequencerWorkersSeed,
 		WorkersAuthtokenExpiration: as.workersAuthtokenExpiration,
 		WorkerJobTimeout:           as.workersJobTimeout,

--- a/service/api_service_test.go
+++ b/service/api_service_test.go
@@ -7,6 +7,7 @@ import (
 
 	qt "github.com/frankban/quicktest"
 	"github.com/vocdoni/arbo/memdb"
+	"github.com/vocdoni/davinci-node/config"
 	"github.com/vocdoni/davinci-node/storage"
 )
 
@@ -19,7 +20,7 @@ func TestAPIService(t *testing.T) {
 	defer store.Close()
 
 	// Create API service with a random available port
-	apiService := NewAPI(store, "127.0.0.1", 0, "local", false) // Port 0 lets the OS choose an available port
+	apiService := NewAPI(store, "127.0.0.1", 0, "test", config.DefaultConfig["test"], false) // Port 0 lets the OS choose an available port
 
 	// Start service in background
 	ctx := context.Background()

--- a/service/mock_web3.go
+++ b/service/mock_web3.go
@@ -14,14 +14,12 @@ var _ ContractsService = &MockContracts{}
 // MockContracts implements a mock version of web3.Contracts for testing
 type MockContracts struct {
 	processes []*types.Process
-	chainID   uint64
 	mu        sync.Mutex
 }
 
 func NewMockContracts() *MockContracts {
 	return &MockContracts{
 		processes: make([]*types.Process, 0),
-		chainID:   1,
 	}
 }
 
@@ -63,7 +61,7 @@ func (m *MockContracts) CreateProcess(process *types.Process) (*types.ProcessID,
 	pid := types.ProcessID{
 		Address: process.OrganizationId,
 		Nonce:   uint64(len(m.processes)),
-		ChainID: uint32(m.chainID),
+		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
 	}
 	process.ID = pid.Marshal()
 	m.processes = append(m.processes, process)

--- a/service/mock_web3.go
+++ b/service/mock_web3.go
@@ -61,7 +61,7 @@ func (m *MockContracts) CreateProcess(process *types.Process) (*types.ProcessID,
 	pid := types.ProcessID{
 		Address: process.OrganizationId,
 		Nonce:   uint64(len(m.processes)),
-		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
+		Version: []byte{0x00, 0x00, 0x00, 0x01},
 	}
 	process.ID = pid.Marshal()
 	m.processes = append(m.processes, process)

--- a/storage/cleanup_test.go
+++ b/storage/cleanup_test.go
@@ -29,12 +29,12 @@ func TestCleanupEndedProcess(t *testing.T) {
 	processID1 := &types.ProcessID{
 		Address: common.Address{1},
 		Nonce:   1,
-		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
+		Version: []byte{0x00, 0x00, 0x00, 0x01},
 	}
 	processID2 := &types.ProcessID{
 		Address: common.Address{2},
 		Nonce:   2,
-		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
+		Version: []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	// Create processes
@@ -71,7 +71,7 @@ func TestCleanupEndedProcessWithSettledVotes(t *testing.T) {
 	processID := &types.ProcessID{
 		Address: common.Address{1},
 		Nonce:   1,
-		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
+		Version: []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	err = st.NewProcess(createTestProcess(processID))
@@ -113,7 +113,7 @@ func TestMarkProcessVoteIDsTimeout(t *testing.T) {
 	processID := &types.ProcessID{
 		Address: common.Address{1},
 		Nonce:   1,
-		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
+		Version: []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	// Create test vote IDs with different statuses

--- a/storage/cleanup_test.go
+++ b/storage/cleanup_test.go
@@ -29,12 +29,12 @@ func TestCleanupEndedProcess(t *testing.T) {
 	processID1 := &types.ProcessID{
 		Address: common.Address{1},
 		Nonce:   1,
-		ChainID: 1,
+		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
 	}
 	processID2 := &types.ProcessID{
 		Address: common.Address{2},
 		Nonce:   2,
-		ChainID: 1,
+		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	// Create processes
@@ -71,7 +71,7 @@ func TestCleanupEndedProcessWithSettledVotes(t *testing.T) {
 	processID := &types.ProcessID{
 		Address: common.Address{1},
 		Nonce:   1,
-		ChainID: 1,
+		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	err = st.NewProcess(createTestProcess(processID))
@@ -113,7 +113,7 @@ func TestMarkProcessVoteIDsTimeout(t *testing.T) {
 	processID := &types.ProcessID{
 		Address: common.Address{1},
 		Nonce:   1,
-		ChainID: 1,
+		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	// Create test vote IDs with different statuses

--- a/storage/keys_test.go
+++ b/storage/keys_test.go
@@ -28,13 +28,13 @@ func TestEncryptionKeys(t *testing.T) {
 	processID1 := &types.ProcessID{
 		Address: common.Address{1},
 		Nonce:   42,
-		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
+		Version: []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	processID2 := &types.ProcessID{
 		Address: common.Address{2},
 		Nonce:   43,
-		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
+		Version: []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	// Test 1: Initially no encryption keys exist

--- a/storage/keys_test.go
+++ b/storage/keys_test.go
@@ -28,13 +28,13 @@ func TestEncryptionKeys(t *testing.T) {
 	processID1 := &types.ProcessID{
 		Address: common.Address{1},
 		Nonce:   42,
-		ChainID: 1,
+		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	processID2 := &types.ProcessID{
 		Address: common.Address{2},
 		Nonce:   43,
-		ChainID: 1,
+		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	// Test 1: Initially no encryption keys exist

--- a/storage/process_monitor_test.go
+++ b/storage/process_monitor_test.go
@@ -27,7 +27,7 @@ func TestMonitorEndedProcesses(t *testing.T) {
 	processID := &types.ProcessID{
 		Address: common.Address{},
 		Nonce:   42,
-		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
+		Version: []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	pastTime := time.Now().Add(-2 * time.Hour) // Started 2 hours ago
@@ -88,7 +88,7 @@ func TestMonitorEndedProcessesNotYetEnded(t *testing.T) {
 	processID := &types.ProcessID{
 		Address: common.Address{1},
 		Nonce:   43,
-		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
+		Version: []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	recentTime := time.Now().Add(-30 * time.Minute) // Started 30 minutes ago
@@ -149,7 +149,7 @@ func TestMonitorEndedProcessesSkipsAlreadyEnded(t *testing.T) {
 	processID := &types.ProcessID{
 		Address: common.Address{2},
 		Nonce:   44,
-		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
+		Version: []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	pastTime := time.Now().Add(-2 * time.Hour)

--- a/storage/process_monitor_test.go
+++ b/storage/process_monitor_test.go
@@ -27,7 +27,7 @@ func TestMonitorEndedProcesses(t *testing.T) {
 	processID := &types.ProcessID{
 		Address: common.Address{},
 		Nonce:   42,
-		ChainID: 1,
+		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	pastTime := time.Now().Add(-2 * time.Hour) // Started 2 hours ago
@@ -88,7 +88,7 @@ func TestMonitorEndedProcessesNotYetEnded(t *testing.T) {
 	processID := &types.ProcessID{
 		Address: common.Address{1},
 		Nonce:   43,
-		ChainID: 1,
+		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	recentTime := time.Now().Add(-30 * time.Minute) // Started 30 minutes ago
@@ -149,7 +149,7 @@ func TestMonitorEndedProcessesSkipsAlreadyEnded(t *testing.T) {
 	processID := &types.ProcessID{
 		Address: common.Address{2},
 		Nonce:   44,
-		ChainID: 1,
+		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	pastTime := time.Now().Add(-2 * time.Hour)

--- a/storage/process_stats_test.go
+++ b/storage/process_stats_test.go
@@ -32,7 +32,7 @@ func TestProcessStatsConcurrency(t *testing.T) {
 	processID := &types.ProcessID{
 		Address: common.Address{},
 		Nonce:   42,
-		ChainID: 1,
+		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	err = st.NewProcess(createTestProcess(processID))
@@ -122,7 +122,7 @@ func TestProcessStatsAggregation(t *testing.T) {
 	processID := &types.ProcessID{
 		Address: common.Address{},
 		Nonce:   43,
-		ChainID: 1,
+		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	err = st.NewProcess(createTestProcess(processID))
@@ -220,7 +220,7 @@ func TestProcessStatsRaceCondition(t *testing.T) {
 	processID := &types.ProcessID{
 		Address: common.Address{},
 		Nonce:   44,
-		ChainID: 1,
+		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	err = st.NewProcess(createTestProcess(processID))
@@ -359,19 +359,19 @@ func TestGetTotalPendingBallots(t *testing.T) {
 	processID1 := &types.ProcessID{
 		Address: common.Address{1},
 		Nonce:   1,
-		ChainID: 1,
+		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	processID2 := &types.ProcessID{
 		Address: common.Address{2},
 		Nonce:   2,
-		ChainID: 1,
+		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	processID3 := &types.ProcessID{
 		Address: common.Address{3},
 		Nonce:   3,
-		ChainID: 1,
+		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	// Create processes with different pending ballot counts
@@ -517,7 +517,7 @@ func TestMarkVerifiedBallotsFailed(t *testing.T) {
 	processID := &types.ProcessID{
 		Address: common.Address{},
 		Nonce:   100,
-		ChainID: 1,
+		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	err = st.NewProcess(createTestProcess(processID))
@@ -603,7 +603,7 @@ func TestMarkBallotBatchFailed(t *testing.T) {
 	processID := &types.ProcessID{
 		Address: common.Address{},
 		Nonce:   101,
-		ChainID: 1,
+		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	err = st.NewProcess(createTestProcess(processID))
@@ -714,7 +714,7 @@ func TestProcessStatsNegativeValuePrevention(t *testing.T) {
 	processID := &types.ProcessID{
 		Address: common.Address{},
 		Nonce:   102,
-		ChainID: 1,
+		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	err = st.NewProcess(createTestProcess(processID))
@@ -829,17 +829,17 @@ func TestTotalStats(t *testing.T) {
 	process1 := &types.ProcessID{
 		Address: common.Address{1},
 		Nonce:   1,
-		ChainID: 1,
+		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
 	}
 	process2 := &types.ProcessID{
 		Address: common.Address{2},
 		Nonce:   2,
-		ChainID: 1,
+		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
 	}
 	process3 := &types.ProcessID{
 		Address: common.Address{3},
 		Nonce:   3,
-		ChainID: 1,
+		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	// Create processes
@@ -926,12 +926,12 @@ func TestTotalPendingBallotsNewFunctionality(t *testing.T) {
 	process1 := &types.ProcessID{
 		Address: common.Address{1},
 		Nonce:   1,
-		ChainID: 1,
+		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
 	}
 	process2 := &types.ProcessID{
 		Address: common.Address{2},
 		Nonce:   2,
-		ChainID: 1,
+		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	// Create processes
@@ -1038,7 +1038,7 @@ func TestTotalStatsConcurrency(t *testing.T) {
 		processes[i] = &types.ProcessID{
 			Address: common.Address{byte(i + 1)},
 			Nonce:   uint64(i + 1),
-			ChainID: 1,
+			Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
 		}
 		err = st.NewProcess(createTestProcess(processes[i]))
 		c.Assert(err, qt.IsNil)
@@ -1112,12 +1112,12 @@ func TestTotalPendingBallotsIntegration(t *testing.T) {
 	process1 := &types.ProcessID{
 		Address: common.Address{1},
 		Nonce:   1,
-		ChainID: 1,
+		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
 	}
 	process2 := &types.ProcessID{
 		Address: common.Address{2},
 		Nonce:   2,
-		ChainID: 1,
+		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	err = st.NewProcess(createTestProcess(process1))

--- a/storage/process_stats_test.go
+++ b/storage/process_stats_test.go
@@ -32,7 +32,7 @@ func TestProcessStatsConcurrency(t *testing.T) {
 	processID := &types.ProcessID{
 		Address: common.Address{},
 		Nonce:   42,
-		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
+		Version: []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	err = st.NewProcess(createTestProcess(processID))
@@ -122,7 +122,7 @@ func TestProcessStatsAggregation(t *testing.T) {
 	processID := &types.ProcessID{
 		Address: common.Address{},
 		Nonce:   43,
-		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
+		Version: []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	err = st.NewProcess(createTestProcess(processID))
@@ -220,7 +220,7 @@ func TestProcessStatsRaceCondition(t *testing.T) {
 	processID := &types.ProcessID{
 		Address: common.Address{},
 		Nonce:   44,
-		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
+		Version: []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	err = st.NewProcess(createTestProcess(processID))
@@ -359,19 +359,19 @@ func TestGetTotalPendingBallots(t *testing.T) {
 	processID1 := &types.ProcessID{
 		Address: common.Address{1},
 		Nonce:   1,
-		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
+		Version: []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	processID2 := &types.ProcessID{
 		Address: common.Address{2},
 		Nonce:   2,
-		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
+		Version: []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	processID3 := &types.ProcessID{
 		Address: common.Address{3},
 		Nonce:   3,
-		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
+		Version: []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	// Create processes with different pending ballot counts
@@ -517,7 +517,7 @@ func TestMarkVerifiedBallotsFailed(t *testing.T) {
 	processID := &types.ProcessID{
 		Address: common.Address{},
 		Nonce:   100,
-		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
+		Version: []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	err = st.NewProcess(createTestProcess(processID))
@@ -603,7 +603,7 @@ func TestMarkBallotBatchFailed(t *testing.T) {
 	processID := &types.ProcessID{
 		Address: common.Address{},
 		Nonce:   101,
-		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
+		Version: []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	err = st.NewProcess(createTestProcess(processID))
@@ -714,7 +714,7 @@ func TestProcessStatsNegativeValuePrevention(t *testing.T) {
 	processID := &types.ProcessID{
 		Address: common.Address{},
 		Nonce:   102,
-		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
+		Version: []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	err = st.NewProcess(createTestProcess(processID))
@@ -829,17 +829,17 @@ func TestTotalStats(t *testing.T) {
 	process1 := &types.ProcessID{
 		Address: common.Address{1},
 		Nonce:   1,
-		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
+		Version: []byte{0x00, 0x00, 0x00, 0x01},
 	}
 	process2 := &types.ProcessID{
 		Address: common.Address{2},
 		Nonce:   2,
-		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
+		Version: []byte{0x00, 0x00, 0x00, 0x01},
 	}
 	process3 := &types.ProcessID{
 		Address: common.Address{3},
 		Nonce:   3,
-		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
+		Version: []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	// Create processes
@@ -926,12 +926,12 @@ func TestTotalPendingBallotsNewFunctionality(t *testing.T) {
 	process1 := &types.ProcessID{
 		Address: common.Address{1},
 		Nonce:   1,
-		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
+		Version: []byte{0x00, 0x00, 0x00, 0x01},
 	}
 	process2 := &types.ProcessID{
 		Address: common.Address{2},
 		Nonce:   2,
-		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
+		Version: []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	// Create processes
@@ -1038,7 +1038,7 @@ func TestTotalStatsConcurrency(t *testing.T) {
 		processes[i] = &types.ProcessID{
 			Address: common.Address{byte(i + 1)},
 			Nonce:   uint64(i + 1),
-			Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
+			Version: []byte{0x00, 0x00, 0x00, 0x01},
 		}
 		err = st.NewProcess(createTestProcess(processes[i]))
 		c.Assert(err, qt.IsNil)
@@ -1112,12 +1112,12 @@ func TestTotalPendingBallotsIntegration(t *testing.T) {
 	process1 := &types.ProcessID{
 		Address: common.Address{1},
 		Nonce:   1,
-		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
+		Version: []byte{0x00, 0x00, 0x00, 0x01},
 	}
 	process2 := &types.ProcessID{
 		Address: common.Address{2},
 		Nonce:   2,
-		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
+		Version: []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	err = st.NewProcess(createTestProcess(process1))

--- a/storage/process_test.go
+++ b/storage/process_test.go
@@ -27,7 +27,7 @@ func TestProcess(t *testing.T) {
 	processID := &types.ProcessID{
 		Address: common.Address{},
 		Nonce:   42,
-		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
+		Version: []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	// Test 1: Get non-existent data
@@ -108,7 +108,7 @@ func TestProcess(t *testing.T) {
 	anotherProcessID := types.ProcessID{
 		Address: common.Address{1},
 		Nonce:   43,
-		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
+		Version: []byte{0x00, 0x00, 0x00, 0x01},
 	}
 	process.ID = anotherProcessID.Marshal()
 

--- a/storage/process_test.go
+++ b/storage/process_test.go
@@ -27,7 +27,7 @@ func TestProcess(t *testing.T) {
 	processID := &types.ProcessID{
 		Address: common.Address{},
 		Nonce:   42,
-		ChainID: 1,
+		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	// Test 1: Get non-existent data
@@ -108,7 +108,7 @@ func TestProcess(t *testing.T) {
 	anotherProcessID := types.ProcessID{
 		Address: common.Address{1},
 		Nonce:   43,
-		ChainID: 1,
+		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
 	}
 	process.ID = anotherProcessID.Marshal()
 

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -55,7 +55,7 @@ func TestBallotQueue(t *testing.T) {
 	processID := types.ProcessID{
 		Address: common.Address{},
 		Nonce:   0,
-		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
+		Version: []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	// Create the process first
@@ -185,7 +185,7 @@ func TestBallotQueue(t *testing.T) {
 	// Additional scenario: no verified ballots if none processed
 	anotherPID := types.ProcessID{
 		Address: common.Address{},
-		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
+		Version: []byte{0x00, 0x00, 0x00, 0x01},
 		Nonce:   999,
 	}
 	vbsEmpty, keysEmpty, err := st.PullVerifiedBallots(anotherPID.Marshal(), 10)
@@ -210,7 +210,7 @@ func TestPullVerifiedBallotsReservation(t *testing.T) {
 	processID := types.ProcessID{
 		Address: common.Address{},
 		Nonce:   0,
-		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
+		Version: []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	// Create the process first
@@ -324,7 +324,7 @@ func TestBallotBatchQueue(t *testing.T) {
 	processID := types.ProcessID{
 		Address: common.Address{},
 		Nonce:   0,
-		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
+		Version: []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	// Create the process first
@@ -403,7 +403,7 @@ func TestBallotBatchQueue(t *testing.T) {
 	// Test 4: Different process ID
 	anotherPID := types.ProcessID{
 		Address: common.Address{},
-		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
+		Version: []byte{0x00, 0x00, 0x00, 0x01},
 		Nonce:   999,
 	}
 	_, _, err = st.NextBallotBatch(anotherPID.Marshal())

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -55,7 +55,7 @@ func TestBallotQueue(t *testing.T) {
 	processID := types.ProcessID{
 		Address: common.Address{},
 		Nonce:   0,
-		ChainID: 0,
+		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	// Create the process first
@@ -185,7 +185,7 @@ func TestBallotQueue(t *testing.T) {
 	// Additional scenario: no verified ballots if none processed
 	anotherPID := types.ProcessID{
 		Address: common.Address{},
-		ChainID: 0,
+		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
 		Nonce:   999,
 	}
 	vbsEmpty, keysEmpty, err := st.PullVerifiedBallots(anotherPID.Marshal(), 10)
@@ -210,7 +210,7 @@ func TestPullVerifiedBallotsReservation(t *testing.T) {
 	processID := types.ProcessID{
 		Address: common.Address{},
 		Nonce:   0,
-		ChainID: 0,
+		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	// Create the process first
@@ -324,7 +324,7 @@ func TestBallotBatchQueue(t *testing.T) {
 	processID := types.ProcessID{
 		Address: common.Address{},
 		Nonce:   0,
-		ChainID: 0,
+		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
 	}
 
 	// Create the process first
@@ -403,7 +403,7 @@ func TestBallotBatchQueue(t *testing.T) {
 	// Test 4: Different process ID
 	anotherPID := types.ProcessID{
 		Address: common.Address{},
-		ChainID: 0,
+		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
 		Nonce:   999,
 	}
 	_, _, err = st.NextBallotBatch(anotherPID.Marshal())

--- a/storage/vote_id_status_test.go
+++ b/storage/vote_id_status_test.go
@@ -26,7 +26,7 @@ func TestVoteIDStatus(t *testing.T) {
 	processID := &types.ProcessID{
 		Address: common.Address{},
 		Nonce:   42,
-		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
+		Version: []byte{0x00, 0x00, 0x00, 0x01},
 	}
 	pidBytes := processID.Marshal()
 

--- a/storage/vote_id_status_test.go
+++ b/storage/vote_id_status_test.go
@@ -26,7 +26,7 @@ func TestVoteIDStatus(t *testing.T) {
 	processID := &types.ProcessID{
 		Address: common.Address{},
 		Nonce:   42,
-		ChainID: 1,
+		Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
 	}
 	pidBytes := processID.Marshal()
 

--- a/types/processId.go
+++ b/types/processId.go
@@ -12,13 +12,13 @@ import (
 )
 
 // ProcessID is the type to identify a voting process. It is composed of:
-// - Prefix keccak(chainID + contractAddress) (4 bytes)
 // - Address (20 bytes)
+// - Version keccak(chainID + contractAddress) (4 bytes)
 // - Nonce (8 bytes)
 // TODO: change to []byte wrapper, it will simplify the code and SetBytes() can be removed
 type ProcessID struct {
-	Prefix  []byte         // first 4 bytes of keccak(chainID + contractAddress)
 	Address common.Address // 20 bytes
+	Version []byte         // first 4 bytes of keccak(chainID + contractAddress)
 	Nonce   uint64         // 8 bytes big-endian
 }
 
@@ -28,7 +28,7 @@ type ProcessID struct {
 func (p *ProcessID) SetBytes(data []byte) *ProcessID {
 	if err := p.Unmarshal(data); err != nil {
 		return &ProcessID{
-			Prefix:  make([]byte, 4),
+			Version: make([]byte, 4),
 			Address: common.Address{},
 			Nonce:   0,
 		}
@@ -37,9 +37,9 @@ func (p *ProcessID) SetBytes(data []byte) *ProcessID {
 }
 
 // IsValid checks if the ProcessID is valid.
-// A valid ProcessID must have a non-zero Prefix, Address, and Nonce
+// A valid ProcessID must have a non-zero Address, Version, and Nonce
 func (p *ProcessID) IsValid() bool {
-	return p != nil && !bytes.Equal(p.Prefix, make([]byte, 4)) && !bytes.Equal(p.Address.Bytes(), common.Address{}.Bytes())
+	return p != nil && !bytes.Equal(p.Version, make([]byte, 4)) && !bytes.Equal(p.Address.Bytes(), common.Address{}.Bytes())
 }
 
 // BigInt returns a BigInt representation of the ProcessId.
@@ -51,15 +51,17 @@ func (p *ProcessID) BigInt() *big.Int {
 }
 
 // Marshal encodes ProcessId to bytes:
+//
+//	Address (20 bytes) | Version (4 bytes) | Nonce (8 bytes)
 func (p *ProcessID) Marshal() []byte {
-	prefix := make([]byte, 4)
-	copy(prefix, p.Prefix)
+	version := make([]byte, 4)
+	copy(version, p.Version)
 	nonce := make([]byte, 8)
 	binary.BigEndian.PutUint64(nonce, p.Nonce)
 
 	var id bytes.Buffer
-	id.Write(prefix)
 	id.Write(p.Address.Bytes()[:20])
+	id.Write(version)
 	id.Write(nonce[:8])
 	return id.Bytes()
 }
@@ -69,8 +71,8 @@ func (p *ProcessID) Unmarshal(data []byte) error {
 	if len(data) != 32 {
 		return fmt.Errorf("invalid ProcessID length: %d", len(data))
 	}
-	p.Prefix = data[:4]
-	p.Address = common.BytesToAddress(data[4:24])
+	p.Address = common.BytesToAddress(data[:20])
+	p.Version = data[20:24]
 	p.Nonce = binary.BigEndian.Uint64(data[24:32])
 	return nil
 }
@@ -90,19 +92,24 @@ func (p *ProcessID) String() string {
 	return hex.EncodeToString(p.Marshal())
 }
 
+// HasVersion checks if the ProcessID version matches the given version
+func (p *ProcessID) HasVersion(version []byte) bool {
+	return bytes.Equal(p.Version, version)
+}
+
 // TestProcessID is a deterministic ProcessID used for testing purposes.
 // All circuit tests should use this ProcessID to ensure consistent caching
 // and proof reuse between tests.
 var TestProcessID = &ProcessID{
-	Prefix:  []byte{0x00, 0x00, 0x00, 0x01},
 	Address: common.HexToAddress("0x1234567890123456789012345678901234567890"),
+	Version: []byte{0x00, 0x00, 0x00, 0x01},
 	Nonce:   1,
 }
 
-// ProcessIDPrefix computes the prefix for a ProcessID. It is defined as the
+// ProcessIDVersion computes the version for a ProcessID. It is defined as the
 // first 4 bytes of the Keccak-256 hash of the concatenation of the chain ID
 // (4 bytes big-endian) and the contract address (20 bytes).
-func ProcessIDPrefix(chainID uint32, contractAddr common.Address) []byte {
+func ProcessIDVersion(chainID uint32, contractAddr common.Address) []byte {
 	var buf [24]byte
 	// chainId: 4 bytes big-endian
 	binary.BigEndian.PutUint32(buf[0:4], chainID)
@@ -110,6 +117,6 @@ func ProcessIDPrefix(chainID uint32, contractAddr common.Address) []byte {
 	copy(buf[4:], contractAddr.Bytes())
 	// Keccak-256 (Ethereum's legacy Keccak, not NIST SHA3)
 	sum := crypto.Keccak256(buf[:])
-	// Take the last 4 bytes (least-significant 32 bits) as the prefix
+	// Take the last 4 bytes (least-significant 32 bits) as the version
 	return sum[len(sum)-4:]
 }


### PR DESCRIPTION
Now the processID is calculated as:

```
keccak(ChainID + Contract addr) (4 bytes) - Creatoe addr (20 bytes) - Nonce (8 bytes)
```

Closes #208 