### PR TITLE
web3: use V1 sidecars (Fusaka update)

### DIFF
--- a/web3/blobs.go
+++ b/web3/blobs.go
@@ -315,6 +315,9 @@ func BuildBlobsSidecar(raw [][]byte) (*types.BlobTxSidecar, []common.Hash, error
 		Commitments: comms,
 		Proofs:      proofs,
 	}
+	if err := sc.ToV1(); err != nil { // TODO: construct a V1 from the start, rather than the calling ToV1()
+		return nil, nil, fmt.Errorf("failed to convert sidecar to v1: %w", err)
+	}
 	return sc, sc.BlobHashes(), nil
 }
 


### PR DESCRIPTION
since last week, `go run ./cmd/send-blob` fails with `legacy blob tx is not supported` 

this is due to a sepolia update
see https://blog.ethereum.org/2025/10/15/fusaka-blob-update


i can't confirm if v1 sidecars are accepted in mainnet, i've tried to send a blob tx on mainnet but failed and a quick debugging didn't help. i didn't look further.
