### PR TITLE
migrate blob transactions to EIP-7594 cell proofs for Fusaka compatibility

### DIFF
--- a/sequencer/statetransition.go
+++ b/sequencer/statetransition.go
@@ -172,6 +172,11 @@ func (s *Sequencer) processPendingTransitions() {
 		}
 
 		// Store the proof in the state transition storage
+		// Note: We store the first cell proof in BlobProof for the ABI encoding.
+		// The full sidecar with all 128 cell proofs is stored separately.
+		var firstCellProof [48]byte
+		copy(firstCellProof[:], blobData.CellProofs[0][:])
+
 		if err := s.stg.PushStateTransitionBatch(&storage.StateTransitionBatch{
 			ProcessID: batch.ProcessID,
 			BatchID:   batchID,
@@ -185,7 +190,7 @@ func (s *Sequencer) processPendingTransitions() {
 				BlobEvaluationPointZ: blobData.Z,
 				BlobEvaluationPointY: blobData.Ylimbs,
 				BlobCommitment:       blobData.Commitment,
-				BlobProof:            blobData.Proof,
+				BlobProof:            firstCellProof,
 			},
 			BlobVersionHash: blobHashes[0],
 			BlobSidecar:     blobSidecar,


### PR DESCRIPTION
The error was caused by attempting to verify blob transactions using the old VerifyBlobProof() function with single 48-byte blob proofs, but after Fusaka, blob transactions require 128 cell proofs (48 bytes each) per blob for data availability sampling.

Fix #237 