### PR TITLE
fix(sequencer): bound results decryption search

### DIFF
--- a/crypto/elgamal/elgamal.go
+++ b/crypto/elgamal/elgamal.go
@@ -75,9 +75,6 @@ func Decrypt(
 	if privateKey == nil || privateKey.Sign() <= 0 {
 		return nil, nil, fmt.Errorf("Decrypt: empty or negative private key")
 	}
-	if maxMessage == 0 {
-		return nil, nil, fmt.Errorf("Decrypt: maxMessage == 0")
-	}
 
 	// recover the plaintext point
 
@@ -107,6 +104,15 @@ func Decrypt(
 // compressed point encoding as hash‑map key to remove an O(1) string
 // allocation at every iteration present in the original version.
 func BabyStepGiantStepECC(beta, alpha ecc.Point, max uint64) (*big.Int, error) {
+	if max == 0 {
+		zero := beta.New()
+		zero.SetZero()
+		if beta.Equal(zero) {
+			return big.NewInt(0), nil
+		}
+		return nil, fmt.Errorf("bsgs: discrete log not found in interval")
+	}
+
 	// compute m = ⌈sqrt(max)⌉ using integer arithmetic only
 	m := new(big.Int).Sqrt(new(big.Int).SetUint64(max))
 	if new(big.Int).Mul(m, m).Cmp(new(big.Int).SetUint64(max)) < 0 {

--- a/crypto/elgamal/elgamal_test.go
+++ b/crypto/elgamal/elgamal_test.go
@@ -54,6 +54,28 @@ func TestEncryptDecrypt(t *testing.T) {
 	}
 }
 
+func TestDecryptAllowsZeroUpperBoundForZeroMessage(t *testing.T) {
+	c := qt.New(t)
+	curve := curves.New(bn254.CurveType)
+
+	publicKey, privateKey, err := GenerateKey(curve)
+	c.Assert(err, qt.IsNil)
+
+	msg := big.NewInt(0)
+	c1, c2, _, err := Encrypt(publicKey, msg)
+	c.Assert(err, qt.IsNil)
+
+	M, recoveredMsg, err := Decrypt(publicKey, privateKey, c1, c2, 0)
+	c.Assert(err, qt.IsNil)
+	c.Assert(recoveredMsg, qt.Not(qt.IsNil))
+	c.Assert(recoveredMsg.Cmp(msg), qt.Equals, 0)
+
+	testPoint := curve.New()
+	testPoint.SetGenerator()
+	testPoint.ScalarMult(testPoint, msg)
+	c.Assert(testPoint.Equal(M), qt.IsTrue)
+}
+
 func TestCheckK(t *testing.T) {
 	c := qt.New(t)
 

--- a/sequencer/finalizer.go
+++ b/sequencer/finalizer.go
@@ -19,7 +19,12 @@ import (
 	"github.com/vocdoni/davinci-node/types"
 )
 
-const maxValue = 2 << 24 // 2^24
+// maxPossibleResultCap bounds the BSGS discrete-log search used to decrypt
+// accumulated results. It is an operational guardrail against too-expensive
+// decryption, and it also matches the onchain business cap
+// `maxVoters * maxValue < 1_000_000_000_000`. The runtime still narrows each
+// search further to `process.BallotMode.MaxValue * process.VotersCount`.
+const maxPossibleResultCap = 1_000_000_000_000
 
 // finalizer is responsible for finalizing processes.
 type finalizer struct {
@@ -33,6 +38,35 @@ type finalizer struct {
 	cancel           context.CancelFunc
 	lock             sync.Mutex                                   // Mutex to ensure that only one process results calculation is running at a time
 	getStateRoot     func(types.ProcessID) (*types.BigInt, error) // Function to get state root from contract
+}
+
+// maxPossibleResult returns the maximum possible accumulated result for a
+// process, computed as VotersCount * BallotMode.MaxValue, capped by the
+// operational search limit (maxPossibleResultCap). A nil VotersCount is
+// treated as zero counted voters.
+func maxPossibleResult(process *types.Process) uint64 {
+	if process == nil {
+		return maxPossibleResultCap
+	}
+	if process.VotersCount == nil {
+		return 0
+	}
+
+	votersCount := process.VotersCount.MathBigInt()
+	if !votersCount.IsUint64() {
+		return maxPossibleResultCap
+	}
+
+	count := votersCount.Uint64()
+	maxValue := process.BallotMode.MaxValue
+	if count == 0 || maxValue == 0 {
+		return 0
+	}
+	if maxValue > maxPossibleResultCap/count {
+		return maxPossibleResultCap
+	}
+
+	return maxValue * count
 }
 
 // New creates a new Finalizer instance.
@@ -283,12 +317,13 @@ func (f *finalizer) finalize(processID types.ProcessID) error {
 	resultsAccumulator := [params.FieldsPerBallot]*big.Int{}
 	accumulatorsEncrypted := [params.FieldsPerBallot]elgamal.Ciphertext{}
 	decryptionProofs := [params.FieldsPerBallot]*elgamal.DecryptionProof{}
+	maxResult := maxPossibleResult(process)
 	for i, ct := range encryptedResultsAccumulator.Ciphertexts {
 		if ct.C1 == nil || ct.C2 == nil {
 			setProcessInvalid()
 			return fmt.Errorf("invalid ciphertext for process %s: %v", processID.String(), ct)
 		}
-		_, result, err := elgamal.Decrypt(encryptionPubKey, encryptionPrivKey, ct.C1, ct.C2, maxValue)
+		_, result, err := elgamal.Decrypt(encryptionPubKey, encryptionPrivKey, ct.C1, ct.C2, maxResult)
 		if err != nil {
 			setProcessInvalid()
 			return fmt.Errorf("could not decrypt results accumulator for process %s: %w", processID.String(), err)

--- a/sequencer/finalizer_test.go
+++ b/sequencer/finalizer_test.go
@@ -14,12 +14,59 @@ import (
 	"github.com/vocdoni/davinci-node/db"
 	"github.com/vocdoni/davinci-node/db/metadb"
 	"github.com/vocdoni/davinci-node/internal/testutil"
+	"github.com/vocdoni/davinci-node/spec"
 	"github.com/vocdoni/davinci-node/spec/params"
 	specutil "github.com/vocdoni/davinci-node/spec/util"
 	"github.com/vocdoni/davinci-node/state"
 	"github.com/vocdoni/davinci-node/storage"
 	"github.com/vocdoni/davinci-node/types"
 )
+
+func TestMaxPossibleResult(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		process *types.Process
+		want    uint64
+	}{
+		{
+			name: "returns zero when no votes can contribute",
+			process: &types.Process{
+				BallotMode:  spec.BallotMode{MaxValue: 16},
+				VotersCount: types.BigIntConverter(big.NewInt(0)),
+			},
+			want: 0,
+		},
+		{
+			name: "uses maxValue times votersCount",
+			process: &types.Process{
+				BallotMode:  spec.BallotMode{MaxValue: 16},
+				VotersCount: types.BigIntConverter(big.NewInt(3)),
+			},
+			want: 48,
+		},
+		{
+			name: "caps at fallback maximum",
+			process: &types.Process{
+				BallotMode:  spec.BallotMode{MaxValue: 1_000_000_000_000},
+				VotersCount: types.BigIntConverter(big.NewInt(2)),
+			},
+			want: maxPossibleResultCap,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := maxPossibleResult(tc.process); got != tc.want {
+				t.Fatalf("maxPossibleResult() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
 
 func loadResultsVerifierArtifactsForTest(t *testing.T) *internalCircuits {
 	t.Helper()

--- a/spec/params/params.go
+++ b/spec/params/params.go
@@ -9,8 +9,6 @@ import (
 const (
 	// FieldsPerBallot is the number of fields in a ballot.
 	FieldsPerBallot = 8
-	// MaxValuePerBallotField is the maximum value per field in a ballot.
-	MaxValuePerBallotField = 2 << 16
 	// VotesPerBatch is the number of votes per zkSnark batch.
 	VotesPerBatch = 60
 	// StateTreeMaxLevels is the maximum number of levels in the state merkle tree.


### PR DESCRIPTION
Replace the finalizer's fixed decrypt search window with a
per-process max possible result derived from ballot mode and
voter count, capped to guard against overly expensive BSGS
decryption.

Simplify the helper to use overflow-safe uint64 math, return
zero for zero-contribution cases, and document why the cap is
set to 1_000_000_000_000.

Remove the unused MaxValuePerBallotField constant and add
regression coverage for the derived bound behavior.
