### PR TITLE
feat: restore `ProcessRegistry` configuration via flag/envvar

### DIFF
--- a/cmd/davinci-sequencer/config.go
+++ b/cmd/davinci-sequencer/config.go
@@ -10,6 +10,7 @@ import (
 	flag "github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"github.com/vocdoni/davinci-node/internal"
+	"github.com/vocdoni/davinci-node/web3"
 )
 
 const (
@@ -35,7 +36,7 @@ var Version = internal.Version
 
 // Config holds the application configuration
 type Config struct {
-	Web3         Web3Config
+	Web3         web3.Web3Config
 	API          APIConfig
 	Batch        BatchConfig
 	Log          LogConfig
@@ -43,15 +44,6 @@ type Config struct {
 	Metadata     MetadataConfig
 	Datadir      string
 	ForceCleanup bool `mapstructure:"forceCleanup"` // Force cleanup of all pending items at startup
-}
-
-// Web3Config holds Ethereum-related configuration
-type Web3Config struct {
-	PrivKey       string   `mapstructure:"privkey"`       // Private key for the Ethereum account
-	ChainIDs      []uint   `mapstructure:"chainIDs"`      // Chain IDs to use, if defined, limits RPCs and BeaconAPIs, if empty, use all
-	RPCs          []string `mapstructure:"rpc"`           // Web3 RPC endpoints, can be multiple
-	BeaconAPIs    []string `mapstructure:"bapi"`          // Web3 Consensus Beacon API endpoints, can be multiple
-	GasMultiplier float64  `mapstructure:"gasMultiplier"` // Gas price multiplier for transactions (default: 1.0)
 }
 
 // APIConfig holds the API-specific configuration
@@ -112,7 +104,7 @@ func loadConfig() (*Config, error) {
 	flag.StringSliceP("web3.rpc", "r", []string{defaultRPC}, "web3 rpc endpoint(s), comma-separated")
 	flag.StringSliceP("web3.capi", "c", []string{defaultConsensusAPI}, "consensus api endpoints(s), comma-separated")
 	flag.Float64("web3.gasMultiplier", defaultGasMultiplier, "gas price multiplier for transactions (1.0 = default, 2.0 = double gas prices)")
-	flag.String("web3.processRegistryAddress", "", "Address of the process registry contract to be used by the sequencer (overrides network default)")
+	flag.String("web3.processRegistryContract", "", "'chainID:0xaddress' of the process registry smart contract, if defined, it will be included in the available networks")
 	// sequencer API
 	flag.StringP("api.host", "h", defaultAPIHost, "API host")
 	flag.IntP("api.port", "p", defaultAPIPort, "API port")

--- a/cmd/davinci-sequencer/config.go
+++ b/cmd/davinci-sequencer/config.go
@@ -102,9 +102,9 @@ func loadConfig() (*Config, error) {
 	flag.StringP("web3.privkey", "k", "", "private key to use for the Ethereum account, should have funds for each available network (required)")
 	flag.UintSlice("web3.chainIDs", nil, "chainIDs to limit RPCs and BeaconAPIs, comma-separated, empty for all")
 	flag.StringSliceP("web3.rpc", "r", []string{defaultRPC}, "web3 rpc endpoint(s), comma-separated")
-	flag.StringSliceP("web3.bapi", "b", []string{defaultConsensusAPI}, "consensus api endpoints(s), comma-separated")
+	flag.StringSlice("web3.bapi", []string{defaultConsensusAPI}, "consensus api endpoints(s), comma-separated")
 	flag.Float64("web3.gasMultiplier", defaultGasMultiplier, "gas price multiplier for transactions (1.0 = default, 2.0 = double gas prices)")
-	flag.String("web3.processRegistryContract", "", "'chainID:0xaddress' of the process registry smart contract, if defined, it will be included in the available networks if a valid RPC endpoint is provided")
+	flag.StringSlice("web3.processRegistryContract", nil, "'chainID:0xaddress' of the process registry smart contract, if defined, it will be included in the available networks if a valid RPC endpoint is provided")
 	// sequencer API
 	flag.StringP("api.host", "h", defaultAPIHost, "API host")
 	flag.IntP("api.port", "p", defaultAPIPort, "API port")

--- a/cmd/davinci-sequencer/config.go
+++ b/cmd/davinci-sequencer/config.go
@@ -102,9 +102,9 @@ func loadConfig() (*Config, error) {
 	flag.StringP("web3.privkey", "k", "", "private key to use for the Ethereum account, should have funds for each available network (required)")
 	flag.UintSlice("web3.chainIDs", nil, "chainIDs to limit RPCs and BeaconAPIs, comma-separated, empty for all")
 	flag.StringSliceP("web3.rpc", "r", []string{defaultRPC}, "web3 rpc endpoint(s), comma-separated")
-	flag.StringSliceP("web3.capi", "c", []string{defaultConsensusAPI}, "consensus api endpoints(s), comma-separated")
+	flag.StringSliceP("web3.bapi", "b", []string{defaultConsensusAPI}, "consensus api endpoints(s), comma-separated")
 	flag.Float64("web3.gasMultiplier", defaultGasMultiplier, "gas price multiplier for transactions (1.0 = default, 2.0 = double gas prices)")
-	flag.String("web3.processRegistryContract", "", "'chainID:0xaddress' of the process registry smart contract, if defined, it will be included in the available networks")
+	flag.String("web3.processRegistryContract", "", "'chainID:0xaddress' of the process registry smart contract, if defined, it will be included in the available networks if a valid RPC endpoint is provided")
 	// sequencer API
 	flag.StringP("api.host", "h", defaultAPIHost, "API host")
 	flag.IntP("api.port", "p", defaultAPIPort, "API port")

--- a/cmd/davinci-sequencer/main.go
+++ b/cmd/davinci-sequencer/main.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/signal"
 	"path"
-	"slices"
 	"syscall"
 
 	"github.com/vocdoni/davinci-node/db"
@@ -17,7 +16,6 @@ import (
 	"github.com/vocdoni/davinci-node/service"
 	"github.com/vocdoni/davinci-node/storage"
 	"github.com/vocdoni/davinci-node/web3"
-	"github.com/vocdoni/davinci-node/web3/rpc"
 	"github.com/vocdoni/davinci-node/web3/txmanager"
 	"github.com/vocdoni/davinci-node/workers"
 )
@@ -179,9 +177,19 @@ func setupServices(ctx context.Context, cfg *Config) (services *Services, err er
 		log.Info("force cleanup completed successfully")
 	}
 
-	runtimes, err := initializeRuntimes(ctx, cfg.Web3)
+	runtimes, err := cfg.Web3.InitRuntimes(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize runtimes: %w", err)
+	}
+	for _, runtime := range runtimes {
+		log.Infow("web3 runtime initialized",
+			"chainID", runtime.ChainID,
+			"account", runtime.Contracts.AccountAddress().Hex(),
+			"gasMultiplier", runtime.Contracts.GasMultiplier,
+			"availableEndpoints", runtime.AvailableEndpoints,
+			"processRegistry", runtime.Contracts.ContractsAddresses.ProcessRegistry.Hex(),
+			"consensusAPI", runtime.Contracts.Web3ConsensusAPIEndpoint,
+		)
 	}
 
 	log.Infow("initializing web3 runtimes", "numNetworks", len(runtimes))
@@ -264,76 +272,6 @@ func setupServices(ctx context.Context, cfg *Config) (services *Services, err er
 
 	log.Info("davinci-node is running, ready to process votes!")
 	return services, nil
-}
-
-func initializeRuntimes(ctx context.Context, web3Cfg Web3Config) ([]*web3.NetworkRuntime, error) {
-	// Group RPC endpoints by chain ID
-	rpcsMap, err := rpc.GroupEndpointsByChainID(web3Cfg.RPCs)
-	if err != nil {
-		return nil, fmt.Errorf("resolve RPC endpoints: %w", err)
-	}
-	// Group beacon API endpoints by chain ID
-	beaconAPIsMap, err := rpc.GroupBeaconEndpointsByChainID(ctx, web3Cfg.BeaconAPIs)
-	if err != nil {
-		return nil, fmt.Errorf("resolve beacon API endpoints: %w", err)
-	}
-	limitedNetworks := len(web3Cfg.ChainIDs) > 0
-	// Iterate over available networks to initialize web3 runtimes
-	var runtimes []*web3.NetworkRuntime
-	for chainID, rpcs := range rpcsMap {
-		// Skip networks that are not configured, if any is configured
-		if limitedNetworks && !slices.Contains(web3Cfg.ChainIDs, uint(chainID)) {
-			continue
-		}
-		// Try to find a beacon API for this network
-		var beaconAPI string
-		if beaconAPIs, ok := beaconAPIsMap[chainID]; ok && len(beaconAPIs) > 0 {
-			beaconAPI = beaconAPIs[0]
-		}
-		// Load contracts for this network
-		contracts, err := web3.New(rpcs, beaconAPI, web3Cfg.GasMultiplier)
-		if err != nil {
-			return nil, fmt.Errorf("initialize web3 client: %w", err)
-		}
-
-		if err := contracts.LoadContracts(nil); err != nil {
-			return nil, fmt.Errorf("initialize contracts: %w", err)
-		}
-		if err := contracts.SetAccountPrivateKey(web3Cfg.PrivKey); err != nil {
-			return nil, fmt.Errorf("set account private key: %w", err)
-		}
-
-		txManager, err := txmanager.New(
-			ctx,
-			contracts.Web3Pool(),
-			contracts.Client(),
-			contracts.Signer(),
-			txmanager.DefaultConfig(contracts.ChainID),
-		)
-		if err != nil {
-			return nil, fmt.Errorf("create transaction manager: %w", err)
-		}
-		txManager.Start(ctx)
-		contracts.SetTxManager(txManager)
-
-		runtime, err := web3.NewNetworkRuntime(contracts, txManager)
-		if err != nil {
-			txManager.Stop()
-			return nil, fmt.Errorf("create runtime: %w", err)
-		}
-
-		log.Infow("web3 runtime initialized",
-			"chainID", runtime.ChainID,
-			"account", runtime.Contracts.AccountAddress().Hex(),
-			"gasMultiplier", runtime.Contracts.GasMultiplier,
-			"numEndpoints", len(rpcs),
-			"processRegistry", runtime.Contracts.ContractsAddresses.ProcessRegistry.Hex(),
-			"consensusAPI", runtime.Contracts.Web3ConsensusAPIEndpoint,
-		)
-
-		runtimes = append(runtimes, runtime)
-	}
-	return runtimes, nil
 }
 
 // shutdownServices gracefully shuts down all services

--- a/cmd/davinci-sequencer/main.go
+++ b/cmd/davinci-sequencer/main.go
@@ -186,7 +186,7 @@ func setupServices(ctx context.Context, cfg *Config) (services *Services, err er
 			"chainID", runtime.ChainID,
 			"account", runtime.Contracts.AccountAddress().Hex(),
 			"gasMultiplier", runtime.Contracts.GasMultiplier,
-			"availableEndpoints", runtime.AvailableEndpoints,
+			"availableEndpoints", runtime.AvailableEndpoints(),
 			"processRegistry", runtime.Contracts.ContractsAddresses.ProcessRegistry.Hex(),
 			"consensusAPI", runtime.Contracts.Web3ConsensusAPIEndpoint,
 		)

--- a/sequencer/statetransition_test.go
+++ b/sequencer/statetransition_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/vocdoni/davinci-node/web3"
 )
 
-func testVariableAsBigInt(t *testing.T, v interface{}) *big.Int {
+func testVariableAsBigInt(t *testing.T, v any) *big.Int {
 	t.Helper()
 	switch x := v.(type) {
 	case *big.Int:

--- a/web3/runtime.go
+++ b/web3/runtime.go
@@ -34,12 +34,21 @@ type ProcessBlobFetcherResolver interface {
 // NetworkRuntime groups all chain-specific runtime state needed by the
 // sequencer for one enabled network.
 type NetworkRuntime struct {
-	ChainID            uint64
-	ShortName          string
-	ProcessIDVersion   [4]byte
-	Contracts          *Contracts
-	TxManager          *txmanager.TxManager
-	AvailableEndpoints int
+	ChainID          uint64
+	ShortName        string
+	ProcessIDVersion [4]byte
+	Contracts        *Contracts
+	TxManager        *txmanager.TxManager
+}
+
+// AvailableEndpoints returns the number of available endpoints for this
+// network. It wraps the web3pool NumberOfEndpoints method for the current
+// runtime chain ID.
+func (r *NetworkRuntime) AvailableEndpoints() int {
+	if r.Contracts == nil || r.Contracts.web3pool == nil {
+		return 0
+	}
+	return r.Contracts.web3pool.NumberOfEndpoints(r.ChainID, true)
 }
 
 // NewNetworkRuntime builds a network runtime and computes its ProcessIDVersion
@@ -64,12 +73,11 @@ func NewNetworkRuntime(
 	}
 
 	return &NetworkRuntime{
-		ChainID:            contracts.ChainID,
-		ShortName:          chainlist.ShortNameByChainID(contracts.ChainID),
-		ProcessIDVersion:   types.ProcessIDVersion(uint32(contracts.ChainID), processRegistry),
-		Contracts:          contracts,
-		TxManager:          txManager,
-		AvailableEndpoints: contracts.web3pool.NumberOfEndpoints(contracts.ChainID, true),
+		ChainID:          contracts.ChainID,
+		ShortName:        chainlist.ShortNameByChainID(contracts.ChainID),
+		ProcessIDVersion: types.ProcessIDVersion(uint32(contracts.ChainID), processRegistry),
+		Contracts:        contracts,
+		TxManager:        txManager,
 	}, nil
 }
 

--- a/web3/runtime.go
+++ b/web3/runtime.go
@@ -34,11 +34,12 @@ type ProcessBlobFetcherResolver interface {
 // NetworkRuntime groups all chain-specific runtime state needed by the
 // sequencer for one enabled network.
 type NetworkRuntime struct {
-	ChainID          uint64
-	ShortName        string
-	ProcessIDVersion [4]byte
-	Contracts        *Contracts
-	TxManager        *txmanager.TxManager
+	ChainID            uint64
+	ShortName          string
+	ProcessIDVersion   [4]byte
+	Contracts          *Contracts
+	TxManager          *txmanager.TxManager
+	AvailableEndpoints int
 }
 
 // NewNetworkRuntime builds a network runtime and computes its ProcessIDVersion
@@ -63,11 +64,12 @@ func NewNetworkRuntime(
 	}
 
 	return &NetworkRuntime{
-		ChainID:          contracts.ChainID,
-		ShortName:        chainlist.ShortNameByChainID(contracts.ChainID),
-		ProcessIDVersion: types.ProcessIDVersion(uint32(contracts.ChainID), processRegistry),
-		Contracts:        contracts,
-		TxManager:        txManager,
+		ChainID:            contracts.ChainID,
+		ShortName:          chainlist.ShortNameByChainID(contracts.ChainID),
+		ProcessIDVersion:   types.ProcessIDVersion(uint32(contracts.ChainID), processRegistry),
+		Contracts:          contracts,
+		TxManager:          txManager,
+		AvailableEndpoints: contracts.web3pool.NumberOfEndpoints(contracts.ChainID, true),
 	}, nil
 }
 

--- a/web3/runtime_test.go
+++ b/web3/runtime_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	qt "github.com/frankban/quicktest"
 	"github.com/vocdoni/davinci-node/types"
+	"github.com/vocdoni/davinci-node/web3/rpc"
 )
 
 func TestNewNetworkRuntime(t *testing.T) {
@@ -16,6 +17,7 @@ func TestNewNetworkRuntime(t *testing.T) {
 		ContractsAddresses: &Addresses{
 			ProcessRegistry: common.HexToAddress("0x015eac820688da203a0bd730a8a7a4cdb97e1a02"),
 		},
+		web3pool: rpc.NewWeb3Pool(),
 	}
 
 	runtime, err := NewNetworkRuntime(contracts, nil)
@@ -151,6 +153,7 @@ func testRuntime(c *qt.C, chainID uint64, processRegistry string) *NetworkRuntim
 		ContractsAddresses: &Addresses{
 			ProcessRegistry: common.HexToAddress(processRegistry),
 		},
+		web3pool: rpc.NewWeb3Pool(),
 	}
 	runtime, err := NewNetworkRuntime(contracts, nil)
 	c.Assert(err, qt.IsNil)

--- a/web3/web3_config.go
+++ b/web3/web3_config.go
@@ -1,0 +1,129 @@
+package web3
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/vocdoni/davinci-node/web3/rpc"
+	"github.com/vocdoni/davinci-node/web3/txmanager"
+)
+
+// Web3Config holds Ethereum-related configuration for the sequencer
+type Web3Config struct {
+	PrivKey                 string   `mapstructure:"privkey"`                 // Private key for the Ethereum account
+	ChainIDs                []uint   `mapstructure:"chainIDs"`                // Chain IDs to use, if defined, limits RPCs and BeaconAPIs, if empty, use all
+	RPCs                    []string `mapstructure:"rpc"`                     // Web3 RPC endpoints, can be multiple
+	BeaconAPIs              []string `mapstructure:"bapi"`                    // Web3 Consensus Beacon API endpoints, can be multiple
+	GasMultiplier           float64  `mapstructure:"gasMultiplier"`           // Gas price multiplier for transactions (default: 1.0)
+	ProcessRegistryContract string   `mapstructure:"processRegistryContract"` // Process registry smart contract reference (<chainID>:<address>)
+}
+
+func (web3Cfg Web3Config) InitRuntimes(ctx context.Context) ([]*NetworkRuntime, error) {
+	// Group RPC endpoints by chain ID
+	rpcsMap, err := rpc.GroupEndpointsByChainID(web3Cfg.RPCs)
+	if err != nil {
+		return nil, fmt.Errorf("resolve RPC endpoints: %w", err)
+	}
+	// Group beacon API endpoints by chain ID
+	beaconAPIsMap, err := rpc.GroupBeaconEndpointsByChainID(ctx, web3Cfg.BeaconAPIs)
+	if err != nil {
+		return nil, fmt.Errorf("resolve beacon API endpoints: %w", err)
+	}
+	// Check if any network is configured and RPCs should be limited
+	limitedNetworks := len(web3Cfg.ChainIDs) > 0
+	// Iterate over available networks to initialize web3 runtimes
+	var runtimes []*NetworkRuntime
+	for chainID, rpcs := range rpcsMap {
+		// Skip networks that are not configured, if any is configured
+		if limitedNetworks && !slices.Contains(web3Cfg.ChainIDs, uint(chainID)) {
+			continue
+		}
+		// Try to find a beacon API for this network
+		var beaconAPI string
+		if beaconAPIs, ok := beaconAPIsMap[chainID]; ok && len(beaconAPIs) > 0 {
+			beaconAPI = beaconAPIs[0]
+		}
+		// Try to initialize web3 runtime
+		addresses := web3Cfg.addressesByChainID(chainID)
+		runtime, err := initializeNetworkRuntime(ctx, addresses, rpcs, beaconAPI, web3Cfg.PrivKey, web3Cfg.GasMultiplier)
+		if err != nil {
+			return nil, fmt.Errorf("initialize web3 runtime for chain ID %d: %w", chainID, err)
+		}
+		runtimes = append(runtimes, runtime)
+	}
+	return runtimes, nil
+}
+
+// addressesByChainID returns the address of the process registry contract for
+// the given chain ID. By default, it returns nil, which means that the default
+// addresses should be used. If a process registry contract is specified in the
+// config, it will be used if the chain ID matches.
+func (web3Cfg Web3Config) addressesByChainID(chainID uint64) *Addresses {
+	// If no process registry contract is specified, return nil
+	if web3Cfg.ProcessRegistryContract == "" {
+		return nil
+	}
+	// Ensure that the contract definition is in the expected format:
+	//    <chainID>:<address>
+	parts := strings.Split(web3Cfg.ProcessRegistryContract, ":")
+	if len(parts) != 2 {
+		return nil
+	}
+	// Parse the chain ID from the contract prefix
+	parsedChainID, err := strconv.ParseUint(parts[0], 10, 64)
+	if err != nil || parsedChainID != chainID {
+		return nil
+	}
+	// Parse the address from the contract suffix
+	if addr := common.HexToAddress(parts[1]); addr != (common.Address{}) {
+		return &Addresses{ProcessRegistry: addr}
+	}
+	return nil
+}
+
+func initializeNetworkRuntime(
+	ctx context.Context,
+	addresses *Addresses,
+	rpcEndpoints []string,
+	beaconAPIEndpoint string,
+	privKey string,
+	gasMultiplier float64,
+) (*NetworkRuntime, error) {
+	// Load contracts for this network
+	contracts, err := New(rpcEndpoints, beaconAPIEndpoint, gasMultiplier)
+	if err != nil {
+		return nil, fmt.Errorf("initialize web3 client: %w", err)
+	}
+
+	if err := contracts.LoadContracts(addresses); err != nil {
+		return nil, fmt.Errorf("initialize contracts: %w", err)
+	}
+
+	if err := contracts.SetAccountPrivateKey(privKey); err != nil {
+		return nil, fmt.Errorf("set account private key: %w", err)
+	}
+
+	txManager, err := txmanager.New(
+		ctx,
+		contracts.Web3Pool(),
+		contracts.Client(),
+		contracts.Signer(),
+		txmanager.DefaultConfig(contracts.ChainID),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create transaction manager: %w", err)
+	}
+	txManager.Start(ctx)
+	contracts.SetTxManager(txManager)
+
+	runtime, err := NewNetworkRuntime(contracts, txManager)
+	if err != nil {
+		txManager.Stop()
+		return nil, fmt.Errorf("create runtime: %w", err)
+	}
+	return runtime, nil
+}

--- a/web3/web3_config.go
+++ b/web3/web3_config.go
@@ -73,6 +73,10 @@ func (web3Cfg Web3Config) addressesByChainID(chainID uint64) *Addresses {
 	if len(parts) != 2 {
 		return nil
 	}
+	// Ensure that both parts are not empty
+	if len(parts[0]) == 0 || len(parts[1]) == 0 {
+		return nil
+	}
 	// Parse the chain ID from the contract prefix
 	parsedChainID, err := strconv.ParseUint(parts[0], 10, 64)
 	if err != nil || parsedChainID != chainID {

--- a/web3/web3_config.go
+++ b/web3/web3_config.go
@@ -19,7 +19,7 @@ type Web3Config struct {
 	RPCs                    []string `mapstructure:"rpc"`                     // Web3 RPC endpoints, can be multiple
 	BeaconAPIs              []string `mapstructure:"bapi"`                    // Web3 Consensus Beacon API endpoints, can be multiple
 	GasMultiplier           float64  `mapstructure:"gasMultiplier"`           // Gas price multiplier for transactions (default: 1.0)
-	ProcessRegistryContract string   `mapstructure:"processRegistryContract"` // Process registry smart contract reference (<chainID>:<address>)
+	ProcessRegistryContract []string `mapstructure:"processRegistryContract"` // Process registry smart contract reference (<chainID>:<address>)
 }
 
 func (web3Cfg Web3Config) InitRuntimes(ctx context.Context) ([]*NetworkRuntime, error) {
@@ -64,27 +64,29 @@ func (web3Cfg Web3Config) InitRuntimes(ctx context.Context) ([]*NetworkRuntime, 
 // config, it will be used if the chain ID matches.
 func (web3Cfg Web3Config) addressesByChainID(chainID uint64) *Addresses {
 	// If no process registry contract is specified, return nil
-	if web3Cfg.ProcessRegistryContract == "" {
+	if len(web3Cfg.ProcessRegistryContract) == 0 {
 		return nil
 	}
-	// Ensure that the contract definition is in the expected format:
-	//    <chainID>:<address>
-	parts := strings.Split(web3Cfg.ProcessRegistryContract, ":")
-	if len(parts) != 2 {
-		return nil
-	}
-	// Ensure that both parts are not empty
-	if len(parts[0]) == 0 || len(parts[1]) == 0 {
-		return nil
-	}
-	// Parse the chain ID from the contract prefix
-	parsedChainID, err := strconv.ParseUint(parts[0], 10, 64)
-	if err != nil || parsedChainID != chainID {
-		return nil
-	}
-	// Parse the address from the contract suffix
-	if addr := common.HexToAddress(parts[1]); addr != (common.Address{}) {
-		return &Addresses{ProcessRegistry: addr}
+	for _, contract := range web3Cfg.ProcessRegistryContract {
+		// Ensure that the contract definition is in the expected format:
+		//    <chainID>:<address>
+		parts := strings.Split(contract, ":")
+		if len(parts) != 2 {
+			continue
+		}
+		// Ensure that both parts are not empty
+		if len(parts[0]) == 0 || len(parts[1]) == 0 {
+			continue
+		}
+		// Parse the chain ID from the contract prefix
+		parsedChainID, err := strconv.ParseUint(parts[0], 10, 64)
+		if err != nil || parsedChainID != chainID {
+			continue
+		}
+		// Parse the address from the contract suffix
+		if addr := common.HexToAddress(parts[1]); addr != (common.Address{}) {
+			return &Addresses{ProcessRegistry: addr}
+		}
 	}
 	return nil
 }

--- a/web3/web3_config_test.go
+++ b/web3/web3_config_test.go
@@ -1,0 +1,88 @@
+package web3
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	qt "github.com/frankban/quicktest"
+)
+
+func TestAddressesByChainID(t *testing.T) {
+	c := qt.New(t)
+
+	sepoliaAddr := common.HexToAddress("0x015eac820688da203a0bd730a8a7a4cdb97e1a02")
+	anvilAddr := common.HexToAddress("0xe7f1725e7734ce288f8367e1bb143e90bb3f0512")
+
+	tests := []struct {
+		desc       string
+		config     string
+		chainID    uint64
+		wantAddr   common.Address
+		wantResult bool // true if we expect a non-nil *Addresses result
+	}{
+		{
+			desc:       "empty config returns nil",
+			config:     "",
+			chainID:    11155111,
+			wantResult: false,
+		},
+		{
+			desc:       "valid chainID:address match",
+			config:     "11155111:0x015eac820688da203a0bd730a8a7a4cdb97e1a02",
+			chainID:    11155111,
+			wantAddr:   sepoliaAddr,
+			wantResult: true,
+		},
+		{
+			desc:       "valid chainID:address for anvil",
+			config:     "31337:0xe7f1725e7734ce288f8367e1bb143e90bb3f0512",
+			chainID:    31337,
+			wantAddr:   anvilAddr,
+			wantResult: true,
+		},
+		{
+			desc:       "chain ID mismatch returns nil",
+			config:     "11155111:0x015eac820688da203a0bd730a8a7a4cdb97e1a02",
+			chainID:    1,
+			wantResult: false,
+		},
+		{
+			desc:       "address only (no chainID prefix) returns nil",
+			config:     "0x015eac820688da203a0bd730a8a7a4cdb97e1a02",
+			chainID:    11155111,
+			wantResult: false,
+		},
+		{
+			desc:       "non-numeric chain ID returns nil",
+			config:     "sepolia:0x015eac820688da203a0bd730a8a7a4cdb97e1a02",
+			chainID:    11155111,
+			wantResult: false,
+		},
+		{
+			desc:       "zero address returns nil",
+			config:     "11155111:0x0000000000000000000000000000000000000000",
+			chainID:    11155111,
+			wantResult: false,
+		},
+		{
+			desc:       "empty address part returns nil",
+			config:     "11155111:",
+			chainID:    11155111,
+			wantResult: false,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.desc, func(c *qt.C) {
+			cfg := Web3Config{ProcessRegistryContract: tt.config}
+			result := cfg.addressesByChainID(tt.chainID)
+
+			if !tt.wantResult {
+				c.Assert(result, qt.IsNil)
+				return
+			}
+			c.Assert(result, qt.Not(qt.IsNil))
+			c.Assert(result.ProcessRegistry, qt.DeepEquals, tt.wantAddr)
+		})
+	}
+}

--- a/web3/web3_config_test.go
+++ b/web3/web3_config_test.go
@@ -12,69 +12,132 @@ func TestAddressesByChainID(t *testing.T) {
 
 	sepoliaAddr := common.HexToAddress("0x015eac820688da203a0bd730a8a7a4cdb97e1a02")
 	anvilAddr := common.HexToAddress("0xe7f1725e7734ce288f8367e1bb143e90bb3f0512")
+	mainnetAddr := common.HexToAddress("0x9b7c0b5e1240373c2d8a1f3b7e0b2d8d4a6f3c2e")
 
 	tests := []struct {
 		desc       string
-		config     string
+		contracts  []string // ProcessRegistryContract entries
 		chainID    uint64
 		wantAddr   common.Address
 		wantResult bool // true if we expect a non-nil *Addresses result
 	}{
 		{
 			desc:       "empty config returns nil",
-			config:     "",
+			contracts:  nil,
 			chainID:    11155111,
 			wantResult: false,
 		},
 		{
-			desc:       "valid chainID:address match",
-			config:     "11155111:0x015eac820688da203a0bd730a8a7a4cdb97e1a02",
+			desc:       "single valid match",
+			contracts:  []string{"11155111:0x015eac820688da203a0bd730a8a7a4cdb97e1a02"},
 			chainID:    11155111,
 			wantAddr:   sepoliaAddr,
 			wantResult: true,
 		},
 		{
-			desc:       "valid chainID:address for anvil",
-			config:     "31337:0xe7f1725e7734ce288f8367e1bb143e90bb3f0512",
+			desc:       "single valid match for anvil",
+			contracts:  []string{"31337:0xe7f1725e7734ce288f8367e1bb143e90bb3f0512"},
 			chainID:    31337,
 			wantAddr:   anvilAddr,
 			wantResult: true,
 		},
 		{
 			desc:       "chain ID mismatch returns nil",
-			config:     "11155111:0x015eac820688da203a0bd730a8a7a4cdb97e1a02",
+			contracts:  []string{"11155111:0x015eac820688da203a0bd730a8a7a4cdb97e1a02"},
 			chainID:    1,
 			wantResult: false,
 		},
 		{
-			desc:       "address only (no chainID prefix) returns nil",
-			config:     "0x015eac820688da203a0bd730a8a7a4cdb97e1a02",
+			desc:       "address only (no chainID prefix) skips entry",
+			contracts:  []string{"0x015eac820688da203a0bd730a8a7a4cdb97e1a02"},
 			chainID:    11155111,
 			wantResult: false,
 		},
 		{
-			desc:       "non-numeric chain ID returns nil",
-			config:     "sepolia:0x015eac820688da203a0bd730a8a7a4cdb97e1a02",
+			desc:       "non-numeric chain ID skips entry",
+			contracts:  []string{"sepolia:0x015eac820688da203a0bd730a8a7a4cdb97e1a02"},
 			chainID:    11155111,
 			wantResult: false,
 		},
 		{
-			desc:       "zero address returns nil",
-			config:     "11155111:0x0000000000000000000000000000000000000000",
+			desc:       "zero address skips entry",
+			contracts:  []string{"11155111:0x0000000000000000000000000000000000000000"},
 			chainID:    11155111,
 			wantResult: false,
 		},
 		{
-			desc:       "empty address part returns nil",
-			config:     "11155111:",
+			desc:       "empty address part skips entry",
+			contracts:  []string{"11155111:"},
 			chainID:    11155111,
 			wantResult: false,
+		},
+		{
+			desc: "multiple entries, first matching returns",
+			contracts: []string{
+				"11155111:0x015eac820688da203a0bd730a8a7a4cdb97e1a02",
+				"42220:0x68dac70af68aa0bed8cef36c523243941d7d7876",
+			},
+			chainID:    11155111,
+			wantAddr:   sepoliaAddr,
+			wantResult: true,
+		},
+		{
+			desc: "multiple entries, later entry matches",
+			contracts: []string{
+				"1:0x9b7c0b5e1240373c2d8a1f3b7e0b2d8d4a6f3c2e",
+				"11155111:0x015eac820688da203a0bd730a8a7a4cdb97e1a02",
+			},
+			chainID:    11155111,
+			wantAddr:   sepoliaAddr,
+			wantResult: true,
+		},
+		{
+			desc: "multiple entries, none match returns nil",
+			contracts: []string{
+				"42220:0x68dac70af68aa0bed8cef36c523243941d7d7876",
+				"1:0x9b7c0b5e1240373c2d8a1f3b7e0b2d8d4a6f3c2e",
+			},
+			chainID:    11155111,
+			wantResult: false,
+		},
+		{
+			desc: "invalid entries skipped, valid later entry matches",
+			contracts: []string{
+				"bad",
+				":",
+				"11155111:",
+				"11155111:0x0000000000000000000000000000000000000000",
+				"11155111:0x015eac820688da203a0bd730a8a7a4cdb97e1a02",
+			},
+			chainID:    11155111,
+			wantAddr:   sepoliaAddr,
+			wantResult: true,
+		},
+		{
+			desc: "all entries invalid returns nil",
+			contracts: []string{
+				"bad",
+				"nope:0x015eac820688da203a0bd730a8a7a4cdb97e1a02",
+				"11155111:",
+			},
+			chainID:    11155111,
+			wantResult: false,
+		},
+		{
+			desc: "matching entry with mainnet address",
+			contracts: []string{
+				"11155111:0x015eac820688da203a0bd730a8a7a4cdb97e1a02",
+				"1:0x9b7c0b5e1240373c2d8a1f3b7e0b2d8d4a6f3c2e",
+			},
+			chainID:    1,
+			wantAddr:   mainnetAddr,
+			wantResult: true,
 		},
 	}
 
 	for _, tt := range tests {
 		c.Run(tt.desc, func(c *qt.C) {
-			cfg := Web3Config{ProcessRegistryContract: tt.config}
+			cfg := Web3Config{ProcessRegistryContract: tt.contracts}
 			result := cfg.addressesByChainID(tt.chainID)
 
 			if !tt.wantResult {


### PR DESCRIPTION
- web3 config moved to web3 package 
- new methods to check if a process registry config is defined and should be used
- tests for new methods