### PR TITLE
drop direct import of crate-crypto, use gethkzg instead

### DIFF
--- a/crypto/blobs/barycentric_eval.go
+++ b/crypto/blobs/barycentric_eval.go
@@ -5,7 +5,7 @@ import (
 	"math/big"
 
 	fr "github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
-	goethkzg "github.com/crate-crypto/go-eth-kzg"
+	gethkzg "github.com/ethereum/go-ethereum/crypto/kzg4844"
 )
 
 // EvaluateBlobBarycentric evaluates a polynomial in evaluation form using the barycentric formula.
@@ -20,7 +20,7 @@ import (
 //   - dᵢ are the blob data values (polynomial evaluations at domain points)
 //   - ωᵢ are the roots of unity forming the evaluation domain
 //   - z is the evaluation point
-func EvaluateBlobBarycentricNativeGo(blob *goethkzg.Blob, z *big.Int, debug bool) (*big.Int, error) {
+func EvaluateBlobBarycentricNativeGo(blob *gethkzg.Blob, z *big.Int, debug bool) (*big.Int, error) {
 	if len(blob) != 32*4096 {
 		return nil, fmt.Errorf("blob length is %d, want 131072", len(blob))
 	}
@@ -180,7 +180,7 @@ func EvaluateBlobBarycentricNativeGo(blob *goethkzg.Blob, z *big.Int, debug bool
 
 // blobCell extracts the i-th 32-byte element from the blob and converts it to a big integer.
 // The blob stores field elements in big-endian format.
-func blobCell(blob *goethkzg.Blob, i int) *big.Int {
+func blobCell(blob *gethkzg.Blob, i int) *big.Int {
 	start := i * 32
 	return new(big.Int).SetBytes(blob[start : start+32])
 }

--- a/crypto/blobs/barycentric_eval_test.go
+++ b/crypto/blobs/barycentric_eval_test.go
@@ -7,14 +7,14 @@ import (
 	"os"
 	"testing"
 
-	goethkzg "github.com/crate-crypto/go-eth-kzg"
+	gethkzg "github.com/ethereum/go-ethereum/crypto/kzg4844"
 	qt "github.com/frankban/quicktest"
 	"github.com/vocdoni/davinci-node/util"
 )
 
 func TestBarycentricEvalGo(t *testing.T) {
 	// Create blob with direct values (these ARE the polynomial evaluations)
-	blob := &goethkzg.Blob{}
+	blob := &gethkzg.Blob{}
 	for i := 0; i < 20; i++ {
 		big.NewInt(int64(i + 1)).FillBytes(blob[i*32 : (i+1)*32])
 	}
@@ -27,7 +27,7 @@ func TestBarycentricEvalGo(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil, qt.Commentf("ComputeEvaluationPoint should not return an error"))
 
 	// Ground truth from the KZG precompile
-	_, claim, _ := ComputeProof(blob, z)
+	_, claim, _ := gethkzg.ComputeProof(blob, BigIntToPoint(z))
 	want := new(big.Int).SetBytes(claim[:])
 
 	// Evaluate using the barycentric formula
@@ -55,7 +55,7 @@ func TestBarycentricEvalGoBlobData1(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil, qt.Commentf("ComputeEvaluationPoint should not return an error"))
 
 	// Ground truth from the KZG precompile
-	_, claim, _ := ComputeProof(blob, z)
+	_, claim, _ := gethkzg.ComputeProof(blob, BigIntToPoint(z))
 	want := new(big.Int).SetBytes(claim[:])
 
 	// Evaluate
@@ -81,7 +81,7 @@ func TestBarycentricEvalGoBlobData2(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil, qt.Commentf("ComputeEvaluationPoint should not return an error"))
 
 	// Ground truth from the KZG precompile
-	_, claim, _ := ComputeProof(blob, z)
+	_, claim, _ := gethkzg.ComputeProof(blob, BigIntToPoint(z))
 	want := new(big.Int).SetBytes(claim[:])
 
 	// Evaluate
@@ -90,8 +90,8 @@ func TestBarycentricEvalGoBlobData2(t *testing.T) {
 	qt.Assert(c, want.Cmp(got), qt.Equals, 0, qt.Commentf("Expected and got values should match"))
 }
 
-func hexStrToBlob(hexStr string) (*goethkzg.Blob, error) {
-	var blob goethkzg.Blob
+func hexStrToBlob(hexStr string) (*gethkzg.Blob, error) {
+	var blob gethkzg.Blob
 	byts, err := hexStrToBytes(hexStr)
 	if err != nil {
 		return nil, err

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/cockroachdb/pebble v1.1.5
 	github.com/consensys/gnark v0.13.0
 	github.com/consensys/gnark-crypto v0.19.0
-	github.com/crate-crypto/go-eth-kzg v1.4.0
 	github.com/ethereum/go-ethereum v1.16.5
 	github.com/frankban/quicktest v1.14.6
 	github.com/fxamacker/cbor/v2 v2.9.0
@@ -84,6 +83,7 @@ require (
 	github.com/containerd/ttrpc v1.2.5 // indirect
 	github.com/containerd/typeurl/v2 v2.1.1 // indirect
 	github.com/cpuguy83/dockercfg v0.3.2 // indirect
+	github.com/crate-crypto/go-eth-kzg v1.4.0 // indirect
 	github.com/crate-crypto/go-ipa v0.0.0-20240724233137-53bbb0ceb27a // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dchest/blake512 v1.0.0 // indirect

--- a/sequencer/onchain.go
+++ b/sequencer/onchain.go
@@ -7,7 +7,7 @@ import (
 
 	gethkzg "github.com/ethereum/go-ethereum/crypto/kzg4844"
 
-	ethereumtypes "github.com/ethereum/go-ethereum/core/types"
+	gethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/vocdoni/davinci-node/log"
 	"github.com/vocdoni/davinci-node/solidity"
 	"github.com/vocdoni/davinci-node/storage"
@@ -132,7 +132,7 @@ func (s *Sequencer) pushTransitionToContract(
 	processID types.HexBytes,
 	proof *solidity.Groth16CommitmentProof,
 	inputs storage.StateTransitionBatchProofInputs,
-	blobSidecar *ethereumtypes.BlobTxSidecar,
+	blobSidecar *gethtypes.BlobTxSidecar,
 ) error {
 	var pid32 [32]byte
 	copy(pid32[:], processID)
@@ -158,9 +158,9 @@ func (s *Sequencer) pushTransitionToContract(
 	// Cell proofs are verified during their generation in ComputeCellsAndKZGProofs.
 	if s.contracts.SupportBlobTxs() {
 		// Verify sidecar version and structure
-		if blobSidecar.Version != ethereumtypes.BlobSidecarVersion1 {
+		if blobSidecar.Version != gethtypes.BlobSidecarVersion1 {
 			return fmt.Errorf("unexpected blob sidecar version: got %d, expected %d",
-				blobSidecar.Version, ethereumtypes.BlobSidecarVersion1)
+				blobSidecar.Version, gethtypes.BlobSidecarVersion1)
 		}
 		// Verify we have the correct number of cell proofs (128 per blob)
 		expectedProofs := len(blobSidecar.Blobs) * gethkzg.CellProofsPerBlob

--- a/sequencer/statetransition.go
+++ b/sequencer/statetransition.go
@@ -137,21 +137,14 @@ func (s *Sequencer) processPendingTransitions() {
 		}
 
 		// Get blob sidecar and hash
-		blobSidecar, blobHashes, err := blobData.TxSidecar()
-		if err != nil {
-			log.Errorw(err, "failed to get blob sidecar")
-			if err := s.stg.MarkAggregatorBatchFailed(batchID); err != nil {
-				log.Errorw(err, "failed to mark ballot batch as failed")
-			}
-			return true // Continue to next process ID
-		}
+		blobSidecar := blobData.TxSidecar()
 
 		log.Infow("state transition proof generated",
 			"took", time.Since(startTime).String(),
 			"pid", processID.String(),
 			"rootHashBefore", root.String(),
 			"rootHashAfter", rootHashAfter.String(),
-			"blobHash", blobHashes[0].String(),
+			"blobHash", blobSidecar.BlobHashes()[0].String(),
 		)
 
 		p := proof.(*groth16_bn254.Proof)
@@ -187,7 +180,7 @@ func (s *Sequencer) processPendingTransitions() {
 				BlobCommitment:       blobData.Commitment,
 				BlobProof:            blobData.OpeningProof,
 			},
-			BlobVersionHash: blobHashes[0],
+			BlobVersionHash: blobSidecar.BlobHashes()[0],
 			BlobSidecar:     blobSidecar,
 		}); err != nil {
 			log.Errorw(err, "failed to push state transition batch")

--- a/state/blobs_test.go
+++ b/state/blobs_test.go
@@ -1,11 +1,13 @@
 package state
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"math/big"
 	"testing"
 
-	kzg4844 "github.com/crate-crypto/go-eth-kzg"
+	gethkzg "github.com/ethereum/go-ethereum/crypto/kzg4844"
+
 	qt "github.com/frankban/quicktest"
 	"github.com/vocdoni/arbo/memdb"
 	"github.com/vocdoni/davinci-node/circuits"
@@ -191,7 +193,6 @@ func TestBlobStateTransition(t *testing.T) {
 	// Store blobs and roots for each transition
 	type TransitionData struct {
 		Blob     *blobs.BlobEvalData
-		Proof    kzg4844.KZGProof
 		Root     *big.Int
 		Votes    []*Vote
 		BatchNum uint64
@@ -230,7 +231,6 @@ func TestBlobStateTransition(t *testing.T) {
 		// Store the first cell proof for compatibility with the test structure.
 		transitions[i] = TransitionData{
 			Blob:     blob,
-			Proof:    blob.CellProofs[0],
 			Root:     root,
 			Votes:    votes,
 			BatchNum: batchNum,
@@ -246,10 +246,9 @@ func TestBlobStateTransition(t *testing.T) {
 	// Verify KZG commitment for first transition
 	t.Run("VerifyKZGCommitment_First", func(t *testing.T) {
 		firstTransition := transitions[0]
-		_, hash, err := firstTransition.Blob.TxSidecar()
 		c.Assert(err, qt.IsNil, qt.Commentf("Failed to get tx sidecar for first transition"))
-		verifyKZGCommitment(t, &firstTransition.Blob.Blob, new(big.Int).SetBytes(firstTransition.Blob.Commitment[:]),
-			firstTransition.Proof, firstTransition.Blob.Z, firstTransition.Blob.Y, hash[0])
+		verifyKZGCommitment(t, &firstTransition.Blob.Blob, &firstTransition.Blob.Commitment,
+			firstTransition.Blob.Z, firstTransition.Blob.Y, firstTransition.Blob.TxSidecar().BlobHashes()[0])
 	})
 
 	// Verify blob structure for last transition
@@ -261,10 +260,9 @@ func TestBlobStateTransition(t *testing.T) {
 	// Verify KZG commitment for last transition
 	t.Run("VerifyKZGCommitment_Last", func(t *testing.T) {
 		lastTransition := transitions[numTransitions-1]
-		_, hash, err := lastTransition.Blob.TxSidecar()
 		c.Assert(err, qt.IsNil, qt.Commentf("Failed to get tx sidecar for last transition"))
-		verifyKZGCommitment(t, &lastTransition.Blob.Blob, new(big.Int).SetBytes(lastTransition.Blob.Commitment[:]),
-			lastTransition.Proof, lastTransition.Blob.Z, lastTransition.Blob.Y, hash[0])
+		verifyKZGCommitment(t, &lastTransition.Blob.Blob, &lastTransition.Blob.Commitment,
+			lastTransition.Blob.Z, lastTransition.Blob.Y, lastTransition.Blob.TxSidecar().BlobHashes()[0])
 	})
 
 	// Test state restoration for first transition
@@ -443,7 +441,7 @@ func createTestVotesWithOffset(t *testing.T, publicKey ecc.Point, numVotes int, 
 	return votes
 }
 
-func verifyBlobStructureBasic(t *testing.T, blob *kzg4844.Blob, votes []*Vote) {
+func verifyBlobStructureBasic(t *testing.T, blob *gethkzg.Blob, votes []*Vote) {
 	c := qt.New(t)
 	// Parse blob data
 	blobData, err := ParseBlobData(blob)
@@ -483,16 +481,16 @@ func verifyBlobStructureBasic(t *testing.T, blob *kzg4844.Blob, votes []*Vote) {
 	c.Assert(len(blobData.ResultsSub), qt.Equals, 32, qt.Commentf("Expected 32 ResultsSub coordinates, got %d", len(blobData.ResultsSub)))
 }
 
-func verifyKZGCommitment(t *testing.T, blob *kzg4844.Blob, commit *big.Int, proof kzg4844.KZGProof, z, y *big.Int, versionedHash [32]byte) {
+func verifyKZGCommitment(t *testing.T, blob *gethkzg.Blob, commit *gethkzg.Commitment, z, y *big.Int, versionedHash [32]byte) {
 	c := qt.New(t)
 	// Verify commitment can be regenerated from blob
-	recomputedCommit, err := blobs.BlobToCommitment(blob)
+	recomputedCommit, err := gethkzg.BlobToCommitment(blob)
 	c.Assert(err, qt.IsNil, qt.Commentf("Failed to recompute commitment"))
 
-	c.Assert(string(commit.Bytes()), qt.Equals, string(recomputedCommit[:]), qt.Commentf("Commitment mismatch"))
+	c.Assert(commit, qt.DeepEquals, &recomputedCommit, qt.Commentf("Commitment mismatch"))
 
 	// Verify versioned hash format using the same method as the implementation
-	expectedVersionedHash := blobs.CalcBlobHashV1(commit)
+	expectedVersionedHash := gethkzg.CalcBlobHashV1(sha256.New(), commit)
 
 	c.Assert(versionedHash, qt.Equals, expectedVersionedHash, qt.Commentf("Versioned hash mismatch"))
 
@@ -501,14 +499,14 @@ func verifyKZGCommitment(t *testing.T, blob *kzg4844.Blob, commit *big.Int, proo
 	c.Assert(z.Cmp(maxZ) <= 0, qt.IsTrue, qt.Commentf("z value exceeds 250-bit range"))
 
 	// Verify y value by computing point evaluation separately (just for verification)
-	_, claim, err := blobs.ComputeProof(blob, z)
+	_, claim, err := gethkzg.ComputeProof(blob, blobs.BigIntToPoint(z))
 	c.Assert(err, qt.IsNil, qt.Commentf("Failed to compute point evaluation"))
 
 	recomputedY := new(big.Int).SetBytes(claim[:])
 	c.Assert(y.Cmp(recomputedY), qt.Equals, 0, qt.Commentf("KZG evaluation (y value) mismatch"))
 }
 
-func restoreStateFromBlob(t *testing.T, blob *kzg4844.Blob, processID, censusRoot *big.Int, ballotMode types.BallotMode, encryptionKey ecc.Point, expectedRoot *big.Int) {
+func restoreStateFromBlob(t *testing.T, blob *gethkzg.Blob, processID, censusRoot *big.Int, ballotMode types.BallotMode, encryptionKey ecc.Point, expectedRoot *big.Int) {
 	c := qt.New(t)
 	// Parse blob data
 	blobData, err := ParseBlobData(blob)
@@ -587,7 +585,7 @@ func TestBlobDataParsing(t *testing.T) {
 		t.Run(fmt.Sprintf("ParseVotes_%d", numVotes), func(t *testing.T) {
 			c := qt.New(t)
 			// Create a test blob with known data
-			blob := &kzg4844.Blob{}
+			blob := &gethkzg.Blob{}
 
 			// This would normally populate the blob with test data
 			// For now, we'll test the parsing logic with empty data

--- a/storage/types.go
+++ b/storage/types.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	gethtypes "github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/crypto/kzg4844"
+	gethkzg "github.com/ethereum/go-ethereum/crypto/kzg4844"
 
 	"github.com/consensys/gnark/std/algebra/emulated/sw_bn254"
 	recursion "github.com/consensys/gnark/std/recursion/groth16"
@@ -184,8 +184,8 @@ type StateTransitionBatchProofInputs struct {
 	NumOverwritten       int                `json:"numOverwritten"`
 	BlobEvaluationPointZ *big.Int           `json:"blobEvaluationPointZ"`
 	BlobEvaluationPointY [4]*big.Int        `json:"blobEvaluationPointY"`
-	BlobCommitment       kzg4844.Commitment `json:"blobCommitment"`
-	BlobProof            kzg4844.Proof      `json:"blobProof"`
+	BlobCommitment       gethkzg.Commitment `json:"blobCommitment"`
+	BlobProof            gethkzg.Proof      `json:"blobProof"`
 }
 
 // ABIEncode packs the four fields as a single static uint256[4] blob:

--- a/web3/contracts.go
+++ b/web3/contracts.go
@@ -16,7 +16,7 @@ import (
 	bind "github.com/ethereum/go-ethereum/accounts/abi/bind/v2"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	gtypes "github.com/ethereum/go-ethereum/core/types"
+	gethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 
 	npbindings "github.com/vocdoni/davinci-contracts/golang-types"
@@ -443,7 +443,7 @@ func (c *Contracts) SimulateContractCall(
 	contractAddr common.Address,
 	contractABI *abi.ABI,
 	method string,
-	blobsSidecar *gtypes.BlobTxSidecar,
+	blobsSidecar *gethtypes.BlobTxSidecar,
 	args ...any,
 ) error {
 	if contractABI == nil {

--- a/web3/process.go
+++ b/web3/process.go
@@ -8,7 +8,7 @@ import (
 
 	bind "github.com/ethereum/go-ethereum/accounts/abi/bind/v2"
 	"github.com/ethereum/go-ethereum/common"
-	gtypes "github.com/ethereum/go-ethereum/core/types"
+	gethtypes "github.com/ethereum/go-ethereum/core/types"
 	npbindings "github.com/vocdoni/davinci-contracts/golang-types"
 	"github.com/vocdoni/davinci-node/log"
 	"github.com/vocdoni/davinci-node/types"
@@ -138,7 +138,7 @@ func (c *Contracts) StateRoot(processID []byte) (*types.BigInt, error) {
 // the process. It returns the transaction hash of the state transition
 // submission, or an error if the submission fails. The tx hash can be used to
 // track the status of the transaction on the blockchain.
-func (c *Contracts) sendProcessTransition(processID types.HexBytes, proof, inputs []byte, blobsSidecar *gtypes.BlobTxSidecar) (types.HexBytes, *common.Hash, error) {
+func (c *Contracts) sendProcessTransition(processID types.HexBytes, proof, inputs []byte, blobsSidecar *gethtypes.BlobTxSidecar) (types.HexBytes, *common.Hash, error) {
 	// Copy processID into a fixed-size array to match the contract's expected
 	// type
 	var pid [32]byte
@@ -152,8 +152,8 @@ func (c *Contracts) sendProcessTransition(processID types.HexBytes, proof, input
 	}
 
 	// Use transaction manager for automatic nonce management
-	var sentTx *gtypes.Transaction
-	txID, txHash, err := c.txManager.SendTx(ctx, func(nonce uint64) (*gtypes.Transaction, error) {
+	var sentTx *gethtypes.Transaction
+	txID, txHash, err := c.txManager.SendTx(ctx, func(nonce uint64) (*gethtypes.Transaction, error) {
 		internalCtx, cancel := context.WithTimeout(context.Background(), web3WaitTimeout)
 		defer cancel()
 		// Build the transaction based on whether blobs are provided
@@ -205,7 +205,7 @@ func (c *Contracts) sendProcessTransition(processID types.HexBytes, proof, input
 func (c *Contracts) SetProcessTransition(
 	processID types.HexBytes,
 	proof, inputs []byte,
-	blobsSidecar *gtypes.BlobTxSidecar,
+	blobsSidecar *gethtypes.BlobTxSidecar,
 	timeout time.Duration,
 	callback ...func(error),
 ) error {
@@ -245,7 +245,7 @@ func (c *Contracts) sendProcessResults(processID types.HexBytes, proof, inputs [
 		return nil, nil, fmt.Errorf("failed to pack data: %w", err)
 	}
 	// Use transaction manager for automatic nonce management
-	return c.txManager.SendTx(ctx, func(nonce uint64) (*gtypes.Transaction, error) {
+	return c.txManager.SendTx(ctx, func(nonce uint64) (*gethtypes.Transaction, error) {
 		internalCtx, cancel := context.WithTimeout(context.Background(), web3WaitTimeout)
 		defer cancel()
 		// Results are always regular transactions (no blobs)

--- a/web3/rpc/web3_client.go
+++ b/web3/rpc/web3_client.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
+	gethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/vocdoni/davinci-node/log"
@@ -121,7 +121,7 @@ func (c *Client) EstimateGas(ctx context.Context, msg ethereum.CallMsg) (uint64,
 // the chainID of the Client instance. It returns an error if the chainID is not
 // found in the pool or if the method fails. Required by the bind.ContractBackend
 // interface.
-func (c *Client) FilterLogs(ctx context.Context, query ethereum.FilterQuery) ([]types.Log, error) {
+func (c *Client) FilterLogs(ctx context.Context, query ethereum.FilterQuery) ([]gethtypes.Log, error) {
 	res, err := c.retryAndCheckErr(func(endpoint *Web3Endpoint) (any, error) {
 		internalCtx, cancel := context.WithTimeout(ctx, filterLogsTimeout)
 		defer cancel()
@@ -130,14 +130,14 @@ func (c *Client) FilterLogs(ctx context.Context, query ethereum.FilterQuery) ([]
 	if err != nil {
 		return nil, err
 	}
-	return res.([]types.Log), nil
+	return res.([]gethtypes.Log), nil
 }
 
 // HeaderByNumber method wraps the HeaderByNumber method from the ethclient.Client
 // for the chainID of the Client instance. It returns an error if the chainID is
 // not found in the pool or if the method fails. Required by the
 // bind.ContractBackend interface.
-func (c *Client) HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error) {
+func (c *Client) HeaderByNumber(ctx context.Context, number *big.Int) (*gethtypes.Header, error) {
 	res, err := c.retryAndCheckErr(func(endpoint *Web3Endpoint) (any, error) {
 		internalCtx, cancel := context.WithTimeout(ctx, defaultTimeout)
 		defer cancel()
@@ -146,7 +146,7 @@ func (c *Client) HeaderByNumber(ctx context.Context, number *big.Int) (*types.He
 	if err != nil {
 		return nil, err
 	}
-	return res.(*types.Header), err
+	return res.(*gethtypes.Header), err
 }
 
 // PendingNonceAt method wraps the PendingNonceAt method from the
@@ -185,7 +185,7 @@ func (c *Client) SuggestGasPrice(ctx context.Context) (*big.Int, error) {
 // for the chainID of the Client instance. It returns an error if the chainID is
 // not found in the pool or if the method fails. Required by the
 // bind.ContractBackend interface.
-func (c *Client) SendTransaction(ctx context.Context, tx *types.Transaction) error {
+func (c *Client) SendTransaction(ctx context.Context, tx *gethtypes.Transaction) error {
 	_, err := c.retryAndCheckErr(func(endpoint *Web3Endpoint) (any, error) {
 		internalCtx, cancel := context.WithTimeout(ctx, defaultTimeout)
 		defer cancel()
@@ -215,7 +215,7 @@ func (c *Client) PendingCodeAt(ctx context.Context, account common.Address) ([]b
 // if the chainID is not found in the pool or if the method fails. Required by
 // the bind.ContractBackend interface.
 func (c *Client) SubscribeFilterLogs(ctx context.Context,
-	query ethereum.FilterQuery, ch chan<- types.Log,
+	query ethereum.FilterQuery, ch chan<- gethtypes.Log,
 ) (ethereum.Subscription, error) {
 	res, err := c.retryAndCheckErr(func(endpoint *Web3Endpoint) (any, error) {
 		internalCtx, cancel := context.WithTimeout(ctx, defaultTimeout)

--- a/web3/txmanager/txmanager.go
+++ b/web3/txmanager/txmanager.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
-	gtypes "github.com/ethereum/go-ethereum/core/types"
+	gethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/holiman/uint256"
 	ethSigner "github.com/vocdoni/davinci-node/crypto/signatures/ethereum"
 	"github.com/vocdoni/davinci-node/log"
@@ -88,7 +88,7 @@ type PendingTransaction struct {
 	// BlobHashes store the hashes of the blobs associated with the transaction.
 	BlobHashes []common.Hash
 	// BlobSidecar stores the sidecar for rebuilding blob transactions.
-	BlobSidecar *gtypes.BlobTxSidecar
+	BlobSidecar *gethtypes.BlobTxSidecar
 	// LastError stores the last error encountered for this transaction.
 	// Used to categorize failures as permanent or temporary.
 	LastError error
@@ -186,7 +186,7 @@ func (tm *TxManager) BuildDynamicFeeTx(
 	to common.Address,
 	data []byte,
 	nonce uint64,
-) (*gtypes.Transaction, error) {
+) (*gethtypes.Transaction, error) {
 	return tm.buildTx(ctx, &PendingTransaction{
 		To:    to,
 		Data:  data,
@@ -306,7 +306,7 @@ func (tm *TxManager) buildTx(
 	ptx *PendingTransaction,
 	gasFeeCap *big.Int,
 	blobFee *big.Int,
-) (*gtypes.Transaction, error) {
+) (*gethtypes.Transaction, error) {
 	// Get gas price and tip
 	tipCap, err := tm.cli.SuggestGasTipCap(ctx)
 	if err != nil {
@@ -340,10 +340,10 @@ func (tm *TxManager) buildTx(
 		return nil, fmt.Errorf("failed to estimate gas: %w", err)
 	}
 
-	var tx *gtypes.Transaction
+	var tx *gethtypes.Transaction
 	if blobFee != nil {
 		// Build blob transaction
-		tx = gtypes.NewTx(&gtypes.BlobTx{
+		tx = gethtypes.NewTx(&gethtypes.BlobTx{
 			ChainID:    uint256.NewInt(tm.config.ChainID.Uint64()),
 			Nonce:      ptx.Nonce,
 			GasTipCap:  uint256.MustFromBig(tipCap),
@@ -358,7 +358,7 @@ func (tm *TxManager) buildTx(
 		})
 	} else {
 		// Build standard dynamic fee transaction
-		tx = gtypes.NewTx(&gtypes.DynamicFeeTx{
+		tx = gethtypes.NewTx(&gethtypes.DynamicFeeTx{
 			ChainID:   tm.config.ChainID,
 			Nonce:     ptx.Nonce,
 			GasTipCap: tipCap,
@@ -379,7 +379,7 @@ func (tm *TxManager) buildTx(
 
 // txReceipt fetches the transaction receipt for a given transaction hash. It
 // returns the receipt and any error encountered.
-func (tm *TxManager) txReceipt(ctx context.Context, hash common.Hash) (*gtypes.Receipt, error) {
+func (tm *TxManager) txReceipt(ctx context.Context, hash common.Hash) (*gethtypes.Receipt, error) {
 	ethcli, err := tm.cli.EthClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get eth client: %w", err)
@@ -394,9 +394,9 @@ func (tm *TxManager) txReceipt(ctx context.Context, hash common.Hash) (*gtypes.R
 }
 
 // signTx signs a transaction with the configured signer
-func (tm *TxManager) signTx(tx *gtypes.Transaction) (*gtypes.Transaction, error) {
-	signer := gtypes.NewCancunSigner(tm.config.ChainID)
-	signed, err := gtypes.SignTx(tx, signer, (*ecdsa.PrivateKey)(tm.signer))
+func (tm *TxManager) signTx(tx *gethtypes.Transaction) (*gethtypes.Transaction, error) {
+	signer := gethtypes.NewCancunSigner(tm.config.ChainID)
+	signed, err := gethtypes.SignTx(tx, signer, (*ecdsa.PrivateKey)(tm.signer))
 	if err != nil {
 		return nil, fmt.Errorf("failed to sign transaction: %w", err)
 	}

--- a/web3/types.go
+++ b/web3/types.go
@@ -3,7 +3,7 @@ package web3
 import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	gtypes "github.com/ethereum/go-ethereum/core/types"
+	gethtypes "github.com/ethereum/go-ethereum/core/types"
 )
 
 // SimulationRequest is the top‐level payload for eth_simulateV1
@@ -36,17 +36,17 @@ type StateOverride struct {
 
 // Call is a single call to be executed in the simulated block
 type Call struct {
-	From                 common.Address        `json:"from,omitempty"`
-	To                   common.Address        `json:"to,omitempty"`
-	Gas                  hexutil.Uint64        `json:"gas,omitempty"`
-	GasPrice             *hexutil.Big          `json:"gasPrice,omitempty"`
-	MaxFeePerGas         *hexutil.Big          `json:"maxFeePerGas,omitempty"`
-	MaxPriorityFeePerGas *hexutil.Big          `json:"maxPriorityFeePerGas,omitempty"`
-	Value                *hexutil.Big          `json:"value,omitempty"`
-	Data                 hexutil.Bytes         `json:"data,omitempty"`
-	Nonce                hexutil.Uint64        `json:"nonce,omitempty"`
-	BlobHashes           []common.Hash         `json:"blobHashes,omitempty"`
-	Sidecar              *gtypes.BlobTxSidecar `json:"sidecar,omitempty"`
+	From                 common.Address           `json:"from,omitempty"`
+	To                   common.Address           `json:"to,omitempty"`
+	Gas                  hexutil.Uint64           `json:"gas,omitempty"`
+	GasPrice             *hexutil.Big             `json:"gasPrice,omitempty"`
+	MaxFeePerGas         *hexutil.Big             `json:"maxFeePerGas,omitempty"`
+	MaxPriorityFeePerGas *hexutil.Big             `json:"maxPriorityFeePerGas,omitempty"`
+	Value                *hexutil.Big             `json:"value,omitempty"`
+	Data                 hexutil.Bytes            `json:"data,omitempty"`
+	Nonce                hexutil.Uint64           `json:"nonce,omitempty"`
+	BlobHashes           []common.Hash            `json:"blobHashes,omitempty"`
+	Sidecar              *gethtypes.BlobTxSidecar `json:"sidecar,omitempty"`
 }
 
 // SimulatedBlock is the result of a simulated block


### PR DESCRIPTION
go-ethereum exposes everything we need, no need to use lower level crate-crypto.

While at it, i normalized the import aliases of `gethtypes` and `gethparams` in the whole codebase