### PR TITLE
fix(cmd/davincicrypto-wasm): use types.BytesToProcessID

### DIFF
--- a/cmd/davincicrypto-wasm/main.go
+++ b/cmd/davincicrypto-wasm/main.go
@@ -101,9 +101,9 @@ func cspSign(args []js.Value) any {
 	if err != nil {
 		return JSResult(nil, fmt.Errorf("Invalid process ID decoding: %v", err))
 	}
-	processID := new(types.ProcessID).SetBytes(bProcessID)
-	if !processID.IsValid() {
-		return JSResult(nil, fmt.Errorf("Invalid process ID: %s", bProcessID.String()))
+	processID, err := types.BytesToProcessID(bProcessID)
+	if err != nil {
+		return JSResult(nil, fmt.Errorf("Invalid process ID %s: %w", bProcessID.String(), err))
 	}
 	// decode the address from the fourth argument
 	bAddress, err := FromHexBytes(args[3])


### PR DESCRIPTION
this has been broken since 34a528f "types: ProcessID is now a [32]byte and used everywhere"
