### PR TITLE
fix(sequencer): harden ballot and transition recovery

### DIFF
--- a/api/workers.go
+++ b/api/workers.go
@@ -331,15 +331,6 @@ func (a *API) workersSubmitJob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Set job as completed
-	job := a.jobsManager.CompleteJob(ballot.VoteID, true)
-	if job == nil {
-		log.Warnw("job not found or expired",
-			"voteID", ballot.VoteID.String())
-		ErrResourceNotFound.Withf("job not found or expired").Write(w)
-		return
-	}
-
 	verifiedBallot := storage.VerifiedBallot{
 		VoteID:          ballot.VoteID,
 		ProcessID:       ballot.ProcessID,
@@ -357,6 +348,15 @@ func (a *API) workersSubmitJob(w http.ResponseWriter, r *http.Request) {
 			"error", err.Error(),
 			"voteID", ballot.VoteID.String())
 		ErrGenericInternalServerError.WithErr(err).Write(w)
+		return
+	}
+
+	// Mark the job as completed only after the verified ballot has been stored.
+	job := a.jobsManager.CompleteJob(ballot.VoteID, true)
+	if job == nil {
+		log.Warnw("job not found or expired after ballot verification was stored",
+			"voteID", ballot.VoteID.String())
+		ErrResourceNotFound.Withf("job not found or expired").Write(w)
 		return
 	}
 

--- a/sequencer/statetransition.go
+++ b/sequencer/statetransition.go
@@ -222,10 +222,22 @@ func (s *Sequencer) processStateTransitionBatch(
 	innerProof groth16.Proof,
 ) (groth16.Proof, *blobs.BlobEvalData, *big.Int, error) {
 	startTime := time.Now()
+	rootBefore, err := processState.RootAsBigInt()
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to get root before state transition batch: %w", err)
+	}
+
+	rollbackState := func(cause error, op string) (groth16.Proof, *blobs.BlobEvalData, *big.Int, error) {
+		if rollbackErr := processState.SetRootAsBigInt(rootBefore); rollbackErr != nil {
+			return nil, nil, nil, fmt.Errorf("%s: %w (rollback failed: %v)", op, cause, rollbackErr)
+		}
+		return nil, nil, nil, fmt.Errorf("%s: %w", op, cause)
+	}
+
 	// Generate the state transition assignment from the batch and the blob data.
 	assignment, blobData, err := s.stateBatchToAssignment(processState, votes, censusRoot, censusProofs, kSeed, innerProof)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to generate assignment: %w", err)
