### PR TITLE
feat: show chainID in processes of sequencer dashboard

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "type": "module",
   "scripts": {
-    "dev": "vite --port 3001",
+    "dev": "vite",
     "build": "vite build",
     "lint": "tsc --noEmit && eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --port 3001",
     "build": "vite build",
     "lint": "tsc --noEmit && eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",

--- a/webapp/src/components/ProcessList/ProcessCard.tsx
+++ b/webapp/src/components/ProcessList/ProcessCard.tsx
@@ -40,7 +40,8 @@ import {
   FaCheckCircle,
   FaExternalLinkAlt,
 } from 'react-icons/fa'
-import { Process, ProcessStatus, ProcessStatusLabel, ProcessStatusColor } from '~types/api'
+import { Process, ProcessStatus, ProcessStatusLabel, ProcessStatusColor, processIDVersion } from '~types/api'
+import { useSequencerInfo } from '~hooks/useSequencerAPI'
 
 interface ProcessCardProps {
   process: Process
@@ -50,6 +51,24 @@ export const ProcessCard = ({ process }: ProcessCardProps) => {
   const [isExpanded, setIsExpanded] = useState(false)
   const [copiedField, setCopiedField] = useState<string | null>(null)
   const bgColor = useColorModeValue('white', 'gray.800')
+
+  // Resolve the network for this process by matching processIDVersion
+  const { data: info } = useSequencerInfo()
+  const networkLabel = useMemo(() => {
+    if (!info?.networks) return null
+    let version: string
+    try {
+      version = processIDVersion(process.id)
+    } catch {
+      return null
+    }
+    for (const [, net] of Object.entries(info.networks)) {
+      if (net.processIDVersion.toLowerCase() === version.toLowerCase()) {
+        return `${net.shortName}:${net.chainID}`
+      }
+    }
+    return null
+  }, [info, process.id])
   const borderColor = useColorModeValue(
     isExpanded ? 'purple.200' : 'gray.200',
     isExpanded ? 'purple.600' : 'gray.600'
@@ -316,6 +335,13 @@ export const ProcessCard = ({ process }: ProcessCardProps) => {
             <VStack align="flex-start" spacing={2} flex={1}>
               <HexField label="Process ID" value={process.id} fieldName="processId" />
               <Wrap spacing={2}>
+                {networkLabel && (
+                  <WrapItem>
+                    <Badge colorScheme="purple" variant="subtle" fontSize="xs" fontFamily="mono">
+                      {networkLabel}
+                    </Badge>
+                  </WrapItem>
+                )}
                 <WrapItem>
                   <Badge colorScheme={ProcessStatusColor[process.status]} size="sm">
                     {ProcessStatusLabel[process.status]}

--- a/webapp/src/types/api.ts
+++ b/webapp/src/types/api.ts
@@ -110,6 +110,30 @@ export const ProcessStatusLabel: Record<number, string> = {
   [ProcessStatus.RESULTS]: 'Results',
 }
 
+/**
+ * Extracts the version bytes from a process ID hex string and returns them
+ * as a lowercase hex string (e.g. "0x12345678").
+ * The version occupies bytes 20-23 (4 bytes / 8 hex chars) of the 31-byte process ID.
+ */
+export function processIDVersion(processIDHex: string): string {
+  const hex = processIDHex.startsWith("0x")
+    ? processIDHex.slice(2)
+    : processIDHex
+
+  // ProcessIDLen = 31 bytes = 62 hex chars
+  if (hex.length !== 62) {
+    throw new Error(`invalid process ID hex length ${hex.length}, want 62`)
+  }
+
+  if (!/^[0-9a-fA-F]+$/.test(hex)) {
+    throw new Error("invalid process ID hex string")
+  }
+
+  // address = 20 bytes = 40 hex chars
+  // version = next 4 bytes = 8 hex chars
+  return "0x" + hex.slice(40, 48).toLowerCase()
+}
+
 export const ProcessStatusColor: Record<number, string> = {
   [ProcessStatus.READY]: 'green',
   [ProcessStatus.ENDED]: 'gray',

--- a/webapp/vite.config.ts
+++ b/webapp/vite.config.ts
@@ -21,7 +21,7 @@ export default defineConfig(({ mode }) => {
       react(),
     ],
     server: {
-      port: 3000,
+      port: 3001,
       cors: true,
     },
   }


### PR DESCRIPTION
include the chainID in the processes of the sequencer dashboard

<img width="471" height="74" alt="image" src="https://github.com/user-attachments/assets/85e5f900-fef4-4bb5-b1cc-edbf9a3ecd8a" />
