### PR TITLE
ci(github): don't run go tests in parallel

### DIFF
--- a/.github/workflows/go-test-circuits.yml
+++ b/.github/workflows/go-test-circuits.yml
@@ -41,6 +41,7 @@ jobs:
           RUN_CIRCUIT_TESTS: true
         run: |
           go test -v ./circuits/... \
+            -p 1 \
             -failfast \
             -vet=off \
             -timeout=1h

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -128,6 +128,7 @@ jobs:
           RUN_INTEGRATION_TESTS: false
         run: |
           go test -v ./... \
+            -p 1 \
             -failfast \
             -vet=off \
             -cover \
@@ -150,6 +151,7 @@ jobs:
         run: |
           set -o pipefail
           go test -v ./tests/... \
+            -p 1 \
             -failfast \
             -vet=off \
             -timeout=1h \


### PR DESCRIPTION
* restores output streaming (crucial for long-running tests)
* heavy circuit tests don't interfere with each other
* makes `-failfast` clearer.
