### PR TITLE
fix(finalizer): setProcessInvalid when getStateRoot fails

### DIFF
--- a/sequencer/finalizer.go
+++ b/sequencer/finalizer.go
@@ -235,6 +235,7 @@ func (f *finalizer) finalize(processID types.ProcessID) error {
 	if f.getStateRoot != nil {
 		contractStateRoot, err := f.getStateRoot(processID)
 		if err != nil {
+			setProcessInvalid()
 			return fmt.Errorf("could not fetch contract state root for process %s: %w", processID.String(), err)
 		}
 		if contractStateRoot.MathBigInt().Cmp(process.StateRoot.MathBigInt()) != 0 {


### PR DESCRIPTION
this fixes an endless loop of logs with

```
could not fetch contract state root for process
a62e32147e9c1ea76da552be6e0636f1984143aff3e6014600000000000000c9:
failed to get process: invalid census origin: 0
```
