### PR TITLE
chore: bump github.com/vocdoni/arbo v0.0.0-20260224125436-30808c99dfb2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/vocdoni/arbo v0.0.0-20260224125436-30808c99dfb2
 	github.com/vocdoni/census3-bigquery v0.0.0-20260126152143-a64362ea3427
 	github.com/vocdoni/davinci-circom v0.1.0
-	github.com/vocdoni/davinci-contracts v0.0.36-0.20260223170646-88b3bb97fc8c
+	github.com/vocdoni/davinci-contracts v0.0.36-0.20260223141848-572d869c67d3
 	github.com/vocdoni/davinci-node/spec v0.0.0-20260210223636-e85fc7c89da9
 	github.com/vocdoni/gnark-crypto-primitives v0.0.2-0.20260115102516-64ce9c3fd55d
 	github.com/vocdoni/lean-imt-go v0.0.0-20260126110424-0b1c7ec41924

--- a/go.sum
+++ b/go.sum
@@ -810,8 +810,8 @@ github.com/vocdoni/census3-bigquery v0.0.0-20260126152143-a64362ea3427 h1:agxi6v
 github.com/vocdoni/census3-bigquery v0.0.0-20260126152143-a64362ea3427/go.mod h1:8kDd6AYVCW9HKBng4O0bkNHgameysPWztt502FcQL1c=
 github.com/vocdoni/davinci-circom v0.1.0 h1:bx3JlqaUOQ2dStGo9lySA2Eu1ZsIWrJ3BBTyc6cRQd4=
 github.com/vocdoni/davinci-circom v0.1.0/go.mod h1:7CdVIumC1seueKlazgQDPNhCwnZhu9gRDlSiBKEM4Sc=
-github.com/vocdoni/davinci-contracts v0.0.36-0.20260223170646-88b3bb97fc8c h1:X4hlxkwXBVh4ZmzE9wEOuawsCTSVDbFcaUmMN570p7s=
-github.com/vocdoni/davinci-contracts v0.0.36-0.20260223170646-88b3bb97fc8c/go.mod h1:RgIZ/8KfR5GfS54l59Tbmm33krj8+HL19ZJRpWcVB4g=
+github.com/vocdoni/davinci-contracts v0.0.36-0.20260223141848-572d869c67d3 h1:019TSQOlH2arWl9GLLADsw2aK77nSpISpMma9PJ7ae4=
+github.com/vocdoni/davinci-contracts v0.0.36-0.20260223141848-572d869c67d3/go.mod h1:RgIZ/8KfR5GfS54l59Tbmm33krj8+HL19ZJRpWcVB4g=
 github.com/vocdoni/gnark-crypto-primitives v0.0.2-0.20260115102516-64ce9c3fd55d h1:g/v2DQK3u62nEspG3htAksWof4hGpiPECjwWyBnIkGM=
 github.com/vocdoni/gnark-crypto-primitives v0.0.2-0.20260115102516-64ce9c3fd55d/go.mod h1:vbpZOw6IYuRzO1gdpuW2+Ppnq/v9cscWGcdWiZ2rWi8=
 github.com/vocdoni/lean-imt-go v0.0.0-20260126110424-0b1c7ec41924 h1:RxK5uDIhXuC0XsaW6FxHIqctIO8wCG5sz4V7gJUhKcI=


### PR DESCRIPTION
the version v0.0.0-20260216104828-6bf3dbaeb1af was a PR https://github.com/vocdoni/arbo/pull/41
that has now been merged to `main` as 30808c99dfb2

so this bump doesn't introduce any actual changes, it's the same code but with the definitive version