+		return rollbackState(err, "failed to generate assignment")
 	}
 	log.DebugTime("state transition assignment ready for proof generation", startTime,
 		"processID", processState.ProcessID(),
@@ -240,7 +252,7 @@ func (s *Sequencer) processStateTransitionBatch(
 	proof, err := s.stateTransition.ProveAndVerify(assignment)
 	if err != nil {
 		s.logStateTransitionDebugInfo(processState, votes, censusRoot, assignment, err)
-		return nil, nil, nil, fmt.Errorf("failed to generate proof: %w", err)
+		return rollbackState(err, "failed to generate proof")
 	}
 	return proof, blobData, assignment.RootHashAfter.(*big.Int), nil
 }

--- a/sequencer/statetransition_test.go
+++ b/sequencer/statetransition_test.go
@@ -1,0 +1,112 @@
+package sequencer
+
+import (
+	"testing"
+
+	"github.com/consensys/gnark/backend/groth16"
+	qt "github.com/frankban/quicktest"
+	statetransitiontest "github.com/vocdoni/davinci-node/circuits/test/statetransition"
+	specutil "github.com/vocdoni/davinci-node/spec/util"
+	statetest "github.com/vocdoni/davinci-node/state/testutil"
+	"github.com/vocdoni/davinci-node/types"
+)
+
+func TestProcessStateTransitionBatchRollsBackRootOnAssignmentError(t *testing.T) {
+	c := qt.New(t)
+
+	processState := statetest.NewRandomState(t, types.CensusOriginMerkleTreeOffchainStaticV1)
+	rootBefore, err := processState.RootAsBigInt()
+	c.Assert(err, qt.IsNil)
+
+	publicKey := statetest.EncryptionKeyAsECCPoint(processState)
+	votes := statetest.NewVotesForTest(publicKey, 2, 10)
+
+	kSeed, err := specutil.RandomK()
+	c.Assert(err, qt.IsNil)
+
+	lastK := new(types.BigInt).SetBigInt(kSeed).MathBigInt()
+	for _, vote := range votes {
+		vote.ReencryptedBallot, lastK, err = vote.Ballot.Reencrypt(publicKey, lastK)
+		c.Assert(err, qt.IsNil)
+	}
+
+	processID, err := types.BigIntToProcessID(processState.ProcessID())
+	c.Assert(err, qt.IsNil)
+
+	censusRoot, censusProofs, err := statetransitiontest.CensusProofsForCircuitTest(
+		t,
+		votes,
+		types.CensusOriginMerkleTreeOffchainStaticV1,
+		processID,
+	)
+	c.Assert(err, qt.IsNil)
+
+	var innerProof groth16.Proof
+
+	_, _, _, err = new(Sequencer).processStateTransitionBatch(
+		processState,
+		new(types.BigInt).SetBigInt(censusRoot),
+		censusProofs,
+		votes,
+		new(types.BigInt).SetBigInt(kSeed),
+		innerProof,
+	)
+	c.Assert(err, qt.Not(qt.IsNil))
+
+	rootAfter, err := processState.RootAsBigInt()
+	c.Assert(err, qt.IsNil)
+	c.Assert(rootAfter.Cmp(rootBefore), qt.Equals, 0)
+
+	containsVote := processState.ContainsVoteID(votes[0].VoteID)
+	c.Assert(containsVote, qt.IsFalse)
+}
+
+func TestStateBatchToAssignmentLeavesAdvancedRootOnLateError(t *testing.T) {
+	c := qt.New(t)
+
+	processState := statetest.NewRandomState(t, types.CensusOriginMerkleTreeOffchainStaticV1)
+	rootBefore, err := processState.RootAsBigInt()
+	c.Assert(err, qt.IsNil)
+
+	publicKey := statetest.EncryptionKeyAsECCPoint(processState)
+	votes := statetest.NewVotesForTest(publicKey, 2, 10)
+
+	kSeed, err := specutil.RandomK()
+	c.Assert(err, qt.IsNil)
+
+	lastK := new(types.BigInt).SetBigInt(kSeed).MathBigInt()
+	for _, vote := range votes {
+		vote.ReencryptedBallot, lastK, err = vote.Ballot.Reencrypt(publicKey, lastK)
+		c.Assert(err, qt.IsNil)
+	}
+
+	processID, err := types.BigIntToProcessID(processState.ProcessID())
+	c.Assert(err, qt.IsNil)
+
+	censusRoot, censusProofs, err := statetransitiontest.CensusProofsForCircuitTest(
+		t,
+		votes,
+		types.CensusOriginMerkleTreeOffchainStaticV1,
+		processID,
+	)
+	c.Assert(err, qt.IsNil)
+
+	var innerProof groth16.Proof
+
+	_, _, err = new(Sequencer).stateBatchToAssignment(
+		processState,
+		votes,
+		new(types.BigInt).SetBigInt(censusRoot),
+		censusProofs,
+		new(types.BigInt).SetBigInt(kSeed),
+		innerProof,
+	)
+	c.Assert(err, qt.Not(qt.IsNil))
+
+	rootAfter, err := processState.RootAsBigInt()
+	c.Assert(err, qt.IsNil)
+	c.Assert(rootAfter.Cmp(rootBefore), qt.Not(qt.Equals), 0)
+
+	containsVote := processState.ContainsVoteID(votes[0].VoteID)
+	c.Assert(containsVote, qt.IsTrue)
+}

--- a/storage/ballots.go
+++ b/storage/ballots.go
@@ -242,15 +242,26 @@ func (s *Storage) MarkBallotVerified(voteID types.VoteID, vb *VerifiedBallot) er
 	s.globalLock.Lock()
 	defer s.globalLock.Unlock()
 
-	// Remove reservation
-	if err := s.deleteReservation(ballotPrefix, voteID.Bytes()); err != nil && !errors.Is(err, ErrNotFound) {
-		return fmt.Errorf("delete reservation: %w", err)
+	if vb == nil {
+		return fmt.Errorf("verified ballot is nil")
 	}
 
-	// Remove from pending queue
-	if err := s.deleteArtifact(ballotPrefix, voteID.Bytes()); err != nil && !errors.Is(err, ErrNotFound) {
-		return fmt.Errorf("delete pending ballot: %w", err)
+	var pendingBallot Ballot
+	processID := vb.ProcessID
+	pendingBallotFound := true
+	if err := s.getArtifact(ballotPrefix, voteID.Bytes(), &pendingBallot); err != nil {
+		if !errors.Is(err, ErrNotFound) {
+			return fmt.Errorf("get pending ballot: %w", err)
+		}
+		if !processID.IsValid() {
+			return fmt.Errorf("pending ballot not found for vote %s and verified ballot process ID is invalid", voteID.String())
+		}
+		pendingBallotFound = false
+	} else {
+		processID = pendingBallot.ProcessID
 	}
+
+	vb.ProcessID = processID
 
 	// store verified ballot
 	val, err := EncodeArtifact(vb)
@@ -259,7 +270,7 @@ func (s *Storage) MarkBallotVerified(voteID types.VoteID, vb *VerifiedBallot) er
 	}
 	wTx := prefixeddb.NewPrefixedWriteTx(s.db.WriteTx(), verifiedBallotPrefix)
 	// key with processID as prefix + unique portion from original key
-	combKey := append(vb.ProcessID.Bytes(), voteID.Bytes()...)
+	combKey := append(processID.Bytes(), voteID.Bytes()...)
 	if err := wTx.Set(combKey, val); err != nil {
 		wTx.Discard()
 		return err
@@ -268,17 +279,30 @@ func (s *Storage) MarkBallotVerified(voteID types.VoteID, vb *VerifiedBallot) er
 		return err
 	}
 
-	// Update process stats
-	if err := s.updateProcessStats(vb.ProcessID, []ProcessStatsUpdate{
+	// Remove reservation after the verified ballot is durably stored.
+	if err := s.deleteReservation(ballotPrefix, voteID.Bytes()); err != nil && !errors.Is(err, ErrNotFound) {
+		return fmt.Errorf("delete reservation: %w", err)
+	}
+
+	updates := []ProcessStatsUpdate{
 		{TypeStats: types.TypeStatsVerifiedVotes, Delta: 1},
-		{TypeStats: types.TypeStatsPendingVotes, Delta: -1},
 		{TypeStats: types.TypeStatsCurrentBatchSize, Delta: 1},
-	}); err != nil {
+	}
+	if pendingBallotFound {
+		// Remove from pending queue after the verified ballot is durably stored.
+		if err := s.deleteArtifact(ballotPrefix, voteID.Bytes()); err != nil && !errors.Is(err, ErrNotFound) {
+			return fmt.Errorf("delete pending ballot: %w", err)
+		}
+		updates = append(updates, ProcessStatsUpdate{TypeStats: types.TypeStatsPendingVotes, Delta: -1})
+	}
+
+	// Update process stats
+	if err := s.updateProcessStats(processID, updates); err != nil {
 		return fmt.Errorf("failed to update process stats: %w", err)
 	}
 
 	// Update vote ID status to verified
-	return s.setVoteIDStatus(vb.ProcessID, voteID, VoteIDStatusVerified)
+	return s.setVoteIDStatus(processID, voteID, VoteIDStatusVerified)
 }
 
 // PullVerifiedBallots returns a list of non-reserved verified ballots for a

--- a/storage/ballots_batches.go
+++ b/storage/ballots_batches.go
@@ -554,12 +554,33 @@ func (s *Storage) MarkStateTransitionBatchOutdated(key []byte) error {
 		return fmt.Errorf("delete state transition batch: %w", err)
 	}
 
-	// Release the ballot batch reservation, so the batch can be processed again
-	if err := s.releaseAggregatorBatchReservation(stb.BatchID); err != nil {
-		log.Warnw("failed to release ballot batch reservation after marking state transition batch as outdated",
-			"error", err.Error(),
-			"batchID", fmt.Sprintf("%x", stb.BatchID),
-		)
+	if stb.ProcessID.IsValid() {
+		if err := s.prunePendingTx(StateTransitionTx, stb.ProcessID); err != nil && !errors.Is(err, ErrNotFound) {
+			return fmt.Errorf("prune pending state transition tx: %w", err)
+		}
+
+		pendingBatch, err := s.pendingAggregatorBatch(stb.ProcessID)
+		switch {
+		case err == nil:
+			if err := s.releasePendingAggregatorBatch(stb.ProcessID); err != nil && !errors.Is(err, db.ErrKeyNotFound) {
+				return fmt.Errorf("release pending aggregator batch: %w", err)
+			}
+			if err := s.pushAggregatorBatch(pendingBatch); err != nil && !errors.Is(err, ErrKeyAlreadyExists) {
+				return fmt.Errorf("requeue pending aggregator batch: %w", err)
+			}
+		case !errors.Is(err, ErrNotFound):
+			return fmt.Errorf("get pending aggregator batch: %w", err)
+		}
+	}
+
+	// Release the ballot batch reservation, so the batch can be processed again.
+	if len(stb.BatchID) > 0 {
+		if err := s.releaseAggregatorBatchReservation(stb.BatchID); err != nil {
+			log.Warnw("failed to release ballot batch reservation after marking state transition batch as outdated",
+				"error", err.Error(),
+				"batchID", fmt.Sprintf("%x", stb.BatchID),
+			)
+		}
 	}
 
 	return nil

--- a/storage/ballots_batches_test.go
+++ b/storage/ballots_batches_test.go
@@ -310,6 +310,67 @@ func TestMarkStateTransitionOutdated(t *testing.T) {
 	c.Assert(err, qt.IsNil, qt.Commentf("marking non-existent batch as outdated should not error"))
 }
 
+func TestMarkStateTransitionBatchOutdatedRequeuesPendingBatchAndClearsPendingTx(t *testing.T) {
+	c := qt.New(t)
+	stg := newTestStorage(t)
+	defer stg.Close()
+
+	processID := testutil.RandomProcessID()
+	ensureProcess(t, stg, processID)
+
+	voteID := testutil.RandomVoteID()
+	batch := &AggregatorBallotBatch{
+		ProcessID: processID,
+		Ballots: []*AggregatorBallot{
+			{
+				VoteID:  voteID,
+				Address: big.NewInt(5001),
+			},
+		},
+	}
+
+	c.Assert(stg.PushAggregatorBatch(batch), qt.IsNil)
+
+	retrievedBatch, batchID, err := stg.NextAggregatorBatch(processID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(retrievedBatch, qt.Not(qt.IsNil))
+
+	c.Assert(stg.SetPendingTx(StateTransitionTx, processID), qt.IsNil)
+	c.Assert(stg.MarkAggregatorBatchPending(retrievedBatch), qt.IsNil)
+	c.Assert(stg.MarkAggregatorBatchDone(batchID), qt.IsNil)
+
+	stb := &StateTransitionBatch{
+		ProcessID: processID,
+		BatchID:   batchID,
+		Ballots:   retrievedBatch.Ballots,
+		Inputs: StateTransitionBatchProofInputs{
+			RootHashBefore: big.NewInt(10),
+			RootHashAfter:  big.NewInt(11),
+			CensusRoot:     big.NewInt(12),
+		},
+	}
+	c.Assert(stg.PushStateTransitionBatch(stb), qt.IsNil)
+
+	_, stateTransitionKey, err := stg.NextStateTransitionBatch(processID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(stg.HasPendingTx(StateTransitionTx, processID), qt.IsTrue)
+
+	err = stg.MarkStateTransitionBatchOutdated(stateTransitionKey)
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(stg.HasPendingTx(StateTransitionTx, processID), qt.IsFalse)
+
+	_, err = stg.PendingAggregatorBatch(processID)
+	c.Assert(err, qt.Equals, ErrNotFound)
+
+	requeuedBatch, _, err := stg.NextAggregatorBatch(processID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(requeuedBatch, qt.Not(qt.IsNil))
+	c.Assert(requeuedBatch.ProcessID, qt.Equals, processID)
+	c.Assert(requeuedBatch.Ballots, qt.HasLen, 1)
+	c.Assert(requeuedBatch.Ballots[0].VoteID, qt.Equals, voteID)
+}
+
 // TestMarkStateTransitionOutdatedVsMarkDone tests the difference between outdated and done
 func TestMarkStateTransitionOutdatedVsMarkDone(t *testing.T) {
 	c := qt.New(t)

--- a/storage/ballots_test.go
+++ b/storage/ballots_test.go
@@ -184,6 +184,67 @@ func TestBallotQueue_MarkBallotDoneAndPullVerified(t *testing.T) {
 	c.Assert(stg.CountVerifiedBallots(pid), qt.Equals, 0)
 }
 
+func TestMarkBallotVerifiedUsesCanonicalPendingBallotProcessID(t *testing.T) {
+	c := qt.New(t)
+	stg := newTestStorage(t)
+	defer stg.Close()
+
+	canonicalPID := testutil.RandomProcessID()
+	wrongPID := testutil.RandomProcessID()
+	voteID := testutil.RandomVoteID()
+
+	ensureProcess(t, stg, canonicalPID)
+	ensureProcess(t, stg, wrongPID)
+
+	c.Assert(stg.PushPendingBallot(mkBallot(canonicalPID, voteID)), qt.IsNil)
+
+	_, key, err := stg.NextPendingBallot()
+	c.Assert(err, qt.IsNil)
+
+	err = stg.MarkBallotVerified(key, mkVerifiedBallot(wrongPID, voteID))
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(stg.CountVerifiedBallots(canonicalPID), qt.Equals, 1)
+	c.Assert(stg.CountVerifiedBallots(wrongPID), qt.Equals, 0)
+
+	vbs, _, err := stg.PullVerifiedBallots(canonicalPID, 1)
+	c.Assert(err, qt.IsNil)
+	c.Assert(vbs, qt.HasLen, 1)
+	c.Assert(vbs[0].ProcessID, qt.Equals, canonicalPID)
+
+	status, err := stg.VoteIDStatus(canonicalPID, voteID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(status, qt.Equals, VoteIDStatusVerified)
+}
+
+func TestMarkBallotVerifiedStoresBallotWhenPendingBallotIsMissing(t *testing.T) {
+	c := qt.New(t)
+	stg := newTestStorage(t)
+	defer stg.Close()
+
+	pid := testutil.RandomProcessID()
+	voteID := testutil.RandomVoteID()
+
+	ensureProcess(t, stg, pid)
+
+	vb := mkVerifiedBallot(pid, voteID)
+
+	err := stg.MarkBallotVerified(voteID, vb)
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(stg.CountVerifiedBallots(pid), qt.Equals, 1)
+
+	vbs, _, err := stg.PullVerifiedBallots(pid, 1)
+	c.Assert(err, qt.IsNil)
+	c.Assert(vbs, qt.HasLen, 1)
+	c.Assert(vbs[0].ProcessID, qt.Equals, pid)
+	c.Assert(vbs[0].VoteID, qt.Equals, voteID)
+
+	status, err := stg.VoteIDStatus(pid, voteID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(status, qt.Equals, VoteIDStatusVerified)
+}
+
 func TestBallotQueue_PullVerifiedBallots_ReservationsAndLimits(t *testing.T) {
 	c := qt.New(t)
 	stg := newTestStorage(t)


### PR DESCRIPTION
Store verified ballots using canonical pending-ballot metadata and\nonly clear the worker job after the storage move succeeds. This\nprevents worker-submitted process IDs from affecting storage keys\nand avoids reporting success before the ballot is durably moved.\n\nRoll back the local state root when state-transition witness\nassembly or proof generation fails after AddVotesBatch has\nadvanced state, and make the outdated state-transition cleanup\npath clear the pending-tx marker and requeue the saved\naggregator batch.\n\nAdd regression tests covering canonical verified-ballot storage,\noutdated batch recovery, and state-root rollback on late\nfailures.
