### PR TITLE
web3/rpc: implement endpoint-switching retry with cooldown to prevent…

### DIFF
--- a/web3/rpc/web3_iter.go
+++ b/web3/rpc/web3_iter.go
@@ -3,20 +3,27 @@ package rpc
 import (
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/rpc"
+)
+
+const (
+	// endpointCooldownDuration is how long to wait before re-enabling a disabled endpoint
+	endpointCooldownDuration = 5 * time.Minute
 )
 
 // Web3Endpoint struct contains all the required information about a web3
 // provider based on its URI. It includes its chain ID, its name (and shortName)
 // and the URI.
 type Web3Endpoint struct {
-	ChainID   uint64 `json:"chainId"`
-	URI       string
-	IsArchive bool
-	client    *ethclient.Client
-	rpcClient *rpc.Client
+	ChainID    uint64 `json:"chainId"`
+	URI        string
+	IsArchive  bool
+	client     *ethclient.Client
+	rpcClient  *rpc.Client
+	disabledAt time.Time // When this endpoint was disabled (zero if never disabled)
 }
 
 // Web3Iterator struct is a pool of Web3Endpoint that allows to get the next
@@ -63,15 +70,18 @@ func (w3pp *Web3Iterator) Add(endpoint ...*Web3Endpoint) {
 }
 
 // Next returns the next available endpoint in a round-robin fashion. If
