### PR TITLE
small api fixes

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -193,7 +193,7 @@ func (a *API) initRouter() {
 		AllowedOrigins:   []string{"*"},
 		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
 		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-CSRF-Token"},
-		AllowCredentials: true,
+		AllowCredentials: false,
 		MaxAge:           300,
 	}).Handler)
 	a.router.Use(loggingMiddleware(maxRequestBodyLog))

--- a/api/vote.go
+++ b/api/vote.go
@@ -305,6 +305,18 @@ func (a *API) newVote(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	// verify the signature of the vote early (cheap check before expensive proof verification)
+	signature := new(ethereum.ECDSASignature).SetBytes(vote.Signature)
+	if signature == nil {
+		ErrMalformedBody.Withf("could not decode signature").Write(w)
+		return
+	}
+	signatureOk, pubkey := signature.VerifyVoteID(vote.VoteID, common.BytesToAddress(vote.Address))
+	if !signatureOk {
+		ErrInvalidSignature.Write(w)
+		return
+	}
+
 	// calculate the ballot inputs hash
 	ballotInputsHash, err := ballotproof.BallotInputsHashIden3(
 		vote.ProcessID,
@@ -342,17 +354,6 @@ func (a *API) newVote(w http.ResponseWriter, r *http.Request) {
 	)
 	if err != nil {
 		ErrInvalidBallotProof.Withf("could not verify and convert proof: %v", err).Write(w)
-		return
-	}
-	// verify the signature of the vote
-	signature := new(ethereum.ECDSASignature).SetBytes(vote.Signature)
-	if signature == nil {
-		ErrMalformedBody.Withf("could not decode signature: %v", err).Write(w)
-		return
-	}
-	signatureOk, pubkey := signature.VerifyVoteID(vote.VoteID, common.BytesToAddress(vote.Address))
-	if !signatureOk {
-		ErrInvalidSignature.Write(w)
 		return
 	}
 	// Create the ballot object

--- a/api/vote.go
+++ b/api/vote.go
@@ -190,9 +190,15 @@ func (a *API) ballotByIndex(w http.ResponseWriter, r *http.Request) {
 // POST /votes
 func (a *API) newVote(w http.ResponseWriter, r *http.Request) {
 	// decode the vote
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20) // 1 MiB limit for /votes
 	vote := &Vote{}
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			ErrRequestBodyTooLarge.Write(w)
+			return
+		}
 		ErrMalformedBody.Withf("could not decode request body: %v", err).Write(w)
 		return
 	}

--- a/api/vote.go
+++ b/api/vote.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -359,7 +360,8 @@ func (a *API) newVote(w http.ResponseWriter, r *http.Request) {
 		},
 	)
 	if err != nil {
-		ErrInvalidBallotProof.Withf("could not verify and convert proof: %v", err).Write(w)
+		log.Errorw(err, fmt.Sprintf("failed to verify and convert ballot proof for address %s", vote.Address))
+		ErrInvalidBallotProof.Write(w)
 		return
 	}
 	// Create the ballot object

--- a/api/vote_test.go
+++ b/api/vote_test.go
@@ -41,3 +41,17 @@ func TestNewVoteRejectsNonCanonicalAddressLength(t *testing.T) {
 	c.Assert(rr.Code, qt.Equals, http.StatusBadRequest)
 	c.Assert(rr.Body.String(), qt.Contains, "address must be 20 bytes")
 }
+
+func TestNewVoteBodyTooLarge(t *testing.T) {
+	c := qt.New(t)
+	api := &API{}
+	body := strings.Repeat("a", 1<<20+1)
+
+	req := httptest.NewRequest(http.MethodPost, VotesEndpoint, strings.NewReader(body))
+	rr := httptest.NewRecorder()
+
+	api.newVote(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusRequestEntityTooLarge)
+	c.Assert(rr.Body.String(), qt.Contains, "request body too large")
+}

--- a/api/workers.go
+++ b/api/workers.go
@@ -295,9 +295,15 @@ func (a *API) workersSubmitJob(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Decode verified ballot
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20) // 1 MiB limit for worker submissions
 	var workerVerifiedBallot storage.VerifiedBallot
 	body, err := io.ReadAll(r.Body) // Read the body to ensure it's consumed
 	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			ErrRequestBodyTooLarge.Write(w)
+			return
+		}
 		log.Warnw("failed to read request body",
 			"error", err.Error())
 		ErrMalformedBody.WithErr(err).Write(w)

