### PR TITLE
bug: wrong status in the API

### DIFF
--- a/api/vote.go
+++ b/api/vote.go
@@ -49,8 +49,8 @@ func (a *API) voteStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// DONE status is an internal status and should be not exposed, instead
-	// we use the PROCESSED status
+	// DONE is an internal status and should not be exposed, return PROCESSED
+	// instead
 	if status == storage.VoteIDStatusDone {
 		status = storage.VoteIDStatusProcessed
 	}

--- a/tests/max_voters_test.go
+++ b/tests/max_voters_test.go
@@ -196,7 +196,7 @@ func TestMaxVoters(t *testing.T) {
 	c.Run("wait for settled extra votes", func(c *qt.C) {
 		if err := helpers.WaitUntilCondition(globalCtx, 10*time.Second, func() bool {
 			// Check that votes are settled (state transitions confirmed on blockchain)
-			if allSettled, failed, err := helpers.EnsureVotesStatus(services.HTTPClient, pid, voteIDs, storage.VoteIDStatusName(storage.VoteIDStatusDone)); !allSettled {
+			if allSettled, failed, err := helpers.EnsureVotesStatus(services.HTTPClient, pid, voteIDs, storage.VoteIDStatusName(storage.VoteIDStatusSettled)); !allSettled {
 				c.Assert(err, qt.IsNil, qt.Commentf("Failed to check vote status"))
 				if len(failed) > 0 {
 					hexFailed := types.SliceOf(failed, func(v types.VoteID) string { return v.String() })


### PR DESCRIPTION
The API returns the internal `DONE` status. With this fix, this status is wrapped at the API level as the `PROCESSED` one, expected by SDK and UIs.