### PR TITLE
refactor(api): extract ballot proof verifier

### DIFF
--- a/api/ballotproof_verifier.go
+++ b/api/ballotproof_verifier.go
@@ -1,0 +1,68 @@
+package api
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/vocdoni/davinci-node/circuits/ballotproof"
+	"github.com/vocdoni/davinci-node/spec/params"
+	"github.com/vocdoni/davinci-node/types"
+	"github.com/vocdoni/davinci-node/util/circomgnark"
+)
+
+type ballotProofVerifier struct {
+	rawVerifyingKeyFn  func() ([]byte, error)
+	verifyAndConvertFn func(vkey []byte, proof *circomgnark.CircomProof, pubSignals []string) (*circomgnark.GnarkRecursionProof, error)
+
+	vkMu sync.Mutex
+	vk   []byte
+}
+
+var defaultBallotProofVerifier = &ballotProofVerifier{
+	rawVerifyingKeyFn:  ballotproof.Artifacts.RawVerifyingKey,
+	verifyAndConvertFn: circomgnark.VerifyAndConvertToRecursion,
+}
+
+func (v *ballotProofVerifier) VerifyBallotProof(
+	address types.HexBytes,
+	voteID types.VoteID,
+	ballotInputsHash *types.BigInt,
+	proof *circomgnark.CircomProof,
+) (*circomgnark.GnarkRecursionProof, error) {
+	if ballotInputsHash == nil {
+		return nil, fmt.Errorf("ballot inputs hash is required")
+	}
+	if proof == nil {
+		return nil, fmt.Errorf("ballot proof is required")
+	}
+	rawBallotProofVK, err := v.rawVerifyingKey()
+	if err != nil {
+		return nil, fmt.Errorf("load ballot proof verification key: %w", err)
+	}
+
+	verifiedProof, err := v.verifyAndConvertFn(rawBallotProofVK, proof, []string{
+		address.BigInt().ToFF(params.BallotProofCurve.ScalarField()).String(),
+		voteID.BigInt().String(),
+		ballotInputsHash.String(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("verify and convert ballot proof: %w", err)
+	}
+	return verifiedProof, nil
+}
+
+func (v *ballotProofVerifier) rawVerifyingKey() ([]byte, error) {
+	v.vkMu.Lock()
+	defer v.vkMu.Unlock()
+
+	if v.vk != nil {
+		return v.vk, nil
+	}
+
+	vk, err := v.rawVerifyingKeyFn()
+	if err != nil {
+		return nil, err
+	}
+	v.vk = vk
+	return v.vk, nil
+}

--- a/api/ballotproof_verifier_test.go
+++ b/api/ballotproof_verifier_test.go
@@ -1,0 +1,93 @@
+package api
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/vocdoni/davinci-node/spec/params"
+	"github.com/vocdoni/davinci-node/types"
+	"github.com/vocdoni/davinci-node/util/circomgnark"
+)
+
+func TestBallotProofVerifierVerifyBallotProof(t *testing.T) {
+	c := qt.New(t)
+
+	expectedVK := []byte("vk")
+	expectedProof := &circomgnark.GnarkRecursionProof{}
+	circomProof := &circomgnark.CircomProof{}
+
+	var gotVK []byte
+	var gotProof *circomgnark.CircomProof
+	var gotSignals []string
+
+	verifier := ballotProofVerifier{
+		rawVerifyingKeyFn: func() ([]byte, error) {
+			return expectedVK, nil
+		},
+		verifyAndConvertFn: func(vk []byte, proof *circomgnark.CircomProof, pubSignals []string) (*circomgnark.GnarkRecursionProof, error) {
+			gotVK = append([]byte(nil), vk...)
+			gotProof = proof
+			gotSignals = append([]string(nil), pubSignals...)
+			return expectedProof, nil
+		},
+	}
+
+	address := types.HexBytes{0x12, 0x34}
+	voteID := types.VoteID(123)
+	ballotInputsHash := types.NewInt(456)
+
+	proof, err := verifier.VerifyBallotProof(address, voteID, ballotInputsHash, circomProof)
+	c.Assert(err, qt.IsNil)
+	c.Assert(proof, qt.Equals, expectedProof)
+	c.Assert(gotVK, qt.DeepEquals, expectedVK)
+	c.Assert(gotProof, qt.Equals, circomProof)
+	c.Assert(gotSignals, qt.DeepEquals, []string{
+		address.BigInt().ToFF(params.BallotProofCurve.ScalarField()).String(),
+		voteID.BigInt().String(),
+		ballotInputsHash.String(),
+	})
+}
+
+func TestBallotProofVerifierCachesRawVerifyingKey(t *testing.T) {
+	c := qt.New(t)
+
+	circomProof := &circomgnark.CircomProof{}
+	ballotInputsHash := types.NewInt(456)
+
+	loads := 0
+	verifier := ballotProofVerifier{
+		rawVerifyingKeyFn: func() ([]byte, error) {
+			loads++
+			return []byte("vk"), nil
+		},
+		verifyAndConvertFn: func(vk []byte, proof *circomgnark.CircomProof, pubSignals []string) (*circomgnark.GnarkRecursionProof, error) {
+			return &circomgnark.GnarkRecursionProof{}, nil
+		},
+	}
+
+	_, err := verifier.VerifyBallotProof(types.HexBytes{0x01}, types.VoteID(1), ballotInputsHash, circomProof)
+	c.Assert(err, qt.IsNil)
+	_, err = verifier.VerifyBallotProof(types.HexBytes{0x02}, types.VoteID(2), ballotInputsHash, circomProof)
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(loads, qt.Equals, 1)
+}
+
+func TestBallotProofVerifierRawVerifyingKeyReturnsCachedSlice(t *testing.T) {
+	c := qt.New(t)
+
+	verifier := ballotProofVerifier{
+		rawVerifyingKeyFn: func() ([]byte, error) {
+			return []byte("vk"), nil
+		},
+	}
+
+	first, err := verifier.rawVerifyingKey()
+	c.Assert(err, qt.IsNil)
+	c.Assert(first, qt.DeepEquals, []byte("vk"))
+
+	second, err := verifier.rawVerifyingKey()
+	c.Assert(err, qt.IsNil)
+	c.Assert(second, qt.DeepEquals, []byte("vk"))
+	c.Assert(second, qt.DeepEquals, first)
+}

--- a/api/vote.go
+++ b/api/vote.go
@@ -16,11 +16,9 @@ import (
 	"github.com/vocdoni/davinci-node/crypto/elgamal"
 	"github.com/vocdoni/davinci-node/crypto/signatures/ethereum"
 	"github.com/vocdoni/davinci-node/log"
-	"github.com/vocdoni/davinci-node/spec/params"
 	"github.com/vocdoni/davinci-node/state"
 	"github.com/vocdoni/davinci-node/storage"
 	"github.com/vocdoni/davinci-node/types"
-	"github.com/vocdoni/davinci-node/util/circomgnark"
 )
 
 // voteStatus returns the status of a vote for a given processID and voteID
@@ -342,22 +340,11 @@ func (a *API) newVote(w http.ResponseWriter, r *http.Request) {
 		ErrInvalidBallotInputsHash.Withf("ballot inputs hash mismatch").Write(w)
 		return
 	}
-	rawBallotProofVK, err := ballotproof.Artifacts.RawVerifyingKey()
-	if err != nil {
-		ErrGenericInternalServerError.Withf("could not load ballot proof verification key: %v", err).Write(w)
-		return
-	}
-	// convert the circom proof to gnark proof and verify it
-	ballotProofAddress := vote.Address.BigInt().ToFF(params.BallotProofCurve.ScalarField())
-	ballotProofVoteID := vote.VoteID.BigInt() // ToFF unneeded since VoteID is a uint64
-	proof, err := circomgnark.VerifyAndConvertToRecursion(
-		rawBallotProofVK,
+	proof, err := defaultBallotProofVerifier.VerifyBallotProof(
+		vote.Address,
+		vote.VoteID,
+		vote.BallotInputsHash,
 		vote.BallotProof,
-		[]string{
-			ballotProofAddress.String(),
-			ballotProofVoteID.String(),
-			vote.BallotInputsHash.String(),
-		},
 	)
 	if err != nil {
 		log.Errorw(err, fmt.Sprintf("failed to verify and convert ballot proof for address %s", vote.Address))

--- a/sequencer/finalizer.go
+++ b/sequencer/finalizer.go
@@ -3,6 +3,7 @@ package sequencer
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"sync"
@@ -25,6 +26,8 @@ import (
 // `maxVoters * maxValue < 1_000_000_000_000`. The runtime still narrows each
 // search further to `process.BallotMode.MaxValue * process.VotersCount`.
 const maxPossibleResultCap = 1_000_000_000_000
+
+var ErrProcessEncryptionKeysMissing = errors.New("process encryption keys missing")
 
 // finalizer is responsible for finalizing processes.
 type finalizer struct {
@@ -99,6 +102,10 @@ func (f *finalizer) Start(ctx context.Context, monitorInterval time.Duration) {
 					// Check if process is marked as invalid (thread-safe)
 					if _, isInvalid := f.invalidProcesses.Load(processID); !isInvalid {
 						if err := f.finalize(processID); err != nil {
+							if errors.Is(err, ErrProcessEncryptionKeysMissing) {
+								log.Infow(err.Error(), "processID", processID.String())
+								return
+							}
 							log.Errorw(err, fmt.Sprintf("finalizing process %s", processID.String()))
 						}
 					}
@@ -278,11 +285,10 @@ func (f *finalizer) finalize(processID types.ProcessID) error {
 	encryptionPubKey, encryptionPrivKey, err := f.stg.ProcessEncryptionKeys(processID)
 	if err != nil || encryptionPubKey == nil || encryptionPrivKey == nil {
 		setProcessInvalid()
-		finalErr := fmt.Errorf("encryption keys are nil for process %s", processID.String())
 		if err != nil {
-			finalErr = fmt.Errorf("%w: %w", finalErr, err)
+			return fmt.Errorf("process %s: %w: %w", processID.String(), ErrProcessEncryptionKeysMissing, err)
 		}
-		return finalErr
+		return fmt.Errorf("process %s: %w", processID.String(), ErrProcessEncryptionKeysMissing)
 	}
 
 	// Open the state for the process

--- a/sequencer/finalizer_test.go
+++ b/sequencer/finalizer_test.go
@@ -1,6 +1,7 @@
 package sequencer
 
 import (
+	"errors"
 	"math/big"
 	"path/filepath"
 	"testing"
@@ -105,6 +106,19 @@ func TestFinalize(t *testing.T) {
 	expected := big.NewInt(5000)
 	c.Assert(process.Result[0].MathBigInt().Cmp(expected), qt.Equals, 0,
 		qt.Commentf("Expected first result to be 500, got %s", process.Result[0].String()))
+}
+
+func TestFinalizeMissingEncryptionKeysReturnsSequencerSentinel(t *testing.T) {
+	c := qt.New(t)
+
+	stg, stateDB, processID, _, _, cleanup := setupTestEnvironment(t, 5000)
+	defer cleanup()
+
+	f := newFinalizer(stg, stateDB, nil, nil)
+
+	err := f.finalize(processID)
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(errors.Is(err, ErrProcessEncryptionKeysMissing), qt.IsTrue)
 }
 
 // setupTestEnvironment creates a test environment with necessary objects


### PR DESCRIPTION
Move the Circom ballot proof verification and recursion conversion
out of the /votes handler into a dedicated verifier helper.

Keep the raw ballot proof verifying key cached in the verifier so
repeated vote submissions do not reload it on the hot path.

Add focused tests for public input assembly and verifier-side VK
caching behavior.