--- a/api/workers.go
+++ b/api/workers.go
@@ -351,9 +351,8 @@ func (a *API) workersSubmitJob(w http.ResponseWriter, r *http.Request) {
 
 	// Verify the worker proof
 	if err := a.voteVerifier.Verify(workerVerifiedBallot.Proof, assignment); err != nil {
-		ErrGenericInternalServerError.WithErr(
-			fmt.Errorf("failed to verify worker proof, ballotHash: %v, proof: %v, err: %s",
-				assignment.BallotHash, workerVerifiedBallot.Proof, err.Error())).Write(w)
+		log.Errorw(err, fmt.Sprintf("failed to verify worker proof, ballotHash: %v, proof: %v", assignment.BallotHash, workerVerifiedBallot.Proof))
+		ErrGenericInternalServerError.Write(w)
 		return
 	}
 

--- a/api/workers.go
+++ b/api/workers.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"crypto/subtle"
 	"errors"
 	"fmt"
 	"io"
@@ -11,12 +12,15 @@ import (
 	"github.com/consensys/gnark/std/math/emulated"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
 	"github.com/vocdoni/davinci-node/circuits/voteverifier"
 	"github.com/vocdoni/davinci-node/crypto/signatures/ethereum"
 	"github.com/vocdoni/davinci-node/log"
 	"github.com/vocdoni/davinci-node/storage"
 	"github.com/vocdoni/davinci-node/workers"
 )
+
+const uuidTextLen = 36
 
 // startWorkersAPI method checks if the workers API should be started. If so,
 // it generates the sequencer signer and uuid using the seed defined in the
@@ -103,7 +107,7 @@ func (a *API) authWorkerFromRequest(r *http.Request) (common.Address, *Error) {
 	// Extract the sequencer UUID from the url and compare with UUID of the
 	// current sequencer API.
 	sequencerUUID := chi.URLParam(r, "uuid")
-	if a.sequencerUUID.String() != sequencerUUID {
+	if !a.matchesSequencerUUID(sequencerUUID) {
 		return common.Address{}, &ErrResourceNotFound
 	}
 
@@ -148,6 +152,22 @@ func (a *API) authWorkerFromRequest(r *http.Request) (common.Address, *Error) {
 	// updated
 	a.jobsManager.WorkerManager.AddWorker(strWorkerAddress, workerName)
 	return common.HexToAddress(strWorkerAddress), nil
+}
+
+func (a *API) matchesSequencerUUID(sequencerUUID string) bool {
+	if a == nil || a.sequencerUUID == nil {
+		return false
+	}
+	if len(sequencerUUID) != uuidTextLen {
+		return false
+	}
+
+	parsedUUID, err := uuid.Parse(sequencerUUID)
+	if err != nil {
+		return false
+	}
+
+	return subtle.ConstantTimeCompare(parsedUUID[:], a.sequencerUUID[:]) == 1
 }
 
 // workersList handles GET /workers

--- a/api/workers.go
+++ b/api/workers.go
@@ -60,7 +60,7 @@ func (a *API) startWorkersAPI(conf APIConfig) error {
 		log.Infow("register handler", "endpoint", WorkerJobEndpoint, "method", "POST")
 		a.router.Post(WorkerJobEndpoint, a.workersSubmitJob)
 
-		log.Infow("worker API enabled",
+		log.Debugw("worker API enabled",
 			"sequencerUUID", a.sequencerUUID.String(),
 			"sequencerAddr", a.sequencerSigner.Address().Hex(),
 			"workersEndpoint", EndpointWithParam(WorkersEndpoint, SequencerUUIDURLParam, a.sequencerUUID.String()))

--- a/api/workers_test.go
+++ b/api/workers_test.go
@@ -1,0 +1,23 @@
+package api
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/google/uuid"
+)
+
+func TestAPI_matchesSequencerUUID(t *testing.T) {
+	c := qt.New(t)
+
+	sequencerUUID := uuid.New()
+	api := &API{
+		sequencerUUID: &sequencerUUID,
+	}
+
+	c.Assert(api.matchesSequencerUUID(sequencerUUID.String()), qt.IsTrue)
+	c.Assert(api.matchesSequencerUUID(uuid.New().String()), qt.IsFalse)
+	c.Assert(api.matchesSequencerUUID("not-a-uuid"), qt.IsFalse)
+	c.Assert(api.matchesSequencerUUID(strings.Repeat("a", 4096)), qt.IsFalse)
+}

--- a/api/workers_test.go
+++ b/api/workers_test.go
@@ -1,11 +1,23 @@
 package api
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	qt "github.com/frankban/quicktest"
+	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
+	"github.com/vocdoni/davinci-node/crypto/signatures/ethereum"
+	"github.com/vocdoni/davinci-node/db"
+	"github.com/vocdoni/davinci-node/db/metadb"
+	"github.com/vocdoni/davinci-node/storage"
+	"github.com/vocdoni/davinci-node/workers"
 )
 
 func TestAPI_matchesSequencerUUID(t *testing.T) {
@@ -20,4 +32,67 @@ func TestAPI_matchesSequencerUUID(t *testing.T) {
 	c.Assert(api.matchesSequencerUUID(uuid.New().String()), qt.IsFalse)
 	c.Assert(api.matchesSequencerUUID("not-a-uuid"), qt.IsFalse)
 	c.Assert(api.matchesSequencerUUID(strings.Repeat("a", 4096)), qt.IsFalse)
+}
+
+func apiStorageForTest(t *testing.T) *storage.Storage {
+	c := qt.New(t)
+	tempDir := t.TempDir()
+	t.Cleanup(func() {
+		_ = os.RemoveAll(tempDir)
+	})
+
+	testDB, err := metadb.New(db.TypePebble, filepath.Join(tempDir, "db"))
+	c.Assert(err, qt.IsNil)
+
+	store := storage.New(testDB)
+	t.Cleanup(func() {
+		store.Close()
+	})
+	return store
+}
+
+func TestWorkersSubmitJobBodyTooLarge(t *testing.T) {
+	c := qt.New(t)
+
+	store := apiStorageForTest(t)
+	sequencerSigner, err := ethereum.NewSigner()
+	c.Assert(err, qt.IsNil)
+	workerSigner, err := ethereum.NewSigner()
+	c.Assert(err, qt.IsNil)
+	sequencerUUID := uuid.New()
+
+	jobsManager := workers.NewJobsManager(store, time.Minute, nil)
+	jobsManager.WorkerManager.AddWorker(workerSigner.Address().Hex(), "worker-1")
+
+	api := &API{
+		storage:                    store,
+		sequencerSigner:            sequencerSigner,
+		sequencerUUID:              &sequencerUUID,
+		jobsManager:                jobsManager,
+		workersAuthtokenExpiration: time.Minute,
+		parentCtx:                  context.Background(),
+	}
+
+	signMsg, createdAt, _ := workers.WorkerAuthTokenData(sequencerSigner.Address(), time.Now())
+	signature, err := workerSigner.Sign([]byte(signMsg))
+	c.Assert(err, qt.IsNil)
+	timestamp, err := time.Parse("2006-01-02T15:04:05.000000000Z07:00", createdAt)
+	c.Assert(err, qt.IsNil)
+	token, err := workers.EncodeWorkerAuthToken(signature, timestamp)
+	c.Assert(err, qt.IsNil)
+
+	body := strings.Repeat("a", 1<<20+1)
+	endpoint := EndpointWithParam(WorkerJobEndpoint, SequencerUUIDURLParam, sequencerUUID.String())
+	endpoint = EndpointWithParam(endpoint, WorkerAddressQueryParam, workerSigner.Address().Hex())
+	endpoint = EndpointWithParam(endpoint, WorkerTokenQueryParam, token.String())
+	req := httptest.NewRequest(http.MethodPost, endpoint, strings.NewReader(body))
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add(SequencerUUIDURLParam, sequencerUUID.String())
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx))
+	rr := httptest.NewRecorder()
+
+	api.workersSubmitJob(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusRequestEntityTooLarge)
+	c.Assert(rr.Body.String(), qt.Contains, "request body too large")
 }

--- a/circuits/aggregator/aggregator.go
+++ b/circuits/aggregator/aggregator.go
@@ -91,6 +91,7 @@ func (c *AggregatorCircuit) checkProofs(api frontend.API) {
 	verifier, err := groth16.NewVerifier[sw_bls12377.ScalarField, sw_bls12377.G1Affine, sw_bls12377.G2Affine, sw_bls12377.GT](api)
 	if err != nil {
 		circuits.FrontendError(api, "failed to create BLS12-377 verifier", err)
+		return
 	}
 	// verify each proof with the provided public inputs and the fixed
 	// verification key
@@ -100,6 +101,7 @@ func (c *AggregatorCircuit) checkProofs(api frontend.API) {
 		if err := verifier.AssertProof(c.VerificationKey, c.Proofs[i], witnesses[i],
 			groth16.WithCompleteArithmetic(), groth16.WithSubgroupCheck()); err != nil {
 			circuits.FrontendError(api, "failed to verify proof", err)
+			return
 		}
 	}
 }

--- a/circuits/statetransition/statetransition.go
+++ b/circuits/statetransition/statetransition.go
@@ -242,6 +242,7 @@ func (circuit StateTransitionCircuit) VerifyAggregatorProof(api frontend.API, is
 	witness, err := circuit.CalculateAggregatorWitness(api, isRealVote)
 	if err != nil {
 		circuits.FrontendError(api, "failed to create bw6761 witness: ", err)
+		return
 	}
 	// initialize the verifier
 	verifier, err := groth16.NewVerifier[sw_bw6761.ScalarField, sw_bw6761.G1Affine, sw_bw6761.G2Affine, sw_bw6761.GTEl](api)

--- a/circuits/test/statetransition/statetransition_test.go
+++ b/circuits/test/statetransition/statetransition_test.go
@@ -376,6 +376,7 @@ func (circuit CircuitCalculateAggregatorWitness) Define(api frontend.API) error 
 	_, err := circuit.CalculateAggregatorWitness(api, isRealVote)
 	if err != nil {
 		circuits.FrontendError(api, "failed to create bw6761 witness: ", err)
+		return nil
 	}
 	return nil
 }

--- a/circuits/types.go
+++ b/circuits/types.go
@@ -57,7 +57,8 @@ func (kt EncryptionKey[T]) SerializeAsTE(api frontend.API) []emulated.Element[sw
 	}
 	kTE0, kTE1, err := format.FromEmulatedRTEtoTE(api, k.PubKey[0], k.PubKey[1])
 	if err != nil {
-		FrontendError(api, "failed to convert encryption key to RTE", err)
+		FrontendError(api, "failed to convert encryption key from RTE to TE", err)
+		return nil
 	}
 	return []emulated.Element[sw_bn254.ScalarField]{kTE0, kTE1}
 }
@@ -265,6 +266,7 @@ func (z *Ballot) AssertDecrypt(api frontend.API, privKey frontend.Variable, orig
 	for i := range z {
 		if err := z[i].AssertDecrypt(api, privKey, originals[i]); err != nil {
 			FrontendError(api, "failed to assert decrypt", err)
+			return
 		}
 	}
 }
@@ -459,11 +461,13 @@ func (zt *EmulatedBallot[F]) SerializeAsTE(api frontend.API) []emulated.Element[
 	for _, zi := range z {
 		c1xTE, c1yTE, err := format.FromEmulatedRTEtoTE(api, zi.C1.X, zi.C1.Y)
 		if err != nil {
-			FrontendError(api, "failed to convert coords to RTE", err)
+			FrontendError(api, "failed to convert C1 from RTE to TE", err)
+			return nil
 		}
 		c2xTE, c2yTE, err := format.FromEmulatedRTEtoTE(api, zi.C2.X, zi.C2.Y)
 		if err != nil {
-			FrontendError(api, "failed to convert coords to RTE", err)
+			FrontendError(api, "failed to convert C2 from RTE to TE", err)
+			return nil
 		}
 		list = append(list,
 			c1xTE,

--- a/circuits/voteverifier/vote_verifier.go
+++ b/circuits/voteverifier/vote_verifier.go
@@ -102,11 +102,13 @@ func (c *VerifyVoteCircuit) verifySigForAddress(api frontend.API) {
 	msgSecp256, err := utils.UnpackVarToScalar[emulated.Secp256k1Fr](api, c.VoteID)
 	if err != nil {
 		circuits.FrontendError(api, "failed to unpack voteID", err)
+		return
 	}
 	// first convert the message to bytes and swap the endianness of the content (the hash of the data to be signed)
 	content, err := utils.BytesFromElement(api, *msgSecp256)
 	if err != nil {
-		circuits.FrontendError(api, "failed to convert circomHash to bytes", err)
+		circuits.FrontendError(api, "failed to convert voteID to bytes", err)
+		return
 	}
 	content = utils.SwapEndianness(content)
 	// concatenate the prefix and content to create the hash to be signed
@@ -114,6 +116,7 @@ func (c *VerifyVoteCircuit) verifySigForAddress(api frontend.API) {
 	keccak, err := sha3.NewLegacyKeccak256(api)
 	if err != nil {
 		circuits.FrontendError(api, "failed to create hash function", err)
+		return
 	}
 	keccak.Write(msg)
 	// we need to swap the endianess again and convert the bytes back to the emulated secp256k1 field
@@ -121,6 +124,7 @@ func (c *VerifyVoteCircuit) verifySigForAddress(api frontend.API) {
 	emulatedHash, err := utils.U8ToElem[emulated.Secp256k1Fr](api, hash)
 	if err != nil {
 		circuits.FrontendError(api, "failed to convert hash to emulated element", err)
+		return
 	}
 	// check the signature of the circom inputs hash provided as Secp256k1 emulated element
 	validSign := c.PublicKey.IsValid(api, sw_emulated.GetCurveParams[emulated.Secp256k1Fp](), &emulatedHash, &c.Signature)
@@ -132,11 +136,13 @@ func (c *VerifyVoteCircuit) verifySigForAddress(api frontend.API) {
 	derivedAddr, err := address.DeriveAddress(api, c.PublicKey)
 	if err != nil {
 		circuits.FrontendError(api, "failed to derive address", err)
+		return
 	}
 	// Convert the emulated address to a variable for comparison
 	addressVar, err := utils.PackScalarToVar(api, c.Address)
 	if err != nil {
 		circuits.FrontendError(api, "failed to convert address to var", err)
+		return
 	}
 	// Range constrain address to the canonical AddressLength.
 	rangecheck.New(api).Check(addressVar, common.AddressLength*8)
@@ -148,10 +154,12 @@ func assertValidSecp256k1PublicKey(api frontend.API, pubKey ecdsa.PublicKey[emul
 	curve, err := sw_emulated.New[emulated.Secp256k1Fp, emulated.Secp256k1Fr](api, sw_emulated.GetCurveParams[emulated.Secp256k1Fp]())
 	if err != nil {
 		circuits.FrontendError(api, "failed to initialize secp256k1 curve", err)
+		return
 	}
 	baseApi, err := emulated.NewField[emulated.Secp256k1Fp](api)
 	if err != nil {
 		circuits.FrontendError(api, "failed to initialize secp256k1 field", err)
+		return
 	}
 	pkPoint := sw_emulated.AffinePoint[emulated.Secp256k1Fp]{X: pubKey.X, Y: pubKey.Y}
 	curve.AssertIsOnCurve(&pkPoint)
@@ -168,6 +176,7 @@ func (c *VerifyVoteCircuit) verifyCircomProof(api frontend.API) {
 	voteID, err := utils.UnpackVarToScalar[sw_bn254.ScalarField](api, c.VoteID)
 	if err != nil {
 		circuits.FrontendError(api, "failed to convert voteID to bn254", err)
+		return
 	}
 	witness := groth16.Witness[sw_bn254.ScalarField]{
 		Public: []emulated.Element[sw_bn254.ScalarField]{c.Address, *voteID, c.BallotHash},
@@ -176,12 +185,14 @@ func (c *VerifyVoteCircuit) verifyCircomProof(api frontend.API) {
 	verifier, err := groth16.NewVerifier[sw_bn254.ScalarField, sw_bn254.G1Affine, sw_bn254.G2Affine, sw_bn254.GTEl](api)
 	if err != nil {
 		circuits.FrontendError(api, "failed to create BN254 verifier", err)
+		return
 	}
 	validProof, err := verifier.IsValidProof(c.CircomVerificationKey, c.CircomProof,
 		witness, groth16.WithCompleteArithmetic(), groth16.WithSubgroupCheck())
 	if err != nil {
 		circuits.FrontendError(api, "failed to verify circom proof", err)
 		api.AssertIsEqual(0, 1)
+		return
 	}
 	// if the inputs are valid, ensure that the result of the verification is 1,
 	// otherwise, the result does not matter so force it to be 1

--- a/crypto/blobs/barycentric.go
+++ b/crypto/blobs/barycentric.go
@@ -181,6 +181,9 @@ func EvaluateBarycentricNative(blob *types.Blob, z *big.Int, debug bool) (*big.I
 // blobCell extracts the i-th 32-byte element from the blob and converts it to a big integer.
 // The blob stores field elements in big-endian format.
 func blobCell(blob *types.Blob, i int) *big.Int {
+	if i < 0 || i >= len(*blob)/32 {
+		return big.NewInt(0)
+	}
 	start := i * 32
 	return new(big.Int).SetBytes(blob[start : start+32])
 }

--- a/crypto/blobs/blob.go
+++ b/crypto/blobs/blob.go
@@ -99,8 +99,10 @@ func (b *BlobEvalData) TxSidecar() *types.BlobTxSidecar {
 }
 
 // ComputeEvaluationPoint computes evaluation point z using Poseidon hash.
-// z = Poseidon(processID | rootHashBefore | C | blob)
+// z = Poseidon(processID | rootHashBefore | C)
 // where C is the KZG commitment split into 3 × 16-byte limbs.
+// Note: the blob itself is not hashed because the commitment C is binding to it
+// under the KZG scheme.
 func ComputeEvaluationPoint(processID, rootHashBefore *big.Int, commitment types.KZGCommitment) (*big.Int, error) {
 	// Split 48-byte commitment into 3 × 16-byte limbs
 	limbs := commitment.ToLimbs()

--- a/crypto/elgamal/elgamal.go
+++ b/crypto/elgamal/elgamal.go
@@ -28,8 +28,8 @@ func Encrypt(publicKey ecc.Point, msg *big.Int) (ecc.Point, ecc.Point, *big.Int,
 // points that represent the encrypted message.
 func EncryptWithK(pubKey ecc.Point, msg, k *big.Int) (ecc.Point, ecc.Point) {
 	order := pubKey.Order()
-	// ensure the message is within the field
-	msg.Mod(msg, order)
+	// ensure the message is within the field without mutating the caller's value
+	m := new(big.Int).Mod(msg, order)
 	// compute C1 = k * G
 	c1 := pubKey.New()
 	c1.ScalarBaseMult(k)
@@ -37,11 +37,11 @@ func EncryptWithK(pubKey ecc.Point, msg, k *big.Int) (ecc.Point, ecc.Point) {
 	s := pubKey.New()
 	s.ScalarMult(pubKey, k)
 	// encode message as point M = message * G
-	m := pubKey.New()
-	m.ScalarBaseMult(msg)
+	mPoint := pubKey.New()
+	mPoint.ScalarBaseMult(m)
 	// compute C2 = M + s
 	c2 := pubKey.New()
-	c2.Add(m, s)
+	c2.Add(mPoint, s)
 	return c1, c2
 }
 

--- a/crypto/elgamal/proof.go
+++ b/crypto/elgamal/proof.go
@@ -107,9 +107,9 @@ func BuildDecryptionProof(
 	A2.ScalarMult(c1, r) // r·C1
 
 	// 3. Compute D = C2 – M·G  (shared secret part)
-	msg.Mod(msg, order)
+	m := new(big.Int).Mod(msg, order)
 	M := publicKey.New()
-	M.ScalarBaseMult(msg) // M·G
+	M.ScalarBaseMult(m) // M·G
 
 	D := publicKey.New()
 	D.Set(c2)
@@ -148,9 +148,9 @@ func VerifyDecryptionProof(
 	order := publicKey.Order()
 
 	// Recompute D = C2 – M·G
-	msg.Mod(msg, order)
+	m := new(big.Int).Mod(msg, order)
 	M := publicKey.New()
-	M.ScalarBaseMult(msg)
+	M.ScalarBaseMult(m)
 
 	D := publicKey.New()
 	D.Set(c2)

--- a/crypto/helpers.go
+++ b/crypto/helpers.go
@@ -9,24 +9,6 @@ import "math/big"
 // field elements
 const SignatureCircuitVariableLen = 32 // bytes
 
-// BigIntToFFToSign transform the inputs bigInt to the field provided, if it
-// is not done, the circuit will transform it during the witness calculation
-// and the resulting hash will be different. Moreover, the input hash should
-// be 32 bytes so if it is not, fill with zeros at the beginning of the bytes
-// representation.
-func BigIntToFFToSign(input, field *big.Int) []byte {
-	return BigIntToBytesToSign(BigToFF(field, input))
-}
-
-// BigIntToBytesToSign converts a big.Int to a byte slice, ensuring that
-// the resulting byte slice has SignatureCircuitVariableLen bytes. If the
-// byte slice is shorter than SerializedFieldSize, it prepends zeros until
-// the length is equal to SerializedFieldSize. If the byte slice is longer,
-// it truncates it to the last SerializedFieldSize bytes.
-func BigIntToBytesToSign(input *big.Int) []byte {
-	return PadToSign(input.Bytes())
-}
-
 // PadToSign pads the input byte slice to ensure it has a length of
 // SignatureCircuitVariableLen bytes. If the input is shorter, it prepends
 // zeros until the length is equal to SignatureCircuitVariableLen. If the

--- a/crypto/helpers.go
+++ b/crypto/helpers.go
@@ -3,8 +3,6 @@
 // serialization, and other cryptographic operations.
 package crypto
 
-import "math/big"
-
 // SignatureCircuitVariableLen is the standard size in bytes for serialized
 // field elements
 const SignatureCircuitVariableLen = 32 // bytes
@@ -27,16 +25,4 @@ func PadToSign(input []byte) []byte {
 		input = input[len(input)-SignatureCircuitVariableLen:]
 	}
 	return input
-}
-
-// BigToFF function returns the finite field representation of the big.Int
-// provided. It uses the curve scalar field to represent the provided number.
-func BigToFF(field, iv *big.Int) *big.Int {
-	z := big.NewInt(0)
-	if c := iv.Cmp(field); c == 0 {
-		return z
-	} else if c != 1 && iv.Cmp(z) != -1 {
-		return iv
-	}
-	return z.Mod(iv, field)
 }

--- a/crypto/signatures/ethereum/signature.go
+++ b/crypto/signatures/ethereum/signature.go
@@ -125,7 +125,10 @@ func (sig *ECDSASignature) Verify(signedInput []byte, expectedAddress common.Add
 		return false, nil
 	}
 	// Check if the public key matches the expected address
-	return bytes.Equal(ethcrypto.PubkeyToAddress(*pubKey).Bytes(), expectedAddress.Bytes()), ethcrypto.FromECDSAPub(pubKey)
+	if !bytes.Equal(ethcrypto.PubkeyToAddress(*pubKey).Bytes(), expectedAddress.Bytes()) {
+		return false, nil
+	}
+	return true, ethcrypto.FromECDSAPub(pubKey)
 }
 
 // String returns a string representation of the ECDSASignature, including

--- a/crypto/signatures/ethereum/signature.go
+++ b/crypto/signatures/ethereum/signature.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math/big"
 
-	gecc "github.com/consensys/gnark-crypto/ecc"
 	"github.com/ethereum/go-ethereum/common"
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/vocdoni/davinci-node/crypto"
@@ -102,15 +101,6 @@ func (sig *ECDSASignature) SetBytes(signature []byte) *ECDSASignature {
 	}
 
 	return sig
-}
-
-// VerifyBLS12377 checks if the signature is valid for the given input and
-// public key. The public key should be an ecdsa address. The input should be
-// a big integer that will be converted in a byte slice ensuring that the final
-// value is in the expected scalar field (BLS12_377) and has the expected size.
-func (sig *ECDSASignature) VerifyBLS12377(signedInput *big.Int, expectedAddress common.Address) (bool, []byte) {
-	ffInput := crypto.BigIntToFFToSign(signedInput, gecc.BLS12_377.ScalarField())
-	return sig.Verify(ffInput, expectedAddress)
 }
 
 // VerifyVoteID checks if the signature is valid for the given voteID.

--- a/crypto/signatures/ethereum/signature.go
+++ b/crypto/signatures/ethereum/signature.go
@@ -53,8 +53,8 @@ func (sig *ECDSASignature) Valid() bool {
 
 // Bytes returns the bytes of the binary representation of the signature, which
 // is built by appending the R and S values as byte slices and the recovery byte.
-// The recovery byte is adjusted to the Ethereum standard format (27-30) for compatibility
-// with ethcrypto.SigToPub().
+// The recovery byte is preserved as-is in Ethereum's low form (0-3), which is
+// compatible with ethcrypto.SigToPub().
 func (sig *ECDSASignature) Bytes() []byte {
 	rBytes := sig.R.Bytes()
 	sBytes := sig.S.Bytes()
@@ -65,12 +65,9 @@ func (sig *ECDSASignature) Bytes() []byte {
 	copy(r[32-len(rBytes):], rBytes)
 	copy(s[32-len(sBytes):], sBytes)
 
-	// Subtract 27 from the recovery value to match Ethereum standard
-	// Internal representation is 0-3, but Ethereum expects 27-30
+	// Preserve the recovery byte so SetBytes(Bytes(sig)) is lossless.
+	// ethcrypto.SigToPub accepts the low Ethereum recovery form (0-3).
 	v := sig.recovery
-	if v > 1 {
-		v -= 27
-	}
 
 	return append(r, append(s, v)...)
 }

--- a/crypto/signatures/ethereum/signature.go
+++ b/crypto/signatures/ethereum/signature.go
@@ -77,12 +77,16 @@ func (sig *ECDSASignature) SetBytes(signature []byte) *ECDSASignature {
 	if len(signature) < SignatureLength-1 {
 		return nil
 	}
-	//var sigStruct gecdsa.Signature
-	//if _, err := sigStruct.SetBytes(signature[:64]); err != nil {
-	//	return nil
-	//}
 	sig.R = new(big.Int).SetBytes(signature[:32])
 	sig.S = new(big.Int).SetBytes(signature[32:64])
+
+	// Reject high-S signatures to prevent malleability (R-01)
+	// S must be in [1, n/2]
+	n := ethcrypto.S256().Params().N
+	halfOrder := new(big.Int).Rsh(n, 1)
+	if sig.S.Cmp(halfOrder) > 0 {
+		return nil
+	}
 
 	if len(signature) == SignatureLength {
 		// Make a copy of the recovery byte to avoid modifying the input array

--- a/crypto/signatures/ethereum/signature_test.go
+++ b/crypto/signatures/ethereum/signature_test.go
@@ -111,6 +111,23 @@ func TestECDSASignature_Bytes(t *testing.T) {
 	c.Assert(recoveredSig.recovery, qt.Equals, sig.recovery)
 }
 
+func TestECDSASignature_BytesPreservesRecovery(t *testing.T) {
+	c := qt.New(t)
+
+	sig := &ECDSASignature{
+		R:        big.NewInt(123),
+		S:        big.NewInt(456),
+		recovery: 3,
+	}
+
+	bytes := sig.Bytes()
+	c.Assert(bytes[64], qt.Equals, sig.recovery)
+
+	recoveredSig, err := BytesToSignature(bytes)
+	c.Assert(err, qt.IsNil)
+	c.Assert(recoveredSig.recovery, qt.Equals, sig.recovery)
+}
+
 func TestECDSASignature_Verify(t *testing.T) {
 	c := qt.New(t)
 

--- a/spec/hash/stateroot.go
+++ b/spec/hash/stateroot.go
@@ -36,7 +36,7 @@ func StateRoot(processID, censusOrigin, pubKeyX, pubKeyY, ballotMode *big.Int) (
 	keyCensusOrigin := bigFromUint64(params.StateKeyCensusOrigin)
 
 	leafProcess, err := PoseidonHash(keyProcessID,
-		bigToFF(params.StateTransitionCurve.ScalarField(), processID), leafDomain)
+		new(big.Int).Mod(processID, params.StateTransitionCurve.ScalarField()), leafDomain)
 	if err != nil {
 		return nil, fmt.Errorf("state root: leaf process: %w", err)
 	}

--- a/spec/hash/stateroot_test.go
+++ b/spec/hash/stateroot_test.go
@@ -75,7 +75,7 @@ func TestStateRootMatchesManualConstruction(t *testing.T) {
 	keyResults := big.NewInt(int64(params.StateKeyResults))
 
 	leafProcess, err := PoseidonHash(keyProcessID,
-		bigToFF(params.StateTransitionCurve.ScalarField(), processID), leafDomain)
+		new(big.Int).Mod(processID, params.StateTransitionCurve.ScalarField()), leafDomain)
 	if err != nil {
 		t.Fatalf("leafProcess error: %v", err)
 	}

--- a/spec/hash/voteid.go
+++ b/spec/hash/voteid.go
@@ -15,9 +15,9 @@ func VoteID(processID, address, k *big.Int) (*big.Int, error) {
 	}
 	baseField := params.BallotProofCurve.ScalarField()
 	h, err := PoseidonHash(
-		bigToFF(baseField, processID),
-		bigToFF(baseField, address),
-		bigToFF(baseField, k),
+		new(big.Int).Mod(processID, baseField),
+		new(big.Int).Mod(address, baseField),
+		new(big.Int).Mod(k, baseField),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate vote ID: %w", err)
@@ -31,14 +31,4 @@ func TruncateToLowerBits(input *big.Int, bits uint) *big.Int {
 	mask := new(big.Int).Lsh(big.NewInt(1), bits) // 1 << bits
 	mask.Sub(mask, big.NewInt(1))                 // (1 << bits) - 1
 	return new(big.Int).And(input, mask)          // input & ((1 << bits) - 1)
-}
-
-func bigToFF(field, value *big.Int) *big.Int {
-	z := big.NewInt(0)
-	if c := value.Cmp(field); c == 0 {
-		return z
-	} else if c != 1 && value.Cmp(z) != -1 {
-		return value
-	}
-	return z.Mod(value, field)
 }

--- a/types/big.go
+++ b/types/big.go
@@ -162,14 +162,7 @@ func (i *BigInt) LessThanOrEqual(j *BigInt) bool {
 }
 
 func (i *BigInt) ToFF(field *big.Int) *BigInt {
-	iv := i.MathBigInt()
-	z := big.NewInt(0)
-	if c := iv.Cmp(field); c == 0 {
-		return (*BigInt)(z)
-	} else if c != 1 && iv.Cmp(z) != -1 {
-		return (*BigInt)(iv)
-	}
-	return (*BigInt)(z.Mod(iv, field))
+	return (*BigInt)(new(big.Int).Mod(i.MathBigInt(), field))
 }
 
 func (i *BigInt) IsInField(field *big.Int) bool {

--- a/types/process_id.go
+++ b/types/process_id.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
-	"github.com/vocdoni/davinci-node/crypto"
 	"github.com/vocdoni/davinci-node/util"
 )
 
@@ -130,7 +129,7 @@ func (p *ProcessID) UnmarshalJSON(data []byte) error {
 // ToFF returns the finite field representation of the ProcessID.
 // It uses the curve scalar field to represent the ProcessID.
 func (p *ProcessID) ToFF(field *big.Int) ProcessID {
-	bi := crypto.BigToFF(field, p.MathBigInt())
+	bi := new(big.Int).Mod(p.MathBigInt(), field)
 	var processID ProcessID
 	bi.FillBytes(processID[:])
 	return processID


### PR DESCRIPTION
- **fix(api): disable CORS AllowCredentials on wildcard origin**
- **fix(api): verify signature before expensive proof verification**
- **fix(api): constant-time comparison for worker UUID**
- **fix(api): hide worker UUID from INFO-level startup logs**
- **fix(crypto): canonicalize recovery byte in ECDSASignature.Bytes()**
- **fix(crypto): stop mutating caller-owned *big.Int in elgamal**
- **fix(docs): correct ComputeEvaluationPoint comment to match implementation**
- **fix(circuits): return after FrontendError**
- **refactor(all): simplify ToFF helpers**