-// there are no registered endpoints, it will return an error. If there are no
-// available endpoints, it will reset the disabled endpoints and return the
-// first available endpoint.
+// there are no registered endpoints, it will return an error. It also checks
+// for disabled endpoints that have passed their cooldown period and re-enables them.
 func (w3pp *Web3Iterator) Next() (*Web3Endpoint, error) {
 	if w3pp == nil {
 		return nil, fmt.Errorf("nil Web3Iterator")
 	}
 	w3pp.mtx.Lock()
 	defer w3pp.mtx.Unlock()
+
+	// Check if any disabled endpoints have passed their cooldown period
+	w3pp.checkCooldowns()
+
 	l := len(w3pp.available)
 	if l == 0 {
 		return nil, fmt.Errorf("no registered endpoints")
@@ -90,37 +100,79 @@ func (w3pp *Web3Iterator) Next() (*Web3Endpoint, error) {
 	return currentEndpoint, nil
 }
 
+// checkCooldowns checks if any disabled endpoints have passed their cooldown
+// period and re-enables them. Must be called with mutex locked.
+func (w3pp *Web3Iterator) checkCooldowns() {
+	if len(w3pp.disabled) == 0 {
+		return
+	}
+
+	now := time.Now()
+	var stillDisabled []*Web3Endpoint
+
+	for _, ep := range w3pp.disabled {
+		// Check if cooldown period has passed
+		if now.Sub(ep.disabledAt) >= endpointCooldownDuration {
+			// Re-enable this endpoint
+			ep.disabledAt = time.Time{} // Clear the disabled timestamp
+			w3pp.available = append(w3pp.available, ep)
+		} else {
+			// Still in cooldown
+			stillDisabled = append(stillDisabled, ep)
+		}
+	}
+
+	w3pp.disabled = stillDisabled
+}
+
 // Disable method disables an endpoint, moving it from the available list to the
-// the disabled list.
+// the disabled list. It records the time when the endpoint was disabled for
+// cooldown tracking.
 func (w3pp *Web3Iterator) Disable(uri string) {
 	w3pp.mtx.Lock()
 	defer w3pp.mtx.Unlock()
-	// get the index of the endpoint to disable
-	var index int
+
+	// Find the index of the endpoint to disable
+	index := -1
 	for i, e := range w3pp.available {
 		if e.URI == uri {
 			index = i
 			break
 		}
 	}
-	// get the endpoint to disable and move it to the disabled list
+
+	// If endpoint not found in available list, it may already be disabled or never existed
+	if index == -1 {
+		return
+	}
+
+	// Get the endpoint to disable and move it to the disabled list
 	disabledEndpoint := w3pp.available[index]
+	disabledEndpoint.disabledAt = time.Now() // Record when it was disabled
 	w3pp.available = append(w3pp.available[:index], w3pp.available[index+1:]...)
 	w3pp.disabled = append(w3pp.disabled, disabledEndpoint)
-	// if the next index is the one to disable, update it to the next one
+
+	// If the next index is the one we just disabled, update it to the next one
 	if w3pp.nextIndex == index {
 		w3pp.nextIndex++
+	} else if w3pp.nextIndex > index {
+		// If next index was after the disabled one, decrement it since we removed an element
+		w3pp.nextIndex--
 	}
-	// if there are no available endpoints, reset all the disabled ones to
+
+	// If there are no available endpoints, reset all the disabled ones to
 	// available ones and reset the next index to the first one
-	if l := len(w3pp.available); l == 0 {
-		// reset the next index and move the disabled endpoints to the available
+	if len(w3pp.available) == 0 {
+		// Reset the next index and move the disabled endpoints to the available
 		w3pp.nextIndex = 0
 		w3pp.available = append(w3pp.available, w3pp.disabled...)
 		w3pp.disabled = make([]*Web3Endpoint, 0)
-	}
-	// if the next index is out of bounds, reset it to the first one
-	if w3pp.nextIndex >= len(w3pp.available) {
+		// Clear disabled timestamps since they're back in rotation
+		for _, ep := range w3pp.available {
+			ep.disabledAt = time.Time{}
+		}
+	} else if w3pp.nextIndex >= len(w3pp.available) {
+		// If the next index is out of bounds, reset it to the first one
 		w3pp.nextIndex = 0
 	}
 }

--- a/web3/rpc/web3_pool.go
+++ b/web3/rpc/web3_pool.go
@@ -148,7 +148,25 @@ func (nm *Web3Pool) Endpoint(chainID uint64) (*Web3Endpoint, error) {
 // in the chainID provided.
 func (nm *Web3Pool) DisableEndpoint(chainID uint64, uri string) {
 	if endpoints, ok := nm.endpoints[chainID]; ok {
+		availableBefore := endpoints.Available()
 		endpoints.Disable(uri)
+		availableAfter := endpoints.Available()
+
+		// Log the disable operation
+		if availableBefore != availableAfter {
+			log.Warnw("endpoint disabled",
+				"chainID", chainID,
+				"uri", uri,
+				"availableEndpoints", availableAfter,
+				"disabledEndpoints", endpoints.Disabled())
+
+			// If all endpoints were disabled and got reset, log that too
+			if availableAfter > availableBefore {
+				log.Infow("all endpoints were disabled, reset to available",
+					"chainID", chainID,
+					"resetEndpoints", availableAfter)
+			}
+		}
 	}
 }
 

--- a/web3/rpc/web3_pool_test.go
+++ b/web3/rpc/web3_pool_test.go
@@ -1,0 +1,321 @@
+package rpc
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// TestEndpointSwitchingOnFailure tests that when an endpoint fails,
+// the retry mechanism switches to the next available endpoint
+func TestEndpointSwitchingOnFailure(t *testing.T) {
+	c := qt.New(t)
+	pool := NewWeb3Pool()
+
+	// Create a mock iterator with multiple endpoints
+	endpoints := []*Web3Endpoint{
+		{ChainID: 1, URI: "http://endpoint1.example.com"},
+		{ChainID: 1, URI: "http://endpoint2.example.com"},
+		{ChainID: 1, URI: "http://endpoint3.example.com"},
+	}
+
+	pool.endpoints[1] = NewWeb3Iterator(endpoints...)
+
+	// Verify initial state
+	c.Assert(pool.NumberOfEndpoints(1, true), qt.Equals, 3)
+
+	// Disable first endpoint
+	pool.DisableEndpoint(1, "http://endpoint1.example.com")
+	c.Assert(pool.NumberOfEndpoints(1, true), qt.Equals, 2)
+	c.Assert(pool.NumberOfEndpoints(1, false), qt.Equals, 3)
+
+	// Disable second endpoint
+	pool.DisableEndpoint(1, "http://endpoint2.example.com")
+	c.Assert(pool.NumberOfEndpoints(1, true), qt.Equals, 1)
+
+	// Disable third endpoint - should trigger reset
+	pool.DisableEndpoint(1, "http://endpoint3.example.com")
+
+	// After disabling all endpoints, they should be reset to available
+	c.Assert(pool.NumberOfEndpoints(1, true), qt.Equals, 3)
+}
+
+// TestDisableNonExistentEndpoint tests that disabling a non-existent endpoint
+// doesn't cause issues (race condition fix)
+func TestDisableNonExistentEndpoint(t *testing.T) {
+	c := qt.New(t)
+	pool := NewWeb3Pool()
+
+	endpoints := []*Web3Endpoint{
+		{ChainID: 1, URI: "http://endpoint1.example.com"},
+		{ChainID: 1, URI: "http://endpoint2.example.com"},
+	}
+
+	pool.endpoints[1] = NewWeb3Iterator(endpoints...)
+
+	// Try to disable an endpoint that doesn't exist
+	pool.DisableEndpoint(1, "http://nonexistent.example.com")
+
+	// Should still have 2 available endpoints
+	c.Assert(pool.NumberOfEndpoints(1, true), qt.Equals, 2)
+
+	// Try to disable from a chainID that doesn't exist
+	pool.DisableEndpoint(999, "http://endpoint1.example.com")
+
+	// Original chain should still have 2 endpoints
+	c.Assert(pool.NumberOfEndpoints(1, true), qt.Equals, 2)
+}
+
+// TestIteratorRoundRobin tests that the iterator properly cycles through endpoints
+func TestIteratorRoundRobin(t *testing.T) {
+	c := qt.New(t)
+	endpoints := []*Web3Endpoint{
+		{ChainID: 1, URI: "http://endpoint1.example.com"},
+		{ChainID: 1, URI: "http://endpoint2.example.com"},
+		{ChainID: 1, URI: "http://endpoint3.example.com"},
+	}
+
+	iter := NewWeb3Iterator(endpoints...)
+
+	// Get endpoints in round-robin fashion
+	ep1, err := iter.Next()
+	c.Assert(err, qt.IsNil)
+	c.Assert(ep1.URI, qt.Equals, "http://endpoint1.example.com")
+
+	ep2, err := iter.Next()
+	c.Assert(err, qt.IsNil)
+	c.Assert(ep2.URI, qt.Equals, "http://endpoint2.example.com")
+
+	ep3, err := iter.Next()
+	c.Assert(err, qt.IsNil)
+	c.Assert(ep3.URI, qt.Equals, "http://endpoint3.example.com")
+
+	// Should wrap around to first endpoint
+	ep4, err := iter.Next()
+	c.Assert(err, qt.IsNil)
+	c.Assert(ep4.URI, qt.Equals, "http://endpoint1.example.com")
+}
+
+// TestIteratorDisableAndNext tests that disabling an endpoint properly updates the next index
+func TestIteratorDisableAndNext(t *testing.T) {
+	c := qt.New(t)
+	endpoints := []*Web3Endpoint{
+		{ChainID: 1, URI: "http://endpoint1.example.com"},
+		{ChainID: 1, URI: "http://endpoint2.example.com"},
+		{ChainID: 1, URI: "http://endpoint3.example.com"},
+	}
+
+	iter := NewWeb3Iterator(endpoints...)
+
+	// Get first endpoint (nextIndex moves to 1, pointing to endpoint2)
+	ep1, err := iter.Next()
+	c.Assert(err, qt.IsNil)
+	c.Assert(ep1.URI, qt.Equals, "http://endpoint1.example.com")
+
+	// Disable the second endpoint (at index 1, which is where nextIndex points)
+	// After removal: [endpoint1, endpoint3], nextIndex stays at 1 but gets decremented to 0
+	// because we removed an element before it
+	iter.Disable("http://endpoint2.example.com")
+
+	// Next should return endpoint1 (at index 0, since nextIndex was adjusted)
+	// Then nextIndex moves to 1
+	ep2, err := iter.Next()
+	c.Assert(err, qt.IsNil)
+	c.Assert(ep2.URI, qt.Equals, "http://endpoint1.example.com")
+
+	// Next should return endpoint3 (at index 1)
+	ep3, err := iter.Next()
+	c.Assert(err, qt.IsNil)
+	c.Assert(ep3.URI, qt.Equals, "http://endpoint3.example.com")
+}
+
+// TestIteratorDisableCurrentEndpoint tests disabling the current endpoint
+func TestIteratorDisableCurrentEndpoint(t *testing.T) {
+	c := qt.New(t)
+	endpoints := []*Web3Endpoint{
+		{ChainID: 1, URI: "http://endpoint1.example.com"},
+		{ChainID: 1, URI: "http://endpoint2.example.com"},
+		{ChainID: 1, URI: "http://endpoint3.example.com"},
+	}
+
+	iter := NewWeb3Iterator(endpoints...)
+
+	// Get first endpoint
+	ep1, err := iter.Next()
+	c.Assert(err, qt.IsNil)
+
+	// Disable the first endpoint (the one we just got, but next index is now at 1)
+	iter.Disable(ep1.URI)
+
+	// Next should return endpoint2 (index 0 after removal, but nextIndex was adjusted)
+	ep2, err := iter.Next()
+	c.Assert(err, qt.IsNil)
+	c.Assert(ep2.URI, qt.Equals, "http://endpoint2.example.com")
+}
+
+// TestIteratorEmptyPool tests behavior with no endpoints
+func TestIteratorEmptyPool(t *testing.T) {
+	c := qt.New(t)
+	iter := NewWeb3Iterator()
+
+	_, err := iter.Next()
+	c.Assert(err, qt.Not(qt.IsNil))
+
+	c.Assert(iter.Available(), qt.Equals, 0)
+}
+
+// TestIteratorAllDisabled tests that all endpoints get reset when all are disabled
+func TestIteratorAllDisabled(t *testing.T) {
+	c := qt.New(t)
+	endpoints := []*Web3Endpoint{
+		{ChainID: 1, URI: "http://endpoint1.example.com"},
+		{ChainID: 1, URI: "http://endpoint2.example.com"},
+	}
+
+	iter := NewWeb3Iterator(endpoints...)
+
+	// Disable all endpoints
+	iter.Disable("http://endpoint1.example.com")
+	c.Assert(iter.Available(), qt.Equals, 1)
+
+	iter.Disable("http://endpoint2.example.com")
+
+	// Should have reset all to available
+	c.Assert(iter.Available(), qt.Equals, 2)
+	c.Assert(iter.Disabled(), qt.Equals, 0)
+}
+
+// TestConcurrentAccess tests that concurrent access to the iterator is safe
+func TestConcurrentAccess(t *testing.T) {
+	c := qt.New(t)
+	endpoints := []*Web3Endpoint{
+		{ChainID: 1, URI: "http://endpoint1.example.com"},
+		{ChainID: 1, URI: "http://endpoint2.example.com"},
+		{ChainID: 1, URI: "http://endpoint3.example.com"},
+	}
+
+	iter := NewWeb3Iterator(endpoints...)
+
+	// Run multiple goroutines accessing the iterator concurrently
+	done := make(chan bool)
+	for i := 0; i < 10; i++ {
+		go func() {
+			for j := 0; j < 100; j++ {
+				_, _ = iter.Next()
+				time.Sleep(time.Microsecond)
+			}
+			done <- true
+		}()
+	}
+
+	// Also disable endpoints concurrently
+	go func() {
+		for i := 0; i < 10; i++ {
+			iter.Disable("http://endpoint1.example.com")
+			time.Sleep(time.Millisecond)
+		}
+		done <- true
+	}()
+
+	// Wait for all goroutines
+	for i := 0; i < 11; i++ {
+		<-done
+	}
+
+	// Should still be in a valid state
+	c.Assert(iter.Available() >= 0, qt.IsTrue)
+}
+
+// TestRetryLogic tests the retry logic with endpoint switching
+func TestRetryLogic(t *testing.T) {
+	c := qt.New(t)
+	pool := NewWeb3Pool()
+
+	endpoints := []*Web3Endpoint{
+		{ChainID: 1, URI: "http://endpoint1.example.com"},
+		{ChainID: 1, URI: "http://endpoint2.example.com"},
+	}
+
+	pool.endpoints[1] = NewWeb3Iterator(endpoints...)
+
+	client := &Client{
+		w3p:     pool,
+		chainID: 1,
+	}
+
+	// Test that retryAndCheckErr properly tracks endpoints
+	callCount := 0
+	testErr := errors.New("test error")
+
+	_, err := client.retryAndCheckErr(func(endpoint *Web3Endpoint) (any, error) {
+		callCount++
+		// Fail for the first endpoint's retries
+		if callCount <= defaultRetries {
+			return nil, testErr
+		}
+		// Succeed on second endpoint
+		return "success", nil
+	})
+
+	c.Assert(err, qt.IsNil)
+
+	// Should have tried first endpoint 3 times, then succeeded on second endpoint
+	c.Assert(callCount, qt.Equals, defaultRetries+1)
+}
+
+// TestRetryAllEndpointsFail tests that when all endpoints fail, proper error is returned
+func TestRetryAllEndpointsFail(t *testing.T) {
+	c := qt.New(t)
+	pool := NewWeb3Pool()
+
+	endpoints := []*Web3Endpoint{
+		{ChainID: 1, URI: "http://endpoint1.example.com"},
+		{ChainID: 1, URI: "http://endpoint2.example.com"},
+	}
+
+	pool.endpoints[1] = NewWeb3Iterator(endpoints...)
+
+	client := &Client{
+		w3p:     pool,
+		chainID: 1,
+	}
+
+	testErr := errors.New("test error")
+
+	_, err := client.retryAndCheckErr(func(endpoint *Web3Endpoint) (any, error) {
+		return nil, testErr
+	})
+
+	c.Assert(err, qt.Not(qt.IsNil))
+
+	// All endpoints should have been tried and disabled, then reset
+	c.Assert(pool.NumberOfEndpoints(1, true), qt.Equals, 2)
+}
+
+// TestNoEndpointsAvailable tests behavior when no endpoints are configured
+func TestNoEndpointsAvailable(t *testing.T) {
+	c := qt.New(t)
+	pool := NewWeb3Pool()
+
+	client := &Client{
+		w3p:     pool,
+		chainID: 999, // Non-existent chain
+	}
+
+	_, err := client.retryAndCheckErr(func(endpoint *Web3Endpoint) (any, error) {
+		return nil, nil
+	})
+
+	c.Assert(err, qt.Not(qt.IsNil))
+}
+
+// TestPoolInitialization tests that the pool is properly initialized
+func TestPoolInitialization(t *testing.T) {
+	c := qt.New(t)
+	pool := NewWeb3Pool()
+
+	c.Assert(pool.endpoints, qt.Not(qt.IsNil))
+	c.Assert(len(pool.endpoints), qt.Equals, 0)
+}


### PR DESCRIPTION
… RPC call loss

When a web3 RPC fails, the same query is sent to another RPC endpoint (if available).

In addition, fixed race condition in Disable() method.

Taken some ideas from closed PR #220