### PR TITLE
sequencer: pass OpeningProof to contract rather than first cell proof

### DIFF
--- a/crypto/blobs/blobs.go
+++ b/crypto/blobs/blobs.go
@@ -58,6 +58,8 @@ type BlobEvalData struct {
 	Y          *big.Int
 	Ylimbs     [4]*big.Int
 	Blob       goethkzg.Blob
+	// Opening proof for point-evaluation precompile (integrity check)
+	OpeningProof [CompressedG1Size]byte
 	// Cell proofs for EIP-7594 (Fusaka upgrade)
 	// Each blob has CellsPerExtBlob (128) cell proofs
 	CellProofs [goethkzg.CellsPerExtBlob]goethkzg.KZGProof
@@ -74,11 +76,12 @@ func (b *BlobEvalData) Set(blob *goethkzg.Blob, z *big.Int) (*BlobEvalData, erro
 	}
 	b.Commitment = commitment
 
-	// Compute the point evaluation proof to get the claim (y value)
-	_, claim, err := ComputeProof(blob, z)
+	// Compute the point evaluation proof to get the claim (y value) and OpeningProof
+	openingProof, claim, err := ComputeProof(blob, z)
 	if err != nil {
 		return nil, err
 	}
+	b.OpeningProof = openingProof
 
 	// Compute cell proofs for EIP-7594 (Fusaka upgrade)
 	_, cellProofs, err := kzgContext.ComputeCellsAndKZGProofs(blob, 0)

--- a/sequencer/statetransition.go
+++ b/sequencer/statetransition.go
@@ -172,11 +172,6 @@ func (s *Sequencer) processPendingTransitions() {
 		}
 
 		// Store the proof in the state transition storage
-		// Note: We store the first cell proof in BlobProof for the ABI encoding.
-		// The full sidecar with all 128 cell proofs is stored separately.
-		var firstCellProof [48]byte
-		copy(firstCellProof[:], blobData.CellProofs[0][:])
-
 		if err := s.stg.PushStateTransitionBatch(&storage.StateTransitionBatch{
 			ProcessID: batch.ProcessID,
 			BatchID:   batchID,
@@ -190,7 +185,7 @@ func (s *Sequencer) processPendingTransitions() {
 				BlobEvaluationPointZ: blobData.Z,
 				BlobEvaluationPointY: blobData.Ylimbs,
 				BlobCommitment:       blobData.Commitment,
-				BlobProof:            firstCellProof,
+				BlobProof:            blobData.OpeningProof,
 			},
 			BlobVersionHash: blobHashes[0],
 			BlobSidecar:     blobSidecar,


### PR DESCRIPTION
hotfixes a bug introduced in https://github.com/vocdoni/davinci-node/pull/238