### PR TITLE
feature: multinetwork support (primitives)

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -9,10 +9,10 @@ This document describes the HTTP API endpoints for the Vocdoni Z Sandbox API ser
 - [Error Handling](#error-handling)
 - [Endpoints](#endpoints)
   - [Health Check](#health-check)
+  - [Information](#information)
   - [Process Management](#process-management)
   - [Vote Management](#vote-management)
   - [Vote Status](#vote-status)
-  - [Ballot Proof Information](#ballot-proof-information)
   - [Worker Management](#worker-management)
   - [Sequencer Statistics](#sequencer-statistics)
 
@@ -83,7 +83,9 @@ Simple health check endpoint to verify the API server is running.
 
 #### GET /info
 
-Returns information needed by the client to generate a ballot zkSNARK proof, including circuit URLs, hashes, and smart contract addresses.
+Returns the static proving artifacts plus the set of chain runtimes currently served by the sequencer.
+
+`runtimes` is a JSON object keyed by chain ID. Because JSON object keys are strings, a chain ID such as `11155111` is encoded as `"11155111"` in the response body.
 
 **Response Body**:
 ```json
@@ -94,21 +96,34 @@ Returns information needed by the client to generate a ballot zkSNARK proof, inc
   "provingKeyHash": "hexString",
   "verificationKeyUrl": "string",
   "verificationKeyHash": "hexString",
-  "contracts": {
-    "process": "address",
-    "stateTransitionVerifier": "address",
-    "resultsVerifier": "address",
-  },
-  "network": { 
-    "sepolia": 11155111
+  "runtimes": {
+    "11155111": {
+      "network": "sepolia",
+      "contracts": {
+        "process": "address",
+        "stateTransitionVerifier": "address",
+        "resultsVerifier": "address"
+      }
+    },
+    "42161": {
+      "network": "arbitrum",
+      "contracts": {
+        "process": "address",
+        "stateTransitionVerifier": "address",
+        "resultsVerifier": "address"
+      }
+    }
   },
   "sequencerAddress": "hexString"
 }
 ```
 
+**Notes**:
+- `sequencerAddress` is included when the workers API is enabled.
+- Clients do not need to send a network or chain ID when calling process-scoped endpoints. The sequencer resolves the target runtime from the `processId` itself.
+
 **Errors**:
 - 50001: Marshaling server JSON failed
-- 50002: Internal server error (invalid network configuration)
 
 
 ### Process Management
@@ -235,6 +250,9 @@ Gets information about an existing voting process. It must exist in the smart co
 **URL Parameters**:
 - processId: Process ID in hexadecimal format
 
+**Notes**:
+- If the embedded process version does not belong to one of the runtimes served by the current sequencer, the endpoint returns HTTP 404.
+
 **Response Body**:
 ```json
 {
@@ -291,6 +309,10 @@ Gets information about a census member of a process.
 
 **URL Parameters**:
 - processId: Process ID in hexadecimal format
+- address: Ethereum address of the participant
+
+**Notes**:
+- If the embedded process version does not belong to one of the runtimes served by the current sequencer, the endpoint returns HTTP 404.
 
 **Response Body**:
 ```json
@@ -374,6 +396,9 @@ Gets an encrypted ballot by its index for a specific process.
 - processId: Process ID in hexadecimal format
 - ballotIndex: ballot index value as a hexadecimal string
 
+**Notes**:
+- If the embedded process version does not belong to one of the runtimes served by the current sequencer, the endpoint returns HTTP 404.
+
 **Response Body**:
 Returns the encrypted ballot if found.
 
@@ -393,6 +418,9 @@ Gets the status of a specific vote within a voting process.
 **URL Parameters**:
 - processId: Process ID in hexadecimal format
 - voteId: Vote ID in hexadecimal format
+
+**Notes**:
+- If the embedded process version does not belong to one of the runtimes served by the current sequencer, the endpoint returns HTTP 404.
 
 **Response Body**:
 ```json

--- a/api/api.go
+++ b/api/api.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/cors"
@@ -135,8 +136,6 @@ func (a *API) Router() *chi.Mux {
 
 // registerHandlers registers all the HTTP handlers for the API endpoints.
 func (a *API) registerHandlers() {
-	processScoped := a.router.With(skipUnknownProcessIDMiddleware(a.allowedVersions))
-
 	// health check endpoint
 	log.Infow("register handler", "endpoint", PingEndpoint, "method", "GET")
 	a.router.Get(PingEndpoint, func(w http.ResponseWriter, r *http.Request) {
@@ -157,11 +156,11 @@ func (a *API) registerHandlers() {
 
 	// processes endpoints
 	log.Infow("register handler", "endpoint", ProcessEndpoint, "method", "GET")
-	processScoped.Get(ProcessEndpoint, a.process)
+	a.router.Get(ProcessEndpoint, a.process)
 	log.Infow("register handler", "endpoint", ProcessesEndpoint, "method", "GET")
 	a.router.Get(ProcessesEndpoint, a.processList)
 	log.Infow("register handler", "endpoint", CensusParticipantEndpoint, "method", "GET")
-	processScoped.Get(CensusParticipantEndpoint, a.processParticipant)
+	a.router.Get(CensusParticipantEndpoint, a.processParticipant)
 	log.Infow("register handler", "endpoint", NewEncryptionKeysEndpoint, "method", "POST")
 	a.router.Post(NewEncryptionKeysEndpoint, a.processEncryptionKeys)
 
@@ -175,11 +174,11 @@ func (a *API) registerHandlers() {
 	log.Infow("register handler", "endpoint", VotesEndpoint, "method", "POST")
 	a.router.Post(VotesEndpoint, a.newVote)
 	log.Infow("register handler", "endpoint", VoteStatusEndpoint, "method", "GET")
-	processScoped.Get(VoteStatusEndpoint, a.voteStatus)
+	a.router.Get(VoteStatusEndpoint, a.voteStatus)
 	log.Infow("register handler", "endpoint", VoteByAddressEndpoint, "method", "GET")
-	processScoped.Get(VoteByAddressEndpoint, a.voteByAddress)
+	a.router.Get(VoteByAddressEndpoint, a.voteByAddress)
 	log.Infow("register handler", "endpoint", BallotByIndexEndpoint, "method", "GET")
-	processScoped.Get(BallotByIndexEndpoint, a.ballotByIndex)
+	a.router.Get(BallotByIndexEndpoint, a.ballotByIndex)
 
 	// sequencer workers stats endpoint - available even without worker mode
 	log.Infow("register handler", "endpoint", SequencerWorkersEndpoint, "method", "GET")
@@ -201,6 +200,8 @@ func (a *API) initRouter() {
 	a.router.Use(middleware.Throttle(100))
 	a.router.Use(middleware.ThrottleBacklog(5000, 40000, 60*time.Second))
 	a.router.Use(middleware.Timeout(45 * time.Second))
+	// Add middleware to skip unknown process ID versions
+	a.router.Use(skipUnknownProcessIDMiddleware(a.allowedVersions))
 
 	a.registerHandlers()
 }
@@ -273,15 +274,60 @@ func apiRuntimeData(router *web3.RuntimeRouter) (map[[4]byte]struct{}, map[uint6
 			return nil, nil, fmt.Errorf("duplicate runtime chain ID %d", chainID)
 		}
 
+		contractsInfo, err := apiContractAddresses(runtime.Contracts)
+		if err != nil {
+			return nil, nil, fmt.Errorf("runtime %q: %w", runtime.Network, err)
+		}
+
 		allowedVersions[runtime.ProcessIDVersion] = struct{}{}
 		runtimeInfos[chainID] = SequencerRuntimeInfo{
-			Network: runtime.Network,
-			Contracts: ContractAddresses{
-				ProcessRegistry:           runtime.Contracts.ContractsAddresses.ProcessRegistry.String(),
-				StateTransitionZKVerifier: runtime.Contracts.ContractsAddresses.StateTransitionZKVerifier.String(),
-				ResultsZKVerifier:         runtime.Contracts.ContractsAddresses.ResultsZKVerifier.String(),
-			},
+			Network:   runtime.Network,
+			Contracts: contractsInfo,
 		}
 	}
 	return allowedVersions, runtimeInfos, nil
+}
+
+func apiContractAddresses(contracts *web3.Contracts) (ContractAddresses, error) {
+	if contracts == nil {
+		return ContractAddresses{}, fmt.Errorf("nil contracts")
+	}
+	if contracts.ContractsAddresses == nil {
+		return ContractAddresses{}, fmt.Errorf("nil contract addresses")
+	}
+
+	processRegistry := contracts.ContractsAddresses.ProcessRegistry
+	if processRegistry == (common.Address{}) {
+		return ContractAddresses{}, fmt.Errorf("process registry address is required")
+	}
+
+	stateTransition := contracts.ContractsAddresses.StateTransitionZKVerifier
+	if stateTransition == (common.Address{}) {
+		addr, err := contracts.StateTransitionVerifierAddress()
+		if err != nil {
+			return ContractAddresses{}, fmt.Errorf("resolve state transition verifier address: %w", err)
+		}
+		stateTransition = common.HexToAddress(addr)
+	}
+	if stateTransition == (common.Address{}) {
+		return ContractAddresses{}, fmt.Errorf("state transition verifier address is required")
+	}
+
+	results := contracts.ContractsAddresses.ResultsZKVerifier
+	if results == (common.Address{}) {
+		addr, err := contracts.ResultsVerifierAddress()
+		if err != nil {
+			return ContractAddresses{}, fmt.Errorf("resolve results verifier address: %w", err)
+		}
+		results = common.HexToAddress(addr)
+	}
+	if results == (common.Address{}) {
+		return ContractAddresses{}, fmt.Errorf("results verifier address is required")
+	}
+
+	return ContractAddresses{
+		ProcessRegistry:           processRegistry.String(),
+		StateTransitionZKVerifier: stateTransition.String(),
+		ResultsZKVerifier:         results.String(),
+	}, nil
 }

--- a/api/api.go
+++ b/api/api.go
@@ -9,19 +9,16 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/cors"
 	"github.com/google/uuid"
-	npbindings "github.com/vocdoni/davinci-contracts/golang-types"
 	"github.com/vocdoni/davinci-node/circuits"
-	"github.com/vocdoni/davinci-node/config"
 	"github.com/vocdoni/davinci-node/crypto/signatures/ethereum"
 	"github.com/vocdoni/davinci-node/log"
 	"github.com/vocdoni/davinci-node/metadata"
 	stg "github.com/vocdoni/davinci-node/storage"
-	"github.com/vocdoni/davinci-node/types"
+	"github.com/vocdoni/davinci-node/web3"
 	"github.com/vocdoni/davinci-node/workers"
 )
 
@@ -36,11 +33,10 @@ var webappFileServer = http.StripPrefix(appRouteRoot+"/", http.FileServer(http.F
 // APIConfig type represents the configuration for the API HTTP server.
 // It includes the host, port and optionally an existing storage instance.
 type APIConfig struct {
-	Host       string
-	Port       int
-	Storage    *stg.Storage // Optional: use existing storage instance
-	Network    string       // Optional: web3 network shortname
-	Web3Config config.DavinciWeb3Config
+	Host     string
+	Port     int
+	Storage  *stg.Storage // Optional: use existing storage instance
+	Runtimes *web3.RuntimeRouter
 	// Worker configuration
 	SequencerWorkersSeed       string                  // Seed for workers authentication over current sequencer
 	WorkersAuthtokenExpiration time.Duration           // Expiration time for worker authentication tokens
@@ -52,12 +48,12 @@ type APIConfig struct {
 
 // API type represents the API HTTP server with JWT authentication capabilities.
 type API struct {
-	router            *chi.Mux
-	storage           *stg.Storage
-	metadata          *metadata.MetadataStorage
-	network           string
-	web3Config        config.DavinciWeb3Config
-	processIDsVersion [4]byte // Current process ID version
+	router          *chi.Mux
+	storage         *stg.Storage
+	metadata        *metadata.MetadataStorage
+	runtimes        *web3.RuntimeRouter
+	runtimeInfos    map[uint64]SequencerRuntimeInfo
+	allowedVersions map[[4]byte]struct{}
 	// Workers API stuff
 	sequencerSigner            *ethereum.Signer         // Signer for workers authentication
 	sequencerUUID              *uuid.UUID               // UUID to keep the workers endpoints hidden
@@ -78,6 +74,14 @@ func New(ctx context.Context, conf *APIConfig) (*API, error) {
 	if conf.Storage == nil {
 		return nil, fmt.Errorf("missing storage instance")
 	}
+	if conf.Runtimes == nil {
+		return nil, fmt.Errorf("missing runtime router")
+	}
+
+	allowedVersions, runtimeInfos, err := apiRuntimeData(conf.Runtimes)
+	if err != nil {
+		return nil, fmt.Errorf("invalid runtime router: %w", err)
+	}
 
 	// By default, use the local metadata provider
 	metadataProviders := []metadata.MetadataProvider{
@@ -93,19 +97,13 @@ func New(ctx context.Context, conf *APIConfig) (*API, error) {
 	a := &API{
 		storage:                    conf.Storage,
 		metadata:                   metadata.New(metadata.CID, metadataProviders...),
-		network:                    conf.Network,
-		web3Config:                 conf.Web3Config,
+		runtimes:                   conf.Runtimes,
+		runtimeInfos:               runtimeInfos,
+		allowedVersions:            allowedVersions,
 		workersJobTimeout:          conf.WorkerJobTimeout,
 		workersAuthtokenExpiration: conf.WorkersAuthtokenExpiration,
 		parentCtx:                  ctx,
 	}
-
-	// Set the supported process ID versions
-	currentProcessIDVersion, err := a.ProcessIDVersion()
-	if err != nil {
-		return nil, fmt.Errorf("could not determine current process ID version: %w", err)
-	}
-	a.processIDsVersion = currentProcessIDVersion
 
 	// If no ban rules for workers are provided, use default rules
 	if conf.WorkerBanRules != nil {
@@ -137,6 +135,8 @@ func (a *API) Router() *chi.Mux {
 
 // registerHandlers registers all the HTTP handlers for the API endpoints.
 func (a *API) registerHandlers() {
+	processScoped := a.router.With(skipUnknownProcessIDMiddleware(a.allowedVersions))
+
 	// health check endpoint
 	log.Infow("register handler", "endpoint", PingEndpoint, "method", "GET")
 	a.router.Get(PingEndpoint, func(w http.ResponseWriter, r *http.Request) {
@@ -157,11 +157,11 @@ func (a *API) registerHandlers() {
 
 	// processes endpoints
 	log.Infow("register handler", "endpoint", ProcessEndpoint, "method", "GET")
-	a.router.Get(ProcessEndpoint, a.process)
+	processScoped.Get(ProcessEndpoint, a.process)
 	log.Infow("register handler", "endpoint", ProcessesEndpoint, "method", "GET")
 	a.router.Get(ProcessesEndpoint, a.processList)
 	log.Infow("register handler", "endpoint", CensusParticipantEndpoint, "method", "GET")
-	a.router.Get(CensusParticipantEndpoint, a.processParticipant)
+	processScoped.Get(CensusParticipantEndpoint, a.processParticipant)
 	log.Infow("register handler", "endpoint", NewEncryptionKeysEndpoint, "method", "POST")
 	a.router.Post(NewEncryptionKeysEndpoint, a.processEncryptionKeys)
 
@@ -175,11 +175,11 @@ func (a *API) registerHandlers() {
 	log.Infow("register handler", "endpoint", VotesEndpoint, "method", "POST")
 	a.router.Post(VotesEndpoint, a.newVote)
 	log.Infow("register handler", "endpoint", VoteStatusEndpoint, "method", "GET")
-	a.router.Get(VoteStatusEndpoint, a.voteStatus)
+	processScoped.Get(VoteStatusEndpoint, a.voteStatus)
 	log.Infow("register handler", "endpoint", VoteByAddressEndpoint, "method", "GET")
-	a.router.Get(VoteByAddressEndpoint, a.voteByAddress)
+	processScoped.Get(VoteByAddressEndpoint, a.voteByAddress)
 	log.Infow("register handler", "endpoint", BallotByIndexEndpoint, "method", "GET")
-	a.router.Get(BallotByIndexEndpoint, a.ballotByIndex)
+	processScoped.Get(BallotByIndexEndpoint, a.ballotByIndex)
 
 	// sequencer workers stats endpoint - available even without worker mode
 	log.Infow("register handler", "endpoint", SequencerWorkersEndpoint, "method", "GET")
@@ -201,8 +201,6 @@ func (a *API) initRouter() {
 	a.router.Use(middleware.Throttle(100))
 	a.router.Use(middleware.ThrottleBacklog(5000, 40000, 60*time.Second))
 	a.router.Use(middleware.Timeout(45 * time.Second))
-	// Add middleware to skip unknown process ID versions
-	a.router.Use(skipUnknownProcessIDMiddleware(a.processIDsVersion))
 
 	a.registerHandlers()
 }
@@ -251,13 +249,39 @@ func staticHandler(w http.ResponseWriter, r *http.Request) {
 	webappFileServer.ServeHTTP(w, r)
 }
 
-// ProcessIDVersion returns the expected ProcessID version for the current
-// network and contract address. It can be used to validate ProcessIDs.
-func (a *API) ProcessIDVersion() ([4]byte, error) {
-	chainID, ok := npbindings.AvailableNetworksByName[a.network]
-	if !ok {
-		return [4]byte{}, fmt.Errorf("unknown network: %s", a.network)
+func apiRuntimeData(router *web3.RuntimeRouter) (map[[4]byte]struct{}, map[uint64]SequencerRuntimeInfo, error) {
+	runtimes := router.Runtimes()
+	if len(runtimes) == 0 {
+		return nil, nil, fmt.Errorf("no runtimes configured")
 	}
-	contractAddr := common.HexToAddress(a.web3Config.ProcessRegistrySmartContract)
-	return types.ProcessIDVersion(chainID, contractAddr), nil
+
+	allowedVersions := make(map[[4]byte]struct{}, len(runtimes))
+	runtimeInfos := make(map[uint64]SequencerRuntimeInfo, len(runtimes))
+	for _, runtime := range runtimes {
+		if runtime == nil {
+			return nil, nil, fmt.Errorf("nil runtime")
+		}
+		if runtime.Contracts == nil {
+			return nil, nil, fmt.Errorf("runtime %q has nil contracts", runtime.Network)
+		}
+		if runtime.Contracts.ContractsAddresses == nil {
+			return nil, nil, fmt.Errorf("runtime %q has nil contract addresses", runtime.Network)
+		}
+
+		chainID := runtime.Contracts.ChainID
+		if _, exists := runtimeInfos[chainID]; exists {
+			return nil, nil, fmt.Errorf("duplicate runtime chain ID %d", chainID)
+		}
+
+		allowedVersions[runtime.ProcessIDVersion] = struct{}{}
+		runtimeInfos[chainID] = SequencerRuntimeInfo{
+			Network: runtime.Network,
+			Contracts: ContractAddresses{
+				ProcessRegistry:           runtime.Contracts.ContractsAddresses.ProcessRegistry.String(),
+				StateTransitionZKVerifier: runtime.Contracts.ContractsAddresses.StateTransitionZKVerifier.String(),
+				ResultsZKVerifier:         runtime.Contracts.ContractsAddresses.ResultsZKVerifier.String(),
+			},
+		}
+	}
+	return allowedVersions, runtimeInfos, nil
 }

--- a/api/info.go
+++ b/api/info.go
@@ -6,20 +6,17 @@ import (
 	"net/http"
 	"strconv"
 
-	npbindings "github.com/vocdoni/davinci-contracts/golang-types"
 	"github.com/vocdoni/davinci-node/config"
 )
 
 // info returns the information needed by the client to generate a ballot zkSNARK proof
 // GET /info
 func (a *API) info(w http.ResponseWriter, r *http.Request) {
-	_, ok := npbindings.AvailableNetworksByName[a.network]
-	if !ok {
-		ErrGenericInternalServerError.Withf("invalid network configuration for %s", a.network).Write(w)
-		return
-	}
-	contracts := npbindings.GetAllContractAddresses(a.network)
 	// Build the response with the necessary circuit information
+	runtimes := make(map[uint64]SequencerRuntimeInfo, len(a.runtimeInfos))
+	for chainID, runtime := range a.runtimeInfos {
+		runtimes[chainID] = runtime
+	}
 	response := &SequencerInfo{
 		CircuitURL:          config.BallotProofCircuitURL,
 		CircuitHash:         config.BallotProofCircuitHash,
@@ -27,30 +24,13 @@ func (a *API) info(w http.ResponseWriter, r *http.Request) {
 		ProvingKeyHash:      config.BallotProofProvingKeyHash,
 		VerificationKeyURL:  config.BallotProofVerificationKeyURL,
 		VerificationKeyHash: config.BallotProofVerificationKeyHash,
-		Contracts: ContractAddresses{
-			ProcessRegistry:           contracts[npbindings.ProcessRegistryContract],
-			StateTransitionZKVerifier: contracts[npbindings.StateTransitionVerifierGroth16Contract],
-			ResultsZKVerifier:         contracts[npbindings.ResultsVerifierGroth16Contract],
-		},
-		Network: map[string]uint32{
-			a.network: npbindings.AvailableNetworksByName[a.network],
-		},
+		Runtimes:            runtimes,
 	}
 	// if the sequencer has a signer, include the sequencer address
 	if a.sequencerSigner != nil {
 		response.SequencerAddress = a.sequencerSigner.Address().Bytes()
 	}
-
-	// Write the response
-	jsonResponse, err := json.Marshal(response)
-	if err != nil {
-		ErrMarshalingServerJSONFailed.WithErr(err).Write(w)
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write(jsonResponse)
+	httpWriteJSON(w, response)
 }
 
 // hostLoad reports expvar system metrics in a typed JSON object.

--- a/api/info_test.go
+++ b/api/info_test.go
@@ -8,72 +8,53 @@ import (
 
 	qt "github.com/frankban/quicktest"
 	"github.com/vocdoni/davinci-node/config"
-	"github.com/vocdoni/davinci-node/storage"
 )
 
 func TestInfo(t *testing.T) {
 	c := qt.New(t)
 
-	// Create a mock storage
-	store := &storage.Storage{}
+	api := &API{
+		runtimeInfos: map[uint64]SequencerRuntimeInfo{
+			11155111: {
+				Network: "sepolia",
+				Contracts: ContractAddresses{
+					ProcessRegistry:           "0x1111111111111111111111111111111111111111",
+					StateTransitionZKVerifier: "0x2222222222222222222222222222222222222222",
+					ResultsZKVerifier:         "0x3333333333333333333333333333333333333333",
+				},
+			},
+			42161: {
+				Network: "arbitrum",
+				Contracts: ContractAddresses{
+					ProcessRegistry:           "0x4444444444444444444444444444444444444444",
+					StateTransitionZKVerifier: "0x5555555555555555555555555555555555555555",
+					ResultsZKVerifier:         "0x6666666666666666666666666666666666666666",
+				},
+			},
+		},
+	}
 
-	// Test case 1: Valid network
-	t.Run("ValidNetwork", func(t *testing.T) {
-		// Create API with a valid network
-		api := &API{
-			storage: store,
-			network: "sepolia", // This is a valid network as defined in config.DefaultConfig
-		}
+	req, err := http.NewRequest(http.MethodGet, InfoEndpoint, nil)
+	c.Assert(err, qt.IsNil)
 
-		// Create a new request
-		req, err := http.NewRequest("GET", InfoEndpoint, nil)
-		c.Assert(err, qt.IsNil)
+	rr := httptest.NewRecorder()
+	api.info(rr, req)
 
-		// Create a response recorder to record the response
-		rr := httptest.NewRecorder()
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
 
-		// Call the handler
-		api.info(rr, req)
+	var response SequencerInfo
+	err = json.Unmarshal(rr.Body.Bytes(), &response)
+	c.Assert(err, qt.IsNil)
 
-		// Check the status code
-		c.Assert(rr.Code, qt.Equals, http.StatusOK)
-
-		// Parse the response
-		var response SequencerInfo
-		err = json.Unmarshal(rr.Body.Bytes(), &response)
-		c.Assert(err, qt.IsNil)
-
-		// Verify the returned data
-		c.Assert(response.CircuitURL, qt.Equals, config.BallotProofCircuitURL)
-		c.Assert(response.CircuitHash, qt.Equals, config.BallotProofCircuitHash)
-		c.Assert(response.ProvingKeyURL, qt.Equals, config.BallotProofProvingKeyURL)
-		c.Assert(response.ProvingKeyHash, qt.Equals, config.BallotProofProvingKeyHash)
-		c.Assert(response.VerificationKeyURL, qt.Equals, config.BallotProofVerificationKeyURL)
-		c.Assert(response.VerificationKeyHash, qt.Equals, config.BallotProofVerificationKeyHash)
-	})
-
-	// Test case 2: Invalid network
-	t.Run("InvalidNetwork", func(t *testing.T) {
-		// Create API with an invalid network
-		api := &API{
-			storage: store,
-			network: "invalid_network", // This network doesn't exist in config.DefaultConfig
-		}
-
-		// Create a new request
-		req, err := http.NewRequest("GET", InfoEndpoint, nil)
-		c.Assert(err, qt.IsNil)
-
-		// Create a response recorder to record the response
-		rr := httptest.NewRecorder()
-
-		// Call the handler
-		api.info(rr, req)
-
-		// Check the status code (should be an error)
-		c.Assert(rr.Code, qt.Equals, http.StatusInternalServerError)
-
-		// Verify the error message contains the expected content
-		c.Assert(rr.Body.String(), qt.Contains, "invalid network configuration")
-	})
+	c.Assert(response.CircuitURL, qt.Equals, config.BallotProofCircuitURL)
+	c.Assert(response.CircuitHash, qt.Equals, config.BallotProofCircuitHash)
+	c.Assert(response.ProvingKeyURL, qt.Equals, config.BallotProofProvingKeyURL)
+	c.Assert(response.ProvingKeyHash, qt.Equals, config.BallotProofProvingKeyHash)
+	c.Assert(response.VerificationKeyURL, qt.Equals, config.BallotProofVerificationKeyURL)
+	c.Assert(response.VerificationKeyHash, qt.Equals, config.BallotProofVerificationKeyHash)
+	c.Assert(response.Runtimes, qt.HasLen, 2)
+	c.Assert(response.Runtimes[11155111].Network, qt.Equals, "sepolia")
+	c.Assert(response.Runtimes[11155111].Contracts.ProcessRegistry, qt.Equals, "0x1111111111111111111111111111111111111111")
+	c.Assert(response.Runtimes[42161].Network, qt.Equals, "arbitrum")
+	c.Assert(response.Runtimes[42161].Contracts.ResultsZKVerifier, qt.Equals, "0x6666666666666666666666666666666666666666")
 }

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -147,7 +147,7 @@ func loggingMiddlewareWithConfig(config LoggingConfig) func(http.Handler) http.H
 }
 
 // skipUnknownProcessIDMiddleware allows to skip requests with unknown
-// ProcessID versions. It checks the "processID" URL parameter and compares
+// ProcessID versions. It checks the "processId" URL parameter and compares
 // its version against the provided allowedVersions. If there is no match, it
 // responds with 404 Not Found. If the route does not contain a processID
 // parameter, it simply calls the next handler.

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -148,10 +148,10 @@ func loggingMiddlewareWithConfig(config LoggingConfig) func(http.Handler) http.H
 
 // skipUnknownProcessIDMiddleware allows to skip requests with unknown
 // ProcessID versions. It checks the "processID" URL parameter and compares
-// its version against the provided currentVersion. If they don't match, it
-// responds with 404 Not Found. If the path does not contain a processID
+// its version against the provided allowedVersions. If there is no match, it
+// responds with 404 Not Found. If the route does not contain a processID
 // parameter, it simply calls the next handler.
-func skipUnknownProcessIDMiddleware(currentVersion [4]byte) func(http.Handler) http.Handler {
+func skipUnknownProcessIDMiddleware(allowedVersions map[[4]byte]struct{}) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Check if the route contains a process id
@@ -172,8 +172,8 @@ func skipUnknownProcessIDMiddleware(currentVersion [4]byte) func(http.Handler) h
 				ErrMalformedProcessID.Withf("invalid process ID: %s", processIDStr).Write(w)
 				return
 			}
-			// Check if the version matches the current expected version
-			if processID.Version() != currentVersion {
+			// Check if the version matches one of the allowed versions
+			if _, ok := allowedVersions[processID.Version()]; !ok {
 				http.NotFound(w, r)
 				return
 			}

--- a/api/middleware_test.go
+++ b/api/middleware_test.go
@@ -1,267 +1,60 @@
 package api
 
 import (
-	"bytes"
-	"io"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	qt "github.com/frankban/quicktest"
+	"github.com/go-chi/chi/v5"
+	"github.com/vocdoni/davinci-node/types"
 )
 
-func TestLoggingMiddleware(t *testing.T) {
-	// Create a simple handler that echoes the body
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, _ := io.ReadAll(r.Body)
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write(body)
-	})
+func TestSkipUnknownProcessIDMiddleware(t *testing.T) {
+	versionSepolia := [4]byte{0x01, 0x02, 0x03, 0x04}
+	versionArbitrum := [4]byte{0x05, 0x06, 0x07, 0x08}
+	versionUnknown := [4]byte{0x09, 0x0a, 0x0b, 0x0c}
 
-	// Wrap with logging middleware
-	middleware := loggingMiddleware(100)
-	wrappedHandler := middleware(handler)
-
-	tests := []struct {
-		name        string
-		body        string
-		shouldLog   bool
-		description string
-	}{
-		{
-			name:        "JSON object",
-			body:        `{"key": "value"}`,
-			shouldLog:   true,
-			description: "Should log JSON objects",
-		},
-		{
-			name:        "JSON array",
-			body:        `[1, 2, 3]`,
-			shouldLog:   true,
-			description: "Should log JSON arrays",
-		},
-		{
-			name:        "JSON with whitespace",
-			body:        `  {"key": "value"}`,
-			shouldLog:   true,
-			description: "Should log JSON with leading whitespace",
-		},
-		{
-			name:        "Binary data",
-			body:        "\x00\x01\x02\x03\x04",
-			shouldLog:   false,
-			description: "Should not log binary data",
-		},
-		{
-			name:        "Plain text",
-			body:        "Hello, World!",
-			shouldLog:   false,
-			description: "Should not log plain text",
-		},
-		{
-			name:        "Empty body",
-			body:        "",
-			shouldLog:   false,
-			description: "Should handle empty body",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Create request
-			req := httptest.NewRequest("POST", "/test", bytes.NewBufferString(tt.body))
-			rec := httptest.NewRecorder()
-
-			// Execute
-			wrappedHandler.ServeHTTP(rec, req)
-
-			// Check response
-			if rec.Code != http.StatusOK {
-				t.Errorf("Expected status %d, got %d", http.StatusOK, rec.Code)
-			}
-
-			// Check body was preserved
-			respBody, _ := io.ReadAll(rec.Body)
-			if string(respBody) != tt.body {
-				t.Errorf("Body was modified: expected %q, got %q", tt.body, string(respBody))
-			}
-		})
-	}
-}
-
-func TestLoggingMiddlewareExclusions(t *testing.T) {
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	router := chi.NewRouter()
+	router.With(skipUnknownProcessIDMiddleware(map[[4]byte]struct{}{
+		versionSepolia:  {},
+		versionArbitrum: {},
+	})).Get(ProcessEndpoint, func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	tests := []struct {
-		name        string
-		path        string
-		shouldSkip  bool
-		description string
+	testCases := []struct {
+		name      string
+		processID types.ProcessID
+		wantCode  int
 	}{
 		{
-			name:        "Ping endpoint",
-			path:        "/ping",
-			shouldSkip:  true,
-			description: "Should skip ping endpoint",
+			name:      "accepted first version",
+			processID: types.NewProcessID(common.HexToAddress("0x0000000000000000000000000000000000000004"), versionSepolia, 1),
+			wantCode:  http.StatusOK,
 		},
 		{
-			name:        "Workers endpoint",
-			path:        "/workers/123/job",
-			shouldSkip:  true,
-			description: "Should skip workers endpoints",
+			name:      "accepted second version",
+			processID: types.NewProcessID(common.HexToAddress("0x0000000000000000000000000000000000000005"), versionArbitrum, 2),
+			wantCode:  http.StatusOK,
 		},
 		{
-			name:        "Regular endpoint",
-			path:        "/votes",
-			shouldSkip:  false,
-			description: "Should not skip regular endpoints",
+			name:      "rejected unknown version",
+			processID: types.NewProcessID(common.HexToAddress("0x0000000000000000000000000000000000000006"), versionUnknown, 3),
+			wantCode:  http.StatusNotFound,
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			middleware := loggingMiddleware(100)
-			wrappedHandler := middleware(handler)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+			req := httptest.NewRequest(http.MethodGet, "/processes/"+tc.processID.String(), nil)
+			rr := httptest.NewRecorder()
 
-			req := httptest.NewRequest("GET", tt.path, nil)
-			rec := httptest.NewRecorder()
+			router.ServeHTTP(rr, req)
 
-			wrappedHandler.ServeHTTP(rec, req)
-
-			if rec.Code != http.StatusOK {
-				t.Errorf("Expected status %d, got %d", http.StatusOK, rec.Code)
-			}
+			c.Assert(rr.Code, qt.Equals, tc.wantCode)
 		})
 	}
-}
-
-func TestLoggingConfigCustomExclusions(t *testing.T) {
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
-
-	config := LoggingConfig{
-		MaxBodyLog: 100,
-		ExcludedPrefixes: []string{
-			"/api/v1/",
-			"/health",
-			"/metrics",
-		},
-	}
-
-	middleware := loggingMiddlewareWithConfig(config)
-	wrappedHandler := middleware(handler)
-
-	tests := []struct {
-		path       string
-		shouldSkip bool
-	}{
-		{"/api/v1/users", true},
-		{"/api/v1/posts/123", true},
-		{"/health", true},
-		{"/healthcheck", true}, // prefix match
-		{"/metrics/prometheus", true},
-		{"/api/v2/users", false},
-		{"/users", false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.path, func(t *testing.T) {
-			req := httptest.NewRequest("GET", tt.path, nil)
-			rec := httptest.NewRecorder()
-
-			wrappedHandler.ServeHTTP(rec, req)
-
-			if rec.Code != http.StatusOK {
-				t.Errorf("Expected status %d, got %d", http.StatusOK, rec.Code)
-			}
-		})
-	}
-}
-
-func TestResponseWriterCapture(t *testing.T) {
-	// Test that responseWriter correctly captures status codes
-	tests := []struct {
-		name           string
-		handlerFunc    func(w http.ResponseWriter, r *http.Request)
-		expectedStatus int
-	}{
-		{
-			name: "WriteHeader before Write",
-			handlerFunc: func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusCreated)
-				_, _ = w.Write([]byte("test"))
-			},
-			expectedStatus: http.StatusCreated,
-		},
-		{
-			name: "Write without WriteHeader",
-			handlerFunc: func(w http.ResponseWriter, r *http.Request) {
-				_, _ = w.Write([]byte("test"))
-			},
-			expectedStatus: http.StatusOK,
-		},
-		{
-			name: "Multiple WriteHeader calls",
-			handlerFunc: func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusCreated)
-				w.WriteHeader(http.StatusAccepted) // Should be ignored
-			},
-			expectedStatus: http.StatusCreated,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			rec := httptest.NewRecorder()
-			rw := &responseWriter{
-				ResponseWriter: rec,
-				statusCode:     0,
-			}
-
-			req := httptest.NewRequest("GET", "/", nil)
-			tt.handlerFunc(rw, req)
-
-			if rw.statusCode != tt.expectedStatus {
-				t.Errorf("Expected status %d, got %d", tt.expectedStatus, rw.statusCode)
-			}
-		})
-	}
-}
-
-func BenchmarkLoggingMiddleware(b *testing.B) {
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
-
-	middleware := loggingMiddleware(512)
-	wrappedHandler := middleware(handler)
-
-	jsonBody := `{"key": "value", "number": 123, "array": [1, 2, 3]}`
-
-	b.Run("JSON body", func(b *testing.B) {
-		for b.Loop() {
-			req := httptest.NewRequest("POST", "/test", strings.NewReader(jsonBody))
-			rec := httptest.NewRecorder()
-			wrappedHandler.ServeHTTP(rec, req)
-		}
-	})
-
-	b.Run("Binary body", func(b *testing.B) {
-		binaryBody := bytes.Repeat([]byte{0x00, 0x01, 0x02, 0x03}, 100)
-		for b.Loop() {
-			req := httptest.NewRequest("POST", "/test", bytes.NewReader(binaryBody))
-			rec := httptest.NewRecorder()
-			wrappedHandler.ServeHTTP(rec, req)
-		}
-	})
-
-	b.Run("No body", func(b *testing.B) {
-		for b.Loop() {
-			req := httptest.NewRequest("GET", "/test", nil)
-			rec := httptest.NewRecorder()
-			wrappedHandler.ServeHTTP(rec, req)
-		}
-	})
 }

--- a/api/middleware_test.go
+++ b/api/middleware_test.go
@@ -1,14 +1,18 @@
 package api
 
 import (
+	"bytes"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
 	qt "github.com/frankban/quicktest"
 	"github.com/go-chi/chi/v5"
 	"github.com/vocdoni/davinci-node/types"
+	"github.com/vocdoni/davinci-node/web3"
 )
 
 func TestSkipUnknownProcessIDMiddleware(t *testing.T) {
@@ -57,4 +61,220 @@ func TestSkipUnknownProcessIDMiddleware(t *testing.T) {
 			c.Assert(rr.Code, qt.Equals, tc.wantCode)
 		})
 	}
+}
+
+func TestLoggingMiddleware(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	})
+
+	wrappedHandler := loggingMiddleware(100)(handler)
+
+	testCases := []struct {
+		name string
+		body string
+	}{
+		{name: "json object", body: `{"key":"value"}`},
+		{name: "json array", body: `[1,2,3]`},
+		{name: "json with whitespace", body: `  {"key":"value"}`},
+		{name: "binary data", body: "\x00\x01\x02\x03\x04"},
+		{name: "plain text", body: "Hello, World!"},
+		{name: "empty body", body: ""},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+			req := httptest.NewRequest(http.MethodPost, "/test", bytes.NewBufferString(tc.body))
+			rec := httptest.NewRecorder()
+
+			wrappedHandler.ServeHTTP(rec, req)
+
+			c.Assert(rec.Code, qt.Equals, http.StatusOK)
+			respBody, err := io.ReadAll(rec.Body)
+			c.Assert(err, qt.IsNil)
+			c.Assert(string(respBody), qt.Equals, tc.body)
+		})
+	}
+}
+
+func TestLoggingMiddlewareExclusions(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	wrappedHandler := loggingMiddleware(100)(handler)
+
+	testCases := []struct {
+		name string
+		path string
+	}{
+		{name: "ping endpoint", path: "/ping"},
+		{name: "workers endpoint", path: "/workers/123/job"},
+		{name: "regular endpoint", path: "/votes"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			rec := httptest.NewRecorder()
+
+			wrappedHandler.ServeHTTP(rec, req)
+
+			c.Assert(rec.Code, qt.Equals, http.StatusOK)
+		})
+	}
+}
+
+func TestLoggingConfigCustomExclusions(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	config := LoggingConfig{
+		MaxBodyLog: 100,
+		ExcludedPrefixes: []string{
+			"/api/v1/",
+			"/health",
+			"/metrics",
+		},
+	}
+	wrappedHandler := loggingMiddlewareWithConfig(config)(handler)
+
+	testCases := []struct {
+		path string
+	}{
+		{path: "/api/v1/users"},
+		{path: "/api/v1/posts/123"},
+		{path: "/health"},
+		{path: "/healthcheck"},
+		{path: "/metrics/prometheus"},
+		{path: "/api/v2/users"},
+		{path: "/users"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.path, func(t *testing.T) {
+			c := qt.New(t)
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			rec := httptest.NewRecorder()
+
+			wrappedHandler.ServeHTTP(rec, req)
+
+			c.Assert(rec.Code, qt.Equals, http.StatusOK)
+		})
+	}
+}
+
+func TestResponseWriterCapture(t *testing.T) {
+	testCases := []struct {
+		name           string
+		handlerFunc    func(w http.ResponseWriter, r *http.Request)
+		expectedStatus int
+	}{
+		{
+			name: "WriteHeader before Write",
+			handlerFunc: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusCreated)
+				_, _ = w.Write([]byte("test"))
+			},
+			expectedStatus: http.StatusCreated,
+		},
+		{
+			name: "Write without WriteHeader",
+			handlerFunc: func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte("test"))
+			},
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name: "Multiple WriteHeader calls",
+			handlerFunc: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusCreated)
+				w.WriteHeader(http.StatusAccepted)
+			},
+			expectedStatus: http.StatusCreated,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+			rec := httptest.NewRecorder()
+			rw := &responseWriter{
+				ResponseWriter: rec,
+				statusCode:     0,
+			}
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			tc.handlerFunc(rw, req)
+
+			c.Assert(rw.statusCode, qt.Equals, tc.expectedStatus)
+		})
+	}
+}
+
+func TestAPIRuntimeDataResolvesMissingVerifierAddresses(t *testing.T) {
+	c := qt.New(t)
+
+	contracts := &web3.Contracts{
+		ChainID: 11155111,
+		ContractsAddresses: &web3.Addresses{
+			ProcessRegistry: common.HexToAddress("0x1111111111111111111111111111111111111111"),
+		},
+	}
+	runtime, err := web3.NewNetworkRuntime("sepolia", contracts, nil)
+	c.Assert(err, qt.IsNil)
+	router, err := web3.NewRuntimeRouter(runtime)
+	c.Assert(err, qt.IsNil)
+
+	allowedVersions, runtimeInfos, err := apiRuntimeData(router)
+	c.Assert(err, qt.IsNil)
+	c.Assert(allowedVersions, qt.HasLen, 1)
+
+	info, ok := runtimeInfos[11155111]
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(info.Network, qt.Equals, "sepolia")
+	c.Assert(info.Contracts.ProcessRegistry, qt.Equals, "0x1111111111111111111111111111111111111111")
+	c.Assert(info.Contracts.StateTransitionZKVerifier, qt.Not(qt.Equals), common.Address{}.String())
+	c.Assert(info.Contracts.ResultsZKVerifier, qt.Not(qt.Equals), common.Address{}.String())
+}
+
+func BenchmarkLoggingMiddleware(b *testing.B) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	wrappedHandler := loggingMiddleware(512)(handler)
+	jsonBody := `{"key": "value", "number": 123, "array": [1, 2, 3]}`
+
+	b.Run("JSON body", func(b *testing.B) {
+		for b.Loop() {
+			req := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(jsonBody))
+			rec := httptest.NewRecorder()
+			wrappedHandler.ServeHTTP(rec, req)
+		}
+	})
+
+	b.Run("Binary body", func(b *testing.B) {
+		binaryBody := bytes.Repeat([]byte{0x00, 0x01, 0x02, 0x03}, 100)
+		for b.Loop() {
+			req := httptest.NewRequest(http.MethodPost, "/test", bytes.NewReader(binaryBody))
+			rec := httptest.NewRecorder()
+			wrappedHandler.ServeHTTP(rec, req)
+		}
+	})
+
+	b.Run("No body", func(b *testing.B) {
+		for b.Loop() {
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			rec := httptest.NewRecorder()
+			wrappedHandler.ServeHTTP(rec, req)
+		}
+	})
 }

--- a/api/types.go
+++ b/api/types.go
@@ -33,17 +33,22 @@ type ContractAddresses struct {
 	ResultsZKVerifier         string `json:"resultsVerifier"`
 }
 
+// SequencerRuntimeInfo contains the network label and contract addresses for a runtime.
+type SequencerRuntimeInfo struct {
+	Network   string            `json:"network"`
+	Contracts ContractAddresses `json:"contracts"`
+}
+
 // SequencerInfo contains any relevant information about the current sequencer for a client.
 type SequencerInfo struct {
-	CircuitURL          string            `json:"circuitUrl"`
-	CircuitHash         string            `json:"circuitHash"`
-	ProvingKeyURL       string            `json:"provingKeyUrl"`
-	ProvingKeyHash      string            `json:"provingKeyHash"`
-	VerificationKeyURL  string            `json:"verificationKeyUrl"`
-	VerificationKeyHash string            `json:"verificationKeyHash"`
-	Contracts           ContractAddresses `json:"contracts"`
-	Network             map[string]uint32 `json:"network,omitempty"`
-	SequencerAddress    types.HexBytes    `json:"sequencerAddress"`
+	CircuitURL          string                          `json:"circuitUrl"`
+	CircuitHash         string                          `json:"circuitHash"`
+	ProvingKeyURL       string                          `json:"provingKeyUrl"`
+	ProvingKeyHash      string                          `json:"provingKeyHash"`
+	VerificationKeyURL  string                          `json:"verificationKeyUrl"`
+	VerificationKeyHash string                          `json:"verificationKeyHash"`
+	Runtimes            map[uint64]SequencerRuntimeInfo `json:"runtimes"`
+	SequencerAddress    types.HexBytes                  `json:"sequencerAddress"`
 }
 
 // VoteResponse is the response returned by the vote submission endpoint.

--- a/cmd/davinci-sequencer/main.go
+++ b/cmd/davinci-sequencer/main.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
-	npbindings "github.com/vocdoni/davinci-contracts/golang-types"
-	"github.com/vocdoni/davinci-node/config"
 	"github.com/vocdoni/davinci-node/db"
 	"github.com/vocdoni/davinci-node/db/metadb"
 	"github.com/vocdoni/davinci-node/log"
@@ -253,23 +251,20 @@ func setupServices(ctx context.Context, cfg *Config) (*Services, error) {
 	}
 
 	// Start API service
-	_, ok := npbindings.AvailableNetworksByName[cfg.Web3.Network]
-	if !ok {
-		return nil, fmt.Errorf("invalid network configuration for %s", cfg.Web3.Network)
+	apiRuntime, err := web3.NewNetworkRuntime(cfg.Web3.Network, services.Contracts, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create API runtime: %w", err)
 	}
-	contracts := npbindings.GetAllContractAddresses(cfg.Web3.Network)
-	web3Conf := config.DavinciWeb3Config{
-		ProcessRegistrySmartContract: contracts[npbindings.ProcessRegistryContract],
-		ResultsZKVerifier:            contracts[npbindings.ResultsVerifierGroth16Contract],
-		StateTransitionZKVerifier:    contracts[npbindings.StateTransitionVerifierGroth16Contract],
+	apiRuntimes, err := web3.NewRuntimeRouter(apiRuntime)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create API runtime router: %w", err)
 	}
 	log.Infow("starting API service", "host", cfg.API.Host, "port", cfg.API.Port)
 	services.API = service.NewAPI(
 		services.Storage,
 		cfg.API.Host,
 		cfg.API.Port,
-		cfg.Web3.Network,
-		web3Conf,
+		apiRuntimes,
 		metadata.PinataMetadataProviderConfig{
 			HostnameURL:  cfg.Metadata.PinataHostnameURL,
 			HostnameJWT:  cfg.Metadata.PinataHostnameJWT,

--- a/cmd/e2e-test/main.go
+++ b/cmd/e2e-test/main.go
@@ -19,7 +19,6 @@ import (
 	censustest "github.com/vocdoni/davinci-node/census/test"
 	"github.com/vocdoni/davinci-node/circuits/ballotproof"
 	ballotprooftest "github.com/vocdoni/davinci-node/circuits/test/ballotproof"
-	"github.com/vocdoni/davinci-node/config"
 	"github.com/vocdoni/davinci-node/crypto/elgamal"
 	"github.com/vocdoni/davinci-node/crypto/signatures/ethereum"
 	"github.com/vocdoni/davinci-node/internal/testutil"
@@ -322,17 +321,15 @@ func (s *localService) Start(ctx context.Context, contracts *web3.Contracts, net
 		return fmt.Errorf("failed to start sequencer: %v", err)
 	}
 	// Start API service
-	_, ok := npbindings.AvailableNetworksByName[network]
-	if !ok {
-		return fmt.Errorf("invalid network configuration for %s", network)
+	apiRuntime, err := web3.NewNetworkRuntime(network, contracts, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create API runtime: %w", err)
 	}
-	c := npbindings.GetAllContractAddresses(network)
-	web3Conf := config.DavinciWeb3Config{
-		ProcessRegistrySmartContract: c[npbindings.ProcessRegistryContract],
-		ResultsZKVerifier:            c[npbindings.ResultsVerifierGroth16Contract],
-		StateTransitionZKVerifier:    c[npbindings.StateTransitionVerifierGroth16Contract],
+	apiRuntimes, err := web3.NewRuntimeRouter(apiRuntime)
+	if err != nil {
+		return fmt.Errorf("failed to create API runtime router: %w", err)
 	}
-	s.api = service.NewAPI(s.storage, localSequencerHost, localSequencerPort, network, web3Conf, metadata.PinataMetadataProviderConfig{}, false)
+	s.api = service.NewAPI(s.storage, localSequencerHost, localSequencerPort, apiRuntimes, metadata.PinataMetadataProviderConfig{}, false)
 	if err := s.api.Start(ctx); err != nil {
 		return fmt.Errorf("failed to start API: %v", err)
 	}

--- a/service/api_service.go
+++ b/service/api_service.go
@@ -7,10 +7,10 @@ import (
 	"time"
 
 	"github.com/vocdoni/davinci-node/api"
-	"github.com/vocdoni/davinci-node/config"
 	"github.com/vocdoni/davinci-node/log"
 	"github.com/vocdoni/davinci-node/metadata"
 	"github.com/vocdoni/davinci-node/storage"
+	"github.com/vocdoni/davinci-node/web3"
 	"github.com/vocdoni/davinci-node/workers"
 )
 
@@ -22,8 +22,7 @@ type APIService struct {
 	cancel                     context.CancelFunc
 	host                       string
 	port                       int
-	network                    string
-	web3Config                 config.DavinciWeb3Config
+	runtimes                   *web3.RuntimeRouter
 	pinataConfig               metadata.PinataMetadataProviderConfig
 	sequencerWorkersSeed       string
 	workersAuthtokenExpiration time.Duration
@@ -36,8 +35,7 @@ func NewAPI(
 	storage *storage.Storage,
 	host string,
 	port int,
-	network string,
-	web3Config config.DavinciWeb3Config,
+	runtimes *web3.RuntimeRouter,
 	pinataConfig metadata.PinataMetadataProviderConfig,
 	disableLogging bool,
 ) *APIService {
@@ -49,8 +47,7 @@ func NewAPI(
 		storage:      storage,
 		host:         host,
 		port:         port,
-		network:      network,
-		web3Config:   web3Config,
+		runtimes:     runtimes,
 		pinataConfig: pinataConfig,
 	}
 }
@@ -84,8 +81,7 @@ func (as *APIService) Start(ctx context.Context) error {
 		Host:                       as.host,
 		Port:                       as.port,
 		Storage:                    as.storage,
-		Network:                    as.network,
-		Web3Config:                 as.web3Config,
+		Runtimes:                   as.runtimes,
 		SequencerWorkersSeed:       as.sequencerWorkersSeed,
 		WorkersAuthtokenExpiration: as.workersAuthtokenExpiration,
 		WorkerJobTimeout:           as.workersJobTimeout,

--- a/service/api_service_test.go
+++ b/service/api_service_test.go
@@ -5,11 +5,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	qt "github.com/frankban/quicktest"
 	"github.com/vocdoni/arbo/memdb"
 	"github.com/vocdoni/davinci-node/config"
 	"github.com/vocdoni/davinci-node/metadata"
 	"github.com/vocdoni/davinci-node/storage"
+	"github.com/vocdoni/davinci-node/web3"
 )
 
 func TestAPIService(t *testing.T) {
@@ -20,13 +22,26 @@ func TestAPIService(t *testing.T) {
 	store := storage.New(kv)
 	defer store.Close()
 
+	contracts := &web3.Contracts{
+		ChainID: 11155111,
+		ContractsAddresses: &web3.Addresses{
+			ProcessRegistry:           common.HexToAddress(config.TestConfig.ProcessRegistrySmartContract),
+			StateTransitionZKVerifier: common.HexToAddress(config.TestConfig.StateTransitionZKVerifier),
+			ResultsZKVerifier:         common.HexToAddress(config.TestConfig.ResultsZKVerifier),
+		},
+	}
+	runtime, err := web3.NewNetworkRuntime("test", contracts, nil)
+	c.Assert(err, qt.IsNil)
+	runtimes, err := web3.NewRuntimeRouter(runtime)
+	c.Assert(err, qt.IsNil)
+
 	// Create API service with a random available port
-	apiService := NewAPI(store, "127.0.0.1", 0, "test", config.TestConfig, metadata.PinataMetadataProviderConfig{}, false) // Port 0 lets the OS choose an available port
+	apiService := NewAPI(store, "127.0.0.1", 0, runtimes, metadata.PinataMetadataProviderConfig{}, false) // Port 0 lets the OS choose an available port
 
 	// Start service in background
 	ctx := context.Background()
 
-	err := apiService.Start(ctx)
+	err = apiService.Start(ctx)
 	c.Assert(err, qt.IsNil)
 	defer apiService.Stop()
 

--- a/spec/testutil/ballotmode.go
+++ b/spec/testutil/ballotmode.go
@@ -3,26 +3,26 @@ package testutil
 import "github.com/vocdoni/davinci-node/spec"
 
 const (
-	BallotNumFields      = 6
-	BallotGroupSize      = 2
-	BallotUniqueValues   = 0
-	BallotMaxValue       = 16
-	BallotMinValue       = 0
-	BallotMaxValueSum    = 1280 // (maxValue ^ costExponent) * numFields
-	BallotMinValueSum    = BallotNumFields
-	BallotCostExponent   = 2
+	BallotNumFields    = 6
+	BallotGroupSize    = 2
+	BallotUniqueValues = 0
+	BallotMaxValue     = 16
+	BallotMinValue     = 0
+	BallotMaxValueSum  = 1280 // (maxValue ^ costExponent) * numFields
+	BallotMinValueSum  = BallotNumFields
+	BallotCostExponent = 2
 )
 
 // FixedBallotMode returns a fixed ballot mode fixture used in tests.
 func FixedBallotMode() spec.BallotMode {
 	return spec.BallotMode{
-		NumFields:      BallotNumFields,
-		GroupSize:      BallotGroupSize,
-		UniqueValues:   BallotUniqueValues == 1,
-		MaxValue:       BallotMaxValue,
-		MinValue:       BallotMinValue,
-		MaxValueSum:    BallotMaxValueSum,
-		MinValueSum:    BallotMinValueSum,
-		CostExponent:   BallotCostExponent,
+		NumFields:    BallotNumFields,
+		GroupSize:    BallotGroupSize,
+		UniqueValues: BallotUniqueValues == 1,
+		MaxValue:     BallotMaxValue,
+		MinValue:     BallotMinValue,
+		MaxValueSum:  BallotMaxValueSum,
+		MinValueSum:  BallotMinValueSum,
+		CostExponent: BallotCostExponent,
 	}
 }

--- a/tests/helpers/service.go
+++ b/tests/helpers/service.go
@@ -16,7 +16,6 @@ import (
 	c3config "github.com/vocdoni/census3-bigquery/config"
 	c3service "github.com/vocdoni/census3-bigquery/service"
 	"github.com/vocdoni/davinci-node/api/client"
-	"github.com/vocdoni/davinci-node/config"
 	"github.com/vocdoni/davinci-node/db"
 	"github.com/vocdoni/davinci-node/db/metadb"
 	"github.com/vocdoni/davinci-node/log"
@@ -121,12 +120,7 @@ func NewTestServices(
 		return nil, nil, fmt.Errorf("failed to start process monitor: %w", err)
 	}
 	// Start API service
-	web3Conf := config.DavinciWeb3Config{
-		ProcessRegistrySmartContract: contracts.ContractsAddresses.ProcessRegistry.String(),
-		ResultsZKVerifier:            contracts.ContractsAddresses.ResultsZKVerifier.String(),
-		StateTransitionZKVerifier:    contracts.ContractsAddresses.StateTransitionZKVerifier.String(),
-	}
-	api, err := setupAPI(ctx, stg, workerSecret, workerTokenExpiration, workerTimeout, banRules, web3Conf)
+	api, err := setupAPI(ctx, stg, contracts, workerSecret, workerTokenExpiration, workerTimeout, banRules)
 	if err != nil {
 		pm.Stop()
 		cd.Stop()
@@ -172,15 +166,23 @@ func httpClient(port int) (*client.HTTPclient, error) {
 func setupAPI(
 	ctx context.Context,
 	db *storage.Storage,
+	contracts *web3.Contracts,
 	workerSeed string,
 	workerTokenExpiration time.Duration,
 	workerTimeout time.Duration,
 	banRules *workers.WorkerBanRules,
-	web3Conf config.DavinciWeb3Config,
 ) (*service.APIService, error) {
-	api := service.NewAPI(db, "127.0.0.1", DefaultAPIPort, "test", web3Conf, metadata.PinataMetadataProviderConfig{}, false)
+	apiRuntime, err := web3.NewNetworkRuntime("test", contracts, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create API runtime: %w", err)
+	}
+	apiRuntimes, err := web3.NewRuntimeRouter(apiRuntime)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create API runtime router: %w", err)
+	}
+	api := service.NewAPI(db, "127.0.0.1", DefaultAPIPort, apiRuntimes, metadata.PinataMetadataProviderConfig{}, false)
 	api.SetWorkerConfig(workerSeed, workerTokenExpiration, workerTimeout, banRules)
-	if err := api.Start(ctx); err != nil {
+	if err = api.Start(ctx); err != nil {
 		return nil, err
 	}
 

--- a/web3/runtime.go
+++ b/web3/runtime.go
@@ -1,0 +1,121 @@
+package web3
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/vocdoni/davinci-node/types"
+	"github.com/vocdoni/davinci-node/web3/txmanager"
+)
+
+// Since ProcessIDVersion is a uint32, we limit the chain ID to 32 bits
+const maxProcessIDChainID = uint64(^uint32(0))
+
+// NetworkRuntime groups all chain-specific runtime state needed by the
+// sequencer for one enabled network.
+type NetworkRuntime struct {
+	Network          string
+	ProcessIDVersion [4]byte
+	Contracts        *Contracts
+	TxManager        *txmanager.TxManager
+}
+
+// NewNetworkRuntime builds a network runtime and computes its ProcessIDVersion
+// from the contracts chain ID and ProcessRegistry address.
+func NewNetworkRuntime(
+	network string,
+	contracts *Contracts,
+	txManager *txmanager.TxManager,
+) (*NetworkRuntime, error) {
+	if network == "" {
+		return nil, fmt.Errorf("network is required")
+	}
+	if contracts == nil {
+		return nil, fmt.Errorf("contracts is required")
+	}
+	if contracts.ContractsAddresses == nil {
+		return nil, fmt.Errorf("contracts addresses are required")
+	}
+	processRegistry := contracts.ContractsAddresses.ProcessRegistry
+	if processRegistry == (common.Address{}) {
+		return nil, fmt.Errorf("process registry address is required")
+	}
+	// Check that the chain ID is within the ProcessIDVersion limit
+	if contracts.ChainID > maxProcessIDChainID {
+		return nil, fmt.Errorf("chain ID %d exceeds ProcessIDVersion limit", contracts.ChainID)
+	}
+
+	return &NetworkRuntime{
+		Network:          network,
+		ProcessIDVersion: types.ProcessIDVersion(uint32(contracts.ChainID), processRegistry),
+		Contracts:        contracts,
+		TxManager:        txManager,
+	}, nil
+}
+
+// RuntimeRouter resolves process-scoped operations to the correct runtime.
+type RuntimeRouter struct {
+	runtimes         []*NetworkRuntime
+	runtimeByVersion map[[4]byte]*NetworkRuntime
+}
+
+// NewRuntimeRouter creates a router and validates that each runtime has a
+// unique ProcessIDVersion.
+func NewRuntimeRouter(runtimes ...*NetworkRuntime) (*RuntimeRouter, error) {
+	router := &RuntimeRouter{
+		runtimes:         make([]*NetworkRuntime, 0, len(runtimes)),
+		runtimeByVersion: make(map[[4]byte]*NetworkRuntime, len(runtimes)),
+	}
+
+	for _, runtime := range runtimes {
+		if runtime == nil {
+			return nil, fmt.Errorf("runtime cannot be nil")
+		}
+		if runtime.Contracts == nil {
+			return nil, fmt.Errorf("runtime contracts cannot be nil")
+		}
+		if existing, ok := router.runtimeByVersion[runtime.ProcessIDVersion]; ok {
+			return nil, fmt.Errorf(
+				"duplicate ProcessIDVersion %x for networks %s and %s",
+				runtime.ProcessIDVersion,
+				existing.Network,
+				runtime.Network,
+			)
+		}
+		router.runtimes = append(router.runtimes, runtime)
+		router.runtimeByVersion[runtime.ProcessIDVersion] = runtime
+	}
+
+	return router, nil
+}
+
+// RuntimeForVersion returns the runtime associated with the provided
+// ProcessIDVersion.
+func (r *RuntimeRouter) RuntimeForVersion(version [4]byte) (*NetworkRuntime, bool) {
+	if r == nil {
+		return nil, false
+	}
+	runtime, ok := r.runtimeByVersion[version]
+	return runtime, ok
+}
+
+// ContractsForProcess resolves the contracts instance associated with the
+// provided process ID.
+func (r *RuntimeRouter) ContractsForProcess(processID types.ProcessID) (*Contracts, error) {
+	if !processID.IsValid() {
+		return nil, fmt.Errorf("invalid process ID")
+	}
+	runtime, ok := r.RuntimeForVersion(processID.Version())
+	if !ok {
+		return nil, fmt.Errorf("runtime not found for process version %x", processID.Version())
+	}
+	return runtime.Contracts, nil
+}
+
+// Runtimes returns the configured runtimes in registration order.
+func (r *RuntimeRouter) Runtimes() []*NetworkRuntime {
+	if r == nil {
+		return nil
+	}
+	return append([]*NetworkRuntime(nil), r.runtimes...)
+}

--- a/web3/runtime_test.go
+++ b/web3/runtime_test.go
@@ -1,0 +1,156 @@
+package web3
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	qt "github.com/frankban/quicktest"
+	"github.com/vocdoni/davinci-node/types"
+)
+
+func TestNewNetworkRuntime(t *testing.T) {
+	c := qt.New(t)
+
+	contracts := &Contracts{
+		ChainID: 11155111,
+		ContractsAddresses: &Addresses{
+			ProcessRegistry: common.HexToAddress("0x015eac820688da203a0bd730a8a7a4cdb97e1a02"),
+		},
+	}
+
+	runtime, err := NewNetworkRuntime("sepolia", contracts, nil)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(runtime.Network, qt.Equals, "sepolia")
+	c.Assert(runtime.Contracts, qt.Equals, contracts)
+	c.Assert(runtime.TxManager, qt.IsNil)
+	c.Assert(runtime.ProcessIDVersion, qt.DeepEquals,
+		types.ProcessIDVersion(uint32(contracts.ChainID), contracts.ContractsAddresses.ProcessRegistry))
+}
+
+func TestNewNetworkRuntimeErrors(t *testing.T) {
+	c := qt.New(t)
+
+	validContracts := &Contracts{
+		ChainID: 1,
+		ContractsAddresses: &Addresses{
+			ProcessRegistry: common.HexToAddress("0x0000000000000000000000000000000000000001"),
+		},
+	}
+
+	c.Run("missing network", func(c *qt.C) {
+		runtime, err := NewNetworkRuntime("", validContracts, nil)
+		c.Assert(runtime, qt.IsNil)
+		c.Assert(err, qt.Not(qt.IsNil))
+		c.Assert(err.Error(), qt.Contains, "network is required")
+	})
+
+	c.Run("missing contracts", func(c *qt.C) {
+		runtime, err := NewNetworkRuntime("mainnet", nil, nil)
+		c.Assert(runtime, qt.IsNil)
+		c.Assert(err, qt.Not(qt.IsNil))
+		c.Assert(err.Error(), qt.Contains, "contracts is required")
+	})
+
+	c.Run("missing addresses", func(c *qt.C) {
+		runtime, err := NewNetworkRuntime("mainnet", &Contracts{ChainID: 1}, nil)
+		c.Assert(runtime, qt.IsNil)
+		c.Assert(err, qt.Not(qt.IsNil))
+		c.Assert(err.Error(), qt.Contains, "contracts addresses are required")
+	})
+
+	c.Run("missing process registry", func(c *qt.C) {
+		runtime, err := NewNetworkRuntime("mainnet", &Contracts{
+			ChainID:            1,
+			ContractsAddresses: &Addresses{},
+		}, nil)
+		c.Assert(runtime, qt.IsNil)
+		c.Assert(err, qt.Not(qt.IsNil))
+		c.Assert(err.Error(), qt.Contains, "process registry address is required")
+	})
+
+	c.Run("chain ID exceeds version limit", func(c *qt.C) {
+		runtime, err := NewNetworkRuntime("oversized", &Contracts{
+			ChainID: maxProcessIDChainID + 1,
+			ContractsAddresses: &Addresses{
+				ProcessRegistry: common.HexToAddress("0x0000000000000000000000000000000000000001"),
+			},
+		}, nil)
+		c.Assert(runtime, qt.IsNil)
+		c.Assert(err, qt.Not(qt.IsNil))
+		c.Assert(err.Error(), qt.Contains, "exceeds ProcessIDVersion limit")
+	})
+}
+
+func TestNewRuntimeRouter(t *testing.T) {
+	c := qt.New(t)
+
+	sepoliaRuntime := testRuntime(c, "sepolia", 11155111, "0x015eac820688da203a0bd730a8a7a4cdb97e1a02")
+	celoRuntime := testRuntime(c, "celo", 42220, "0x68dac70af68aa0bed8cef36c523243941d7d7876")
+
+	router, err := NewRuntimeRouter(sepoliaRuntime, celoRuntime)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(router.Runtimes(), qt.HasLen, 2)
+
+	runtime, ok := router.RuntimeForVersion(sepoliaRuntime.ProcessIDVersion)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(runtime, qt.Equals, sepoliaRuntime)
+
+	processID := types.NewProcessID(
+		common.HexToAddress("0x1234567890123456789012345678901234567890"),
+		celoRuntime.ProcessIDVersion,
+		7,
+	)
+	contracts, err := router.ContractsForProcess(processID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(contracts, qt.Equals, celoRuntime.Contracts)
+}
+
+func TestNewRuntimeRouterRejectsDuplicateVersions(t *testing.T) {
+	c := qt.New(t)
+
+	processRegistry := "0x015eac820688da203a0bd730a8a7a4cdb97e1a02"
+	runtimeA := testRuntime(c, "sepolia-a", 11155111, processRegistry)
+	runtimeB := testRuntime(c, "sepolia-b", 11155111, processRegistry)
+
+	router, err := NewRuntimeRouter(runtimeA, runtimeB)
+
+	c.Assert(router, qt.IsNil)
+	c.Assert(err, qt.Not(qt.IsNil))
+	c.Assert(err.Error(), qt.Contains, "duplicate ProcessIDVersion")
+}
+
+func TestRuntimeRouterContractsForProcessErrors(t *testing.T) {
+	c := qt.New(t)
+
+	router, err := NewRuntimeRouter(testRuntime(c, "sepolia", 11155111, "0x015eac820688da203a0bd730a8a7a4cdb97e1a02"))
+	c.Assert(err, qt.IsNil)
+
+	contracts, err := router.ContractsForProcess(types.ProcessID{})
+	c.Assert(contracts, qt.IsNil)
+	c.Assert(err, qt.Not(qt.IsNil))
+	c.Assert(err.Error(), qt.Contains, "invalid process ID")
+
+	unknownProcess := types.NewProcessID(
+		common.HexToAddress("0x1234567890123456789012345678901234567890"),
+		[4]byte{0xde, 0xad, 0xbe, 0xef},
+		1,
+	)
+	contracts, err = router.ContractsForProcess(unknownProcess)
+	c.Assert(contracts, qt.IsNil)
+	c.Assert(err, qt.Not(qt.IsNil))
+	c.Assert(err.Error(), qt.Contains, "runtime not found")
+}
+
+func testRuntime(c *qt.C, network string, chainID uint64, processRegistry string) *NetworkRuntime {
+	contracts := &Contracts{
+		ChainID: chainID,
+		ContractsAddresses: &Addresses{
+			ProcessRegistry: common.HexToAddress(processRegistry),
+		},
+	}
+	runtime, err := NewNetworkRuntime(network, contracts, nil)
+	c.Assert(err, qt.IsNil)
+	return runtime
+}

--- a/webapp/src/components/Layout/Navbar.tsx
+++ b/webapp/src/components/Layout/Navbar.tsx
@@ -4,6 +4,7 @@ import { useSequencerInfo } from '~hooks/useSequencerAPI'
 
 export const Navbar = () => {
   const { data: info, isLoading } = useSequencerInfo()
+  const runtimes = Object.entries(info?.runtimes ?? {})
   
   // Get block explorer URL from runtime config (injected by Docker) or fallback to build-time env var
   const getBlockExplorerUrl = (): string => {
@@ -45,30 +46,46 @@ export const Navbar = () => {
                 </>
               ) : (
                 <>
-                  <Tooltip label={info?.contracts?.process || 'Not available'}>
-                    <HStack spacing={1}>
-                      <Text>Process:</Text>
-                      {info?.contracts?.process ? (
-                        <Link
-                          href={`${blockExplorerUrl}/${info.contracts.process}`}
-                          isExternal
-                          display="inline-flex"
-                          alignItems="center"
-                          gap={1}
-                          color="purple.500"
-                          _hover={{ color: 'purple.600' }}
-                        >
-                          <Badge colorScheme="purple" fontSize="xs" fontFamily="mono">
-                            {info.contracts.process.slice(0, 6)}...{info.contracts.process.slice(-4)}
-                          </Badge>
-                          <FaExternalLinkAlt size={10} />
-                        </Link>
-                      ) : (
-                        <Text color="gray.400" fontSize="xs">N/A</Text>
-                      )}
-                    </HStack>
-                  </Tooltip>
-                  
+                  {runtimes.length === 0 ? (
+                    <Text color="gray.400" fontSize="xs">N/A</Text>
+                  ) : (
+                    runtimes.map(([chainId, runtime]) => {
+                      const processAddress = runtime.contracts.process
+                      const processLabel = `${runtime.network} (${chainId})`
+
+                      return (
+                        <Tooltip key={chainId} label={processAddress || 'Not available'}>
+                          <HStack spacing={1}>
+                            <Text>{processLabel}:</Text>
+                            {processAddress ? (
+                              runtimes.length === 1 ? (
+                                <Link
+                                  href={`${blockExplorerUrl}/${processAddress}`}
+                                  isExternal
+                                  display="inline-flex"
+                                  alignItems="center"
+                                  gap={1}
+                                  color="purple.500"
+                                  _hover={{ color: 'purple.600' }}
+                                >
+                                  <Badge colorScheme="purple" fontSize="xs" fontFamily="mono">
+                                    {processAddress.slice(0, 6)}...{processAddress.slice(-4)}
+                                  </Badge>
+                                  <FaExternalLinkAlt size={10} />
+                                </Link>
+                              ) : (
+                                <Badge colorScheme="purple" fontSize="xs" fontFamily="mono">
+                                  {processAddress.slice(0, 6)}...{processAddress.slice(-4)}
+                                </Badge>
+                              )
+                            ) : (
+                              <Text color="gray.400" fontSize="xs">N/A</Text>
+                            )}
+                          </HStack>
+                        </Tooltip>
+                      )
+                    })
+                  )}
                 </>
               )}
             </HStack>

--- a/webapp/src/types/api.ts
+++ b/webapp/src/types/api.ts
@@ -6,6 +6,11 @@ export interface ContractAddresses {
   resultsVerifier: string
 }
 
+export interface RuntimeInfo {
+  network: string
+  contracts: ContractAddresses
+}
+
 export interface InfoResponse {
   circuitUrl: string
   circuitHash: string
@@ -13,7 +18,7 @@ export interface InfoResponse {
   provingKeyHash: string
   verificationKeyUrl: string
   verificationKeyHash: string
-  contracts: ContractAddresses
+  runtimes: Record<string, RuntimeInfo>
 }
 
 export interface SequencerStatsResponse {


### PR DESCRIPTION
  - Add the initial web3 runtime and router primitives.
  - Compute the process ID version once when each runtime is created.
  - Reject duplicated process ID versions when runtimes are registered.
  - Make the API read its accepted process versions from the runtime router.
  - Change /info to return a runtimes map keyed by chain ID.
  - Remove the old /info network and contracts fields.
  - Apply process version validation only on routes that include a processId.
  - Keep middleware process ID extraction based only on chi.URLParam.
  - Update the API service and current startup paths to wrap the existing single contracts instance in a one-runtime router.
  - Update test helpers to build the API from a runtime router.
  - Update the webapp types and navbar to use the new /info response.
  - Update the API README to document the new runtime-based response shape.
  - Add and update tests for runtime registration, API info responses, and process version validation.