### PR TITLE
ci: guard against merging stacked PRs in wrong order

### DIFF
--- a/.github/workflows/stacked-pr.yml
+++ b/.github/workflows/stacked-pr.yml
@@ -1,0 +1,112 @@
+name: Stacked PR Check
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, edited, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  stacked-pr:
+    if: ${{ !github.event.pull_request.draft && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check stacked PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const prNumber = context.payload.pull_request.number;
+            const baseRef = context.payload.pull_request.base.ref;
+            const isMain = baseRef === "main";
+
+            const isStackedBody = (body) =>
+              typeof body === "string" &&
+              /^This PR is stacked on top of #[0-9]+, please merge that one first$/.test(body);
+
+            const stackedBodyFor = (prNumber) =>
+              `This PR is stacked on top of #${prNumber}, please merge that one first`;
+
+            const listReviews = async () =>
+              github.paginate(github.rest.pulls.listReviews, {
+                owner,
+                repo,
+                pull_number: prNumber,
+                per_page: 100,
+              });
+
+            const findLatestBotReview = (reviews) => {
+              const matches = reviews.filter(
+                (review) =>
+                  review.user &&
+                  review.user.login === "github-actions[bot]" &&
+                  review.state === "CHANGES_REQUESTED" &&
+                  isStackedBody(review.body)
+              );
+              return matches.length > 0 ? matches[matches.length - 1] : null;
+            };
+
+            const dismissReview = async (existingReview) => {
+              if (!existingReview) {
+                core.notice("Nothing to do: marking check as skipped.");
+                process.exitCode = 78;
+                return;
+              }
+              await github.rest.pulls.dismissReview({
+                owner,
+                repo,
+                pull_number: prNumber,
+                review_id: existingReview.id,
+                message: "PR is now based on main; unblocking",
+              });
+            };
+
+            const reviews = await listReviews();
+            const existingReview = findLatestBotReview(reviews);
+
+            if (isMain) {
+              await dismissReview(existingReview);
+              return;
+            }
+
+            const pulls = await github.paginate(github.rest.pulls.list, {
+              owner,
+              repo,
+              state: "open",
+              per_page: 100,
+            });
+
+            const stackedOn = pulls.find(
+              (pr) => pr.number !== prNumber && pr.head && pr.head.ref === baseRef
+            );
+
+            if (!stackedOn) {
+              await dismissReview(existingReview);
+              return;
+            }
+
+            const body = stackedBodyFor(stackedOn.number);
+
+            if (!existingReview) {
+              await github.rest.pulls.createReview({
+                owner,
+                repo,
+                pull_number: prNumber,
+                event: "REQUEST_CHANGES",
+                body: body,
+              });
+              return;
+            }
+
+            if (existingReview.body !== body) {
+              await github.rest.pulls.updateReview({
+                owner,
+                repo,
+                pull_number: prNumber,
+                review_id: existingReview.id,
+                body: body,
+              });
+            }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces an automated check to prevent merging stacked PRs out of order.
> 
> - New `/.github/workflows/stacked-pr.yml` uses `actions/github-script@v7` on PR events (non-drafts)
> - Detects when a PR’s base branch is another open PR’s head and posts a `CHANGES_REQUESTED` review with a standardized message
> - Automatically dismisses the bot’s review when the base branch is `main`
> - Uses read `contents` and write `pull-requests` permissions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1e579c45227b89f4b705915d1b3569ed1eb529e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->