### PR TITLE
Fix #441: StateTransition is stuck because of a single "address not found in census"

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(go build *)",
+      "Bash(go vet *)",
+      "Bash(golangci-lint run *)",
+      "Bash(git add *)",
+      "Bash(git commit *)",
+      "Bash(git log *)",
+      "Bash(git diff *)",
+      "Bash(git status)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ letsencrypt
 .worktrees
 go.work
 go.work.sum
+davinci-sequencer

--- a/census/graphql.go
+++ b/census/graphql.go
@@ -248,7 +248,7 @@ func queryEvents(
 			if err != nil {
 				return nil, fmt.Errorf("error creating request: %v", err)
 			}
-			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set(contentTypeHeader, "application/json")
 			res, err := client.Do(req)
 			if err != nil {
 				return nil, fmt.Errorf("error executing request: %v", err)

--- a/census/importer_test.go
+++ b/census/importer_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/vocdoni/davinci-node/types"
 )
 
+const testCensusURI = "https://example.invalid/dump"
+
 func testNewCensusDB(c *qt.C) *censusdb.CensusDB {
 	c.Helper()
 	internalDB, err := metadb.New(db.TypeInMem, "")
@@ -73,7 +75,7 @@ func TestCensusImporter(t *testing.T) {
 			importer := NewCensusImporter(nil)
 			_, err := importer.ImportCensus(c.Context(), 0, &types.Census{
 				CensusOrigin: types.CensusOriginUnknown,
-				CensusURI:    "https://example.invalid/dump",
+				CensusURI:    testCensusURI,
 				CensusRoot:   types.HexBytes{0x01},
 			}, 0)
 			c.Assert(err, qt.Not(qt.IsNil))
@@ -104,13 +106,13 @@ func TestCensusImporter(t *testing.T) {
 				validFn: func(string) bool { return false },
 			}
 			plugin2 := &testImporterPlugin{
-				validFn: func(uri string) bool { return uri == "https://example.invalid/dump" },
+				validFn: func(uri string) bool { return uri == testCensusURI },
 			}
 
 			importer := NewCensusImporter(stg, plugin1, plugin2)
 			census := &types.Census{
 				CensusOrigin: types.CensusOriginMerkleTreeOffchainStaticV1,
-				CensusURI:    "https://example.invalid/dump",
+				CensusURI:    testCensusURI,
 				CensusRoot:   types.HexBytes{0xaa, 0xbb},
 			}
 
@@ -136,7 +138,7 @@ func TestCensusImporter(t *testing.T) {
 			importer := NewCensusImporter(stg, plugin)
 			_, err := importer.ImportCensus(c.Context(), 0, &types.Census{
 				CensusOrigin: types.CensusOriginMerkleTreeOffchainDynamicV1,
-				CensusURI:    "https://example.invalid/dump",
+				CensusURI:    testCensusURI,
 				CensusRoot:   types.HexBytes{0x01},
 			}, 0)
 			c.Assert(err, qt.ErrorIs, sentinelErr)
@@ -150,7 +152,7 @@ func TestCensusImporter(t *testing.T) {
 			importer := NewCensusImporter(stg, plugin)
 			_, err := importer.ImportCensus(c.Context(), 0, &types.Census{
 				CensusOrigin: types.CensusOriginMerkleTreeOffchainStaticV1,
-				CensusURI:    "https://example.invalid/dump",
+				CensusURI:    testCensusURI,
 				CensusRoot:   types.HexBytes{0x01},
 			}, 0)
 			c.Assert(err, qt.Not(qt.IsNil))

--- a/census/json.go
+++ b/census/json.go
@@ -29,6 +29,8 @@ const (
 	UnknownJSON
 )
 
+const contentTypeHeader = "Content-Type"
+
 // String returns the string representation of the JSONFormat.
 func (format JSONFormat) String() string {
 	switch format {
@@ -127,7 +129,7 @@ func requestRawDump(ctx context.Context, targetURL string) (*http.Response, erro
 // cannot be determined, it returns UnknownJSON.
 func jsonReader(res *http.Response) (io.Reader, JSONFormat, error) {
 	// Check Content-Type header first
-	contentType := strings.ToLower(res.Header.Get("Content-Type"))
+	contentType := strings.ToLower(res.Header.Get(contentTypeHeader))
 
 	if strings.Contains(contentType, "ndjson") || strings.Contains(contentType, "jsonl") {
 		return res.Body, JSONL, nil

--- a/census/json_test.go
+++ b/census/json_test.go
@@ -18,6 +18,11 @@ import (
 	leancensus "github.com/vocdoni/lean-imt-go/census"
 )
 
+const (
+	testCensusURI2        = "https://example.invalid/dump"
+	testContentTypeNDJSON = "application/x-ndjson"
+)
+
 type testErrReader struct {
 	err error
 }
@@ -125,7 +130,7 @@ func TestRequestRawDump(t *testing.T) {
 			c.Assert(r.Header.Get("Accept"), qt.Equals, "application/x-ndjson, application/json;q=0.9, */*;q=0.1")
 			return &http.Response{
 				StatusCode: http.StatusOK,
-				Header:     http.Header{"Content-Type": []string{"application/x-ndjson"}},
+				Header:     http.Header{contentTypeHeader: []string{testContentTypeNDJSON}},
 				Body:       io.NopCloser(strings.NewReader(`{"ok":true}` + "\n")),
 				Request:    r,
 			}, nil
@@ -192,7 +197,7 @@ func TestJSONReader(t *testing.T) {
 	c.Run("ContentTypeJSONL", func(c *qt.C) {
 		const body = `{"a":1}` + "\n"
 		res := &http.Response{
-			Header: http.Header{"Content-Type": []string{"application/x-ndjson"}},
+			Header: http.Header{contentTypeHeader: []string{testContentTypeNDJSON}},
 			Body:   io.NopCloser(strings.NewReader(body)),
 		}
 
@@ -208,7 +213,7 @@ func TestJSONReader(t *testing.T) {
 	c.Run("ContentTypeJSONArray", func(c *qt.C) {
 		const body = `[{"a":1}]`
 		res := &http.Response{
-			Header: http.Header{"Content-Type": []string{"application/json; charset=utf-8"}},
+			Header: http.Header{contentTypeHeader: []string{"application/json; charset=utf-8"}},
 			Body:   io.NopCloser(strings.NewReader(body)),
 		}
 
@@ -352,7 +357,7 @@ func TestJSONDownloadAndImportCensus(t *testing.T) {
 		http.DefaultTransport = roundTripperFunc(func(r *http.Request) (*http.Response, error) {
 			return &http.Response{
 				StatusCode: http.StatusOK,
-				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Header:     http.Header{contentTypeHeader: []string{"application/json"}},
 				Body: &testReadCloser{
 					Reader:   bytes.NewReader(dumpJSON),
 					closeErr: fmt.Errorf("close error"),
@@ -382,7 +387,7 @@ func TestJSONDownloadAndImportCensus(t *testing.T) {
 		c.Cleanup(func() { http.DefaultTransport = oldTransport })
 
 		_, err := ji.ImportCensus(c.Context(), censusDB, 0, &types.Census{
-			CensusURI:  "https://example.invalid/dump",
+			CensusURI:  testCensusURI2,
 			CensusRoot: expectedRoot,
 		}, 0)
 		c.Assert(err, qt.Not(qt.IsNil))
@@ -402,7 +407,7 @@ func TestJSONDownloadAndImportCensus(t *testing.T) {
 		c.Cleanup(func() { http.DefaultTransport = oldTransport })
 
 		_, err := ji.ImportCensus(c.Context(), censusDB, 0, &types.Census{
-			CensusURI:  "https://example.invalid/dump",
+			CensusURI:  testCensusURI2,
 			CensusRoot: expectedRoot,
 		}, 0)
 		c.Assert(err, qt.Not(qt.IsNil))
@@ -414,7 +419,7 @@ func TestJSONDownloadAndImportCensus(t *testing.T) {
 		http.DefaultTransport = roundTripperFunc(func(r *http.Request) (*http.Response, error) {
 			return &http.Response{
 				StatusCode: http.StatusOK,
-				Header:     http.Header{"Content-Type": []string{"application/x-ndjson"}},
+				Header:     http.Header{contentTypeHeader: []string{testContentTypeNDJSON}},
 				Body:       io.NopCloser(strings.NewReader("not json\n")),
 				Request:    r,
 			}, nil
@@ -435,7 +440,7 @@ func TestJSONDownloadAndImportCensus(t *testing.T) {
 		http.DefaultTransport = roundTripperFunc(func(r *http.Request) (*http.Response, error) {
 			return &http.Response{
 				StatusCode: http.StatusOK,
-				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Header:     http.Header{contentTypeHeader: []string{"application/json"}},
 				Body:       io.NopCloser(bytes.NewReader(dumpJSON)),
 				Request:    r,
 			}, nil

--- a/census/test/graphql.go
+++ b/census/test/graphql.go
@@ -13,11 +13,16 @@ import (
 	"github.com/vocdoni/davinci-node/types"
 )
 
+const (
+	testAccountID1 = "0xdeb8699659be5d41a0e57e179d6cb42e00b9200c"
+	testAccountID2 = "0xb1f05b11ba3d892edd00f2e7689779e2b8841827"
+)
+
 var (
 	DefaultExpectedRoot  = types.HexStringToHexBytesMustUnmarshal("0x0b3600e19a4f5017dea4f91f03d8aa0dd6f4c797795e7a5aa542e81b2c5a9485")
 	DefaultGraphQLEvents = []TestWeightChangeEvent{
 		{
-			AccountID:      "0xdeb8699659be5d41a0e57e179d6cb42e00b9200c",
+			AccountID:      testAccountID1,
 			PreviousWeight: "0",
 			NewWeight:      "1",
 		},
@@ -27,7 +32,7 @@ var (
 			NewWeight:      "1",
 		},
 		{
-			AccountID:      "0xb1f05b11ba3d892edd00f2e7689779e2b8841827",
+			AccountID:      testAccountID2,
 			PreviousWeight: "0",
 			NewWeight:      "1",
 		},
@@ -47,12 +52,12 @@ var (
 			NewWeight:      "0",
 		},
 		{
-			AccountID:      "0xdeb8699659be5d41a0e57e179d6cb42e00b9200c",
+			AccountID:      testAccountID1,
 			PreviousWeight: "1",
 			NewWeight:      "0",
 		},
 		{
-			AccountID:      "0xb1f05b11ba3d892edd00f2e7689779e2b8841827",
+			AccountID:      testAccountID2,
 			PreviousWeight: "1",
 			NewWeight:      "2",
 		},
@@ -62,12 +67,12 @@ var (
 			NewWeight:      "1",
 		},
 		{
-			AccountID:      "0xb1f05b11ba3d892edd00f2e7689779e2b8841827",
+			AccountID:      testAccountID2,
 			PreviousWeight: "2",
 			NewWeight:      "1",
 		},
 		{
-			AccountID:      "0xdeb8699659be5d41a0e57e179d6cb42e00b9200c",
+			AccountID:      testAccountID1,
 			PreviousWeight: "0",
 			NewWeight:      "1",
 		},

--- a/circuits/test/statetransition/statetransition_test.go
+++ b/circuits/test/statetransition/statetransition_test.go
@@ -37,11 +37,14 @@ import (
 	"github.com/vocdoni/davinci-node/util"
 )
 
-const falseString = "false"
+const (
+	falseString    = "false"
+	testTimeFormat = "15:04:05"
+)
 
 func TestMain(m *testing.M) {
 	// enable log to see nbConstraints
-	logger.Set(zerolog.New(zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: "15:04:05"}).With().Timestamp().Logger())
+	logger.Set(zerolog.New(zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: testTimeFormat}).With().Timestamp().Logger())
 	m.Run()
 }
 
@@ -50,7 +53,7 @@ func testCircuitCompile(t *testing.T, c frontend.Circuit) {
 		t.Skip("skipping circuit tests...")
 	}
 	// enable log to see nbConstraints
-	logger.Set(zerolog.New(zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: "15:04:05"}).With().Timestamp().Logger())
+	logger.Set(zerolog.New(zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: testTimeFormat}).With().Timestamp().Logger())
 	if _, err := frontend.Compile(params.StateTransitionCurve.ScalarField(), r1cs.NewBuilder, c); err != nil {
 		panic(err)
 	}
@@ -69,7 +72,7 @@ func testCircuitProve(t *testing.T, circuit, assignment frontend.Circuit) {
 }
 
 func TestStateTransitionCircuit(t *testing.T) {
-	logger.Set(zerolog.New(zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: "15:04:05"}).With().Timestamp().Logger())
+	logger.Set(zerolog.New(zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: testTimeFormat}).With().Timestamp().Logger())
 	if os.Getenv("RUN_CIRCUIT_TESTS") == "" || os.Getenv("RUN_CIRCUIT_TESTS") == falseString {
 		t.Skip("skipping circuit tests...")
 	}
@@ -87,7 +90,7 @@ func TestStateTransitionCircuit(t *testing.T) {
 }
 
 func TestStateTransitionFullProvingCircuit(t *testing.T) {
-	logger.Set(zerolog.New(zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: "15:04:05"}).With().Timestamp().Logger())
+	logger.Set(zerolog.New(zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: testTimeFormat}).With().Timestamp().Logger())
 	if os.Getenv("RUN_CIRCUIT_TESTS") == "" || os.Getenv("RUN_CIRCUIT_TESTS") == falseString {
 		t.Skip("skipping circuit tests...")
 	}

--- a/circuits/test/voteverifier/vote_verifier_test.go
+++ b/circuits/test/voteverifier/vote_verifier_test.go
@@ -21,8 +21,10 @@ import (
 	"github.com/vocdoni/davinci-node/types"
 )
 
+const testTimeFormat = "15:04:05"
+
 func TestVerifyMerkletreeVoteCircuit(t *testing.T) {
-	logger.Set(zerolog.New(zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: "15:04:05"}).With().Timestamp().Logger())
+	logger.Set(zerolog.New(zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: testTimeFormat}).With().Timestamp().Logger())
 	c := qt.New(t)
 	// Generate a deterministic voter account for reproducible test data.
 	s, err := ballottest.GenDeterministicECDSAaccountForTest(0)
@@ -45,7 +47,7 @@ func TestVerifyMerkletreeVoteCircuit(t *testing.T) {
 }
 
 func TestVerifyCSPVoteCircuit(t *testing.T) {
-	logger.Set(zerolog.New(zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: "15:04:05"}).With().Timestamp().Logger())
+	logger.Set(zerolog.New(zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: testTimeFormat}).With().Timestamp().Logger())
 	c := qt.New(t)
 	// Generate a deterministic voter account for reproducible test data.
 	s, err := ballottest.GenDeterministicECDSAaccountForTest(0)
@@ -81,7 +83,7 @@ func TestVerifyNoValidVoteCircuit(t *testing.T) {
 }
 
 func TestVerifyMultipleVotesCircuit(t *testing.T) {
-	logger.Set(zerolog.New(zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: "15:04:05"}).With().Timestamp().Logger())
+	logger.Set(zerolog.New(zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: testTimeFormat}).With().Timestamp().Logger())
 	if os.Getenv("RUN_CIRCUIT_TESTS") == "" || os.Getenv("RUN_CIRCUIT_TESTS") == "false" {
 		t.Skip("skipping circuit tests...")
 	}
@@ -109,7 +111,7 @@ func TestCompileAndPrintConstraints(t *testing.T) {
 	if os.Getenv("RUN_CIRCUIT_TESTS") == "" || os.Getenv("RUN_CIRCUIT_TESTS") == "false" {
 		t.Skip("skipping circuit tests...")
 	}
-	logger.Set(zerolog.New(zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: "15:04:05"}).With().Timestamp().Logger())
+	logger.Set(zerolog.New(zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: testTimeFormat}).With().Timestamp().Logger())
 	c := qt.New(t)
 	// generate vote verifier circuit and inputs with deterministic ProcessID
 	vvPlaceholder, err := voteverifier.DummyPlaceholder()

--- a/db/mongodb/mongodb.go
+++ b/db/mongodb/mongodb.go
@@ -24,6 +24,8 @@ const (
 	MongodbTimeoutCommit = 12 * time.Second
 	// MongodbTimeoutQuery is the timeout for querying the database
 	MongodbTimeoutQuery = 4 * time.Second
+	// mongoIDField is the MongoDB field name for the document ID
+	mongoIDField = "_id"
 )
 
 // MongoDB is a MongoDB implementation of the db.DB interface
@@ -110,7 +112,7 @@ func (tx *WriteTx) Get(k []byte) ([]byte, error) {
 	}
 	collection := tx.db.Collection(tx.collection)
 
-	filter := bson.M{"_id": string(k)} // Convert to string
+	filter := bson.M{mongoIDField: string(k)} // Convert to string
 	var result KeyVal
 	ctx, cancel := context.WithTimeout(context.Background(), MongodbTimeoutQuery)
 	defer cancel()
@@ -137,7 +139,7 @@ func (tx *WriteTx) Iterate(prefix []byte, callback func(key, value []byte) bool)
 	filter := bson.M{}
 	if len(prefix) > 0 {
 		filter = bson.M{
-			"_id": bson.M{
+			mongoIDField: bson.M{
 				"$regex": primitive.Regex{
 					Pattern: "^" + string(prefix),
 				},
@@ -182,7 +184,7 @@ func (tx *WriteTx) Set(k, v []byte) error {
 	model := mongo.NewUpdateOneModel().SetFilter(
 		bson.D{
 			primitive.E{
-				Key:   "_id",
+				Key:   mongoIDField,
 				Value: string(k),
 			},
 		},
@@ -194,7 +196,7 @@ func (tx *WriteTx) Set(k, v []byte) error {
 }
 
 func (tx *WriteTx) Delete(k []byte) error {
-	model := mongo.NewDeleteOneModel().SetFilter(bson.M{"_id": string(k)}) // Convert to string
+	model := mongo.NewDeleteOneModel().SetFilter(bson.M{mongoIDField: string(k)}) // Convert to string
 	tx.batch = append(tx.batch, model)
 	delete(tx.inMem, string(k))
 	return nil

--- a/metadata/pinata_test.go
+++ b/metadata/pinata_test.go
@@ -14,6 +14,13 @@ import (
 	"github.com/vocdoni/davinci-node/types"
 )
 
+const (
+	testGatewayURL = "gateway.example"
+	testJWT        = "jwt"
+	testToken      = "token"
+	testStatusOK   = "200 OK"
+)
+
 type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -40,7 +47,7 @@ func newTestPinataProvider() *PinataMetadataProvider {
 	return NewPinataMetadataProvider(PinataMetadataProviderConfig{
 		HostnameURL:  "https://pinata.example/upload",
 		HostnameJWT:  "jwt-token",
-		GatewayURL:   "gateway.example",
+		GatewayURL:   testGatewayURL,
 		GatewayToken: "gateway-token",
 	})
 }
@@ -57,42 +64,42 @@ func TestPinataMetadataProviderConfigValid(t *testing.T) {
 			name: "valid with all fields",
 			config: PinataMetadataProviderConfig{
 				HostnameURL:  "https://pinata.example/upload",
-				HostnameJWT:  "jwt",
-				GatewayURL:   "gateway.example",
-				GatewayToken: "token",
+				HostnameJWT:  testJWT,
+				GatewayURL:   testGatewayURL,
+				GatewayToken: testToken,
 			},
 			valid: true,
 		},
 		{
 			name: "missing jwt",
 			config: PinataMetadataProviderConfig{
-				GatewayURL:   "gateway.example",
-				GatewayToken: "token",
+				GatewayURL:   testGatewayURL,
+				GatewayToken: testToken,
 			},
 			valid: false,
 		},
 		{
 			name: "missing gateway url",
 			config: PinataMetadataProviderConfig{
-				HostnameJWT:  "jwt",
-				GatewayToken: "token",
+				HostnameJWT:  testJWT,
+				GatewayToken: testToken,
 			},
 			valid: false,
 		},
 		{
 			name: "missing gateway token",
 			config: PinataMetadataProviderConfig{
-				HostnameJWT: "jwt",
-				GatewayURL:  "gateway.example",
+				HostnameJWT: testJWT,
+				GatewayURL:  testGatewayURL,
 			},
 			valid: false,
 		},
 		{
 			name: "missing hostname url",
 			config: PinataMetadataProviderConfig{
-				HostnameJWT:  "jwt",
-				GatewayURL:   "gateway.example",
-				GatewayToken: "token",
+				HostnameJWT:  testJWT,
+				GatewayURL:   testGatewayURL,
+				GatewayToken: testToken,
 			},
 			valid: false,
 		},
@@ -150,7 +157,7 @@ func TestPinataMetadataProviderSetMetadata(t *testing.T) {
 			respBody := fmt.Sprintf(`{"data":{"cid":"%s"}}`, mustCIDString(c, key))
 			return &http.Response{
 				StatusCode: http.StatusOK,
-				Status:     "200 OK",
+				Status:     testStatusOK,
 				Body:       io.NopCloser(strings.NewReader(respBody)),
 			}, nil
 		})
@@ -171,7 +178,7 @@ func TestPinataMetadataProviderSetMetadata(t *testing.T) {
 		provider := NewPinataMetadataProvider(PinataMetadataProviderConfig{
 			HostnameURL:  server.URL,
 			HostnameJWT:  "default-client-jwt",
-			GatewayURL:   "gateway.example",
+			GatewayURL:   testGatewayURL,
 			GatewayToken: "gateway-token",
 		})
 
@@ -204,7 +211,7 @@ func TestPinataMetadataProviderSetMetadata(t *testing.T) {
 		provider.httpClient = newTestHTTPClient(func(*http.Request) (*http.Response, error) {
 			return &http.Response{
 				StatusCode: http.StatusOK,
-				Status:     "200 OK",
+				Status:     testStatusOK,
 				Body:       errReadCloser{err: expectedErr},
 			}, nil
 		})
@@ -236,7 +243,7 @@ func TestPinataMetadataProviderSetMetadata(t *testing.T) {
 		provider.httpClient = newTestHTTPClient(func(*http.Request) (*http.Response, error) {
 			return &http.Response{
 				StatusCode: http.StatusOK,
-				Status:     "200 OK",
+				Status:     testStatusOK,
 				Body:       io.NopCloser(strings.NewReader("not-json")),
 			}, nil
 		})
@@ -254,7 +261,7 @@ func TestPinataMetadataProviderSetMetadata(t *testing.T) {
 		provider.httpClient = newTestHTTPClient(func(*http.Request) (*http.Response, error) {
 			return &http.Response{
 				StatusCode: http.StatusOK,
-				Status:     "200 OK",
+				Status:     testStatusOK,
 				Body:       io.NopCloser(strings.NewReader(respBody)),
 			}, nil
 		})
@@ -286,7 +293,7 @@ func TestPinataMetadataProviderMetadata(t *testing.T) {
 			c.Assert(err, qt.IsNil)
 			return &http.Response{
 				StatusCode: http.StatusOK,
-				Status:     "200 OK",
+				Status:     testStatusOK,
 				Body:       io.NopCloser(strings.NewReader(string(body))),
 			}, nil
 		})
@@ -323,7 +330,7 @@ func TestPinataMetadataProviderMetadata(t *testing.T) {
 		provider.httpClient = newTestHTTPClient(func(*http.Request) (*http.Response, error) {
 			return &http.Response{
 				StatusCode: http.StatusOK,
-				Status:     "200 OK",
+				Status:     testStatusOK,
 				Body:       errReadCloser{err: expectedErr},
 			}, nil
 		})
@@ -357,7 +364,7 @@ func TestPinataMetadataProviderMetadata(t *testing.T) {
 		provider.httpClient = newTestHTTPClient(func(*http.Request) (*http.Response, error) {
 			return &http.Response{
 				StatusCode: http.StatusOK,
-				Status:     "200 OK",
+				Status:     testStatusOK,
 				Body:       io.NopCloser(strings.NewReader("not-json")),
 			}, nil
 		})

--- a/sequencer/aggregate.go
+++ b/sequencer/aggregate.go
@@ -11,6 +11,7 @@ import (
 	"github.com/consensys/gnark/std/algebra/native/sw_bls12377"
 	"github.com/consensys/gnark/std/math/emulated"
 	stdgroth16 "github.com/consensys/gnark/std/recursion/groth16"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/vocdoni/davinci-node/circuits/aggregator"
 	"github.com/vocdoni/davinci-node/circuits/voteverifier"
 	"github.com/vocdoni/davinci-node/log"
@@ -43,6 +44,7 @@ func collectAggregationBatchInputs(
 	maxVotersReached bool,
 	proofToRecursion proofToRecursionFn,
 	verifyVoteVerifierProof voteVerifierProofValidatorFn,
+	checkCensusMembership func(b *storage.VerifiedBallot) bool,
 ) (*aggregator.AggregatorInputs, error) {
 	// Prepare data structures for the aggregator circuit
 	proofs := [params.VotesPerBatch]stdgroth16.Proof[sw_bls12377.G1Affine, sw_bls12377.G2Affine]{}
@@ -278,6 +280,31 @@ func collectAggregationBatchInputs(
 				}
 				continue
 			}
+		}
+
+		if checkCensusMembership != nil && !checkCensusMembership(b) {
+			log.Warnw("skipping ballot: address not found in census tree at aggregation time",
+				"processID", processID.String(),
+				"voteID", b.VoteID.String(),
+				"address", types.HexBytes(b.Address.Bytes()),
+			)
+			if err := stg.MarkVerifiedBallotsFailed(keys[i]); err != nil {
+				log.Warnw("failed to mark census-absent ballot as failed",
+					"error", err.Error(),
+					"processID", processID.String(),
+					"voteID", b.VoteID.String(),
+					"address", types.HexBytes(b.Address.Bytes()),
+				)
+				if err := stg.ReleaseVerifiedBallotReservations([][]byte{keys[i]}); err != nil {
+					log.Warnw("failed to release ballot reservation after census-absent failure marking",
+						"error", err.Error(),
+						"processID", processID.String(),
+						"voteID", b.VoteID.String(),
+						"address", types.HexBytes(b.Address.Bytes()),
+					)
+				}
+			}
+			continue
 		}
 
 		batchIdx := len(aggBallots)
@@ -518,6 +545,33 @@ func (s *Sequencer) aggregateBatch(processID types.ProcessID) error {
 		return s.voteVerifier.Verify(vb.Proof, pubAssignment)
 	}
 
+	// Build a census membership checker for merkle-tree censuses so that
+	// any address absent from the census is filtered out before the
+	// aggregator proof is generated. Filtering after proof generation would
+	// invalidate the BatchHash public input of the aggregator circuit.
+	// For CSP censuses no local tree is available, so the check is skipped.
+	var checkCensusMembership func(*storage.VerifiedBallot) bool
+	if proc, pErr := s.stg.Process(processID); pErr == nil && proc.Census.CensusOrigin.IsMerkleTree() {
+		var chainID uint64
+		if proc.Census.CensusOrigin == types.CensusOriginMerkleTreeOnchainDynamicV1 {
+			if contracts, cErr := s.contractsForProcess(processID); cErr == nil {
+				chainID = contracts.ChainID
+			}
+		}
+		if censusRef, cErr := s.stg.LoadCensus(chainID, proc.Census); cErr == nil {
+			censusTree := censusRef.Tree()
+			checkCensusMembership = func(b *storage.VerifiedBallot) bool {
+				_, ok := censusTree.GetWeight(common.BigToAddress(b.Address))
+				return ok
+			}
+		} else {
+			log.Warnw("could not load census for pre-aggregation check; census filter skipped",
+				"processID", processID.String(),
+				"error", cErr.Error(),
+			)
+		}
+	}
+
 	batchInputs, err := collectAggregationBatchInputs(
 		s.stg,
 		processID,
@@ -527,6 +581,7 @@ func (s *Sequencer) aggregateBatch(processID types.ProcessID) error {
 		maxVotersReached,
 		proofToRecursion,
 		verifyVoteVerifierProof,
+		checkCensusMembership,
 	)
 	if err != nil {
 		return err

--- a/sequencer/aggregate.go
+++ b/sequencer/aggregate.go
@@ -483,7 +483,7 @@ func (s *Sequencer) aggregateBatch(processID types.ProcessID) error {
 
 	// Ensure the process is accepting votes
 	if isAcceptingVotes, err := s.stg.ProcessIsAcceptingVotes(processID); err != nil {
-		return fmt.Errorf("failed to check if process is accepting votes: %w", err)
+		return fmt.Errorf(errCheckProcessAcceptingVotes, err)
 	} else if !isAcceptingVotes {
 		return fmt.Errorf("process '%s' is not accepting votes", processID.String())
 	}

--- a/sequencer/aggregate_inputs_test.go
+++ b/sequencer/aggregate_inputs_test.go
@@ -75,7 +75,7 @@ func TestCollectAggregationBatchInputs_SkipsDontCreateHoles(t *testing.T) {
 		return stdgroth16.Proof[sw_bls12377.G1Affine, sw_bls12377.G2Affine]{}, nil
 	}
 
-	inputs, err := collectAggregationBatchInputs(stg, processID, ballots, keys, processState, false, proofToRecursion, nil)
+	inputs, err := collectAggregationBatchInputs(stg, processID, ballots, keys, processState, false, proofToRecursion, nil, nil)
 	c.Assert(err, qt.IsNil)
 
 	c.Assert(len(inputs.AggBallots), qt.Equals, params.VotesPerBatch)

--- a/sequencer/ballot.go
+++ b/sequencer/ballot.go
@@ -148,7 +148,7 @@ func (s *Sequencer) processBallot(b *storage.Ballot) (*storage.VerifiedBallot, e
 
 	// Ensure the process is accepting votes
 	if isAcceptingVotes, err := s.stg.ProcessIsAcceptingVotes(b.ProcessID); err != nil {
-		return nil, fmt.Errorf("failed to check if process is accepting votes: %w", err)
+		return nil, fmt.Errorf(errCheckProcessAcceptingVotes, err)
 	} else if !isAcceptingVotes {
 		return nil, fmt.Errorf("process is not accepting votes")
 	}

--- a/sequencer/helpers.go
+++ b/sequencer/helpers.go
@@ -3,7 +3,6 @@ package sequencer
 import (
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/vocdoni/davinci-node/log"
@@ -100,15 +99,12 @@ func (s *Sequencer) filterBallotsByCensus(processID types.ProcessID, ballots []*
 	filtered := make([]*storage.AggregatorBallot, 0, len(ballots))
 	for _, b := range ballots {
 		addr := common.BigToAddress(b.Address)
-		if _, err := censusTree.GenerateProof(addr); err != nil {
-			if strings.Contains(err.Error(), "not found in census") {
-				log.Warnw("address not found in census, skipping ballot",
-					"processID", processID.String(),
-					"address", addr.Hex(),
-				)
-				continue
-			}
-			return nil, fmt.Errorf("census lookup failed for address %s: %w", addr.Hex(), err)
+		if _, ok := censusTree.GetWeight(addr); !ok {
+			log.Warnw("address not found in census, skipping ballot",
+				"processID", processID.String(),
+				"address", addr.Hex(),
+			)
+			continue
 		}
 		filtered = append(filtered, b)
 	}

--- a/sequencer/helpers.go
+++ b/sequencer/helpers.go
@@ -3,9 +3,12 @@ package sequencer
 import (
 	"errors"
 	"fmt"
+	"strings"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/vocdoni/davinci-node/log"
 	"github.com/vocdoni/davinci-node/state"
+	"github.com/vocdoni/davinci-node/storage"
 	"github.com/vocdoni/davinci-node/types"
 )
 
@@ -56,4 +59,58 @@ func (s *Sequencer) currentProcessState(processID types.ProcessID) (*state.State
 		"currentRoot", currentRoot.String())
 
 	return st, nil
+}
+
+// filterBallotsByCensus returns only the ballots whose voter address is
+// present in the process census tree. Ballots with absent addresses are
+// discarded and logged at WARN level. If the census tree is unavailable
+// (no root), an error is returned so the caller can retry rather than
+// silently discarding all ballots.
+//
+// For CSP-based censuses no local merkle lookup is possible; all ballots
+// are returned unchanged.
+func (s *Sequencer) filterBallotsByCensus(processID types.ProcessID, ballots []*storage.AggregatorBallot) ([]*storage.AggregatorBallot, error) {
+	process, err := s.stg.Process(processID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get process metadata: %w", err)
+	}
+	if !process.Census.CensusOrigin.IsMerkleTree() {
+		// CSP censuses are verified via the embedded proof; no local tree to query.
+		return ballots, nil
+	}
+
+	var chainID uint64
+	if process.Census.CensusOrigin == types.CensusOriginMerkleTreeOnchainDynamicV1 {
+		contracts, err := s.contractsForProcess(processID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve contracts for process %s: %w", processID.String(), err)
+		}
+		chainID = contracts.ChainID
+	}
+	censusRef, err := s.stg.LoadCensus(chainID, process.Census)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load census for process %s: %w", processID.String(), err)
+	}
+	censusTree := censusRef.Tree()
+	if _, ok := censusTree.Root(); !ok {
+		return nil, fmt.Errorf("census tree has no root for process %s (censusRoot=%s)",
+			processID.String(), process.Census.CensusRoot.String())
+	}
+
+	filtered := make([]*storage.AggregatorBallot, 0, len(ballots))
+	for _, b := range ballots {
+		addr := common.BigToAddress(b.Address)
+		if _, err := censusTree.GenerateProof(addr); err != nil {
+			if strings.Contains(err.Error(), "not found in census") {
+				log.Warnw("address not found in census, skipping ballot",
+					"processID", processID.String(),
+					"address", addr.Hex(),
+				)
+				continue
+			}
+			return nil, fmt.Errorf("census lookup failed for address %s: %w", addr.Hex(), err)
+		}
+		filtered = append(filtered, b)
+	}
+	return filtered, nil
 }

--- a/sequencer/helpers.go
+++ b/sequencer/helpers.go
@@ -11,6 +11,11 @@ import (
 	"github.com/vocdoni/davinci-node/types"
 )
 
+const (
+	errGetProcessMetadata         = "failed to get process metadata: %w"
+	errCheckProcessAcceptingVotes = "failed to check if process is accepting votes: %w"
+)
+
 // currentProcessState retrieves the current in-construction state for a given
 // process ID. This state includes all locally processed batches, even if they
 // haven't been confirmed on-chain yet. Use this for processing new votes.
@@ -18,11 +23,11 @@ func (s *Sequencer) currentProcessState(processID types.ProcessID) (*state.State
 	// get the process from the storage
 	process, err := s.stg.Process(processID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get process metadata: %w", err)
+		return nil, fmt.Errorf(errGetProcessMetadata, err)
 	}
 	isAcceptingVotes, err := s.stg.ProcessIsAcceptingVotes(processID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to check if process is accepting votes: %w", err)
+		return nil, fmt.Errorf(errCheckProcessAcceptingVotes, err)
 	}
 	if !isAcceptingVotes {
 		return nil, fmt.Errorf("process %x is not accepting votes", processID)
@@ -71,7 +76,7 @@ func (s *Sequencer) currentProcessState(processID types.ProcessID) (*state.State
 func (s *Sequencer) filterBallotsByCensus(processID types.ProcessID, ballots []*storage.AggregatorBallot) ([]*storage.AggregatorBallot, error) {
 	process, err := s.stg.Process(processID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get process metadata: %w", err)
+		return nil, fmt.Errorf(errGetProcessMetadata, err)
 	}
 	if !process.Census.CensusOrigin.IsMerkleTree() {
 		// CSP censuses are verified via the embedded proof; no local tree to query.

--- a/sequencer/helpers_test.go
+++ b/sequencer/helpers_test.go
@@ -1,0 +1,111 @@
+package sequencer
+
+import (
+	"math/big"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/vocdoni/davinci-node/internal/testutil"
+	"github.com/vocdoni/davinci-node/storage"
+	"github.com/vocdoni/davinci-node/types"
+	leanimt "github.com/vocdoni/lean-imt-go"
+	leancensus "github.com/vocdoni/lean-imt-go/census"
+)
+
+// buildCensusForTest creates an in-memory census tree with the given addresses
+// (all with weight 1), imports it into stg, and returns the census root bytes.
+func buildCensusForTest(t *testing.T, stg *storage.Storage, addrs ...uint64) types.HexBytes {
+	t.Helper()
+	tree, err := leancensus.NewCensusIMT(nil, leanimt.PoseidonHasher)
+	if err != nil {
+		t.Fatalf("NewCensusIMT: %v", err)
+	}
+	for _, n := range addrs {
+		if err := tree.Add(testutil.DeterministicAddress(n), big.NewInt(1)); err != nil {
+			t.Fatalf("tree.Add(%d): %v", n, err)
+		}
+	}
+	root, ok := tree.Root()
+	if !ok {
+		t.Fatal("census tree has no root after adding entries")
+	}
+	censusRoot := types.HexBytes(root.Bytes())
+	if _, err := stg.CensusDB().Import(censusRoot, tree.Dump()); err != nil {
+		t.Fatalf("CensusDB.Import: %v", err)
+	}
+	return censusRoot
+}
+
+// ballot returns a minimal AggregatorBallot for the given deterministic address index.
+func ballot(n uint64) *storage.AggregatorBallot {
+	return &storage.AggregatorBallot{
+		VoteID:  testutil.RandomVoteID(),
+		Address: testutil.DeterministicAddress(n).Big(),
+		Weight:  big.NewInt(1),
+	}
+}
+
+// TestFilterBallotsByCensusAllPresent verifies that when every ballot address
+// is in the census tree the full batch is returned unchanged.
+func TestFilterBallotsByCensusAllPresent(t *testing.T) {
+	c := qt.New(t)
+	stg := newTestSequencerStorage(t)
+	defer stg.Close()
+
+	processID := testutil.RandomProcessID()
+	censusRoot := buildCensusForTest(t, stg, 0, 1)
+	makeTestProcessWithCensus(t, stg, processID, censusRoot)
+
+	seq := &Sequencer{stg: stg, processIDs: NewProcessIDMap()}
+	input := []*storage.AggregatorBallot{ballot(0), ballot(1)}
+
+	got, err := seq.filterBallotsByCensus(processID, input)
+	c.Assert(err, qt.IsNil)
+	c.Assert(got, qt.HasLen, 2)
+}
+
+// TestFilterBallotsByCensusOneAbsent verifies that a ballot whose address is
+// absent from the census tree is removed from the returned slice while the
+// remaining ballot is kept and no error is returned.
+func TestFilterBallotsByCensusOneAbsent(t *testing.T) {
+	c := qt.New(t)
+	stg := newTestSequencerStorage(t)
+	defer stg.Close()
+
+	processID := testutil.RandomProcessID()
+	// Census contains addresses 0 and 1; address 999 is not in the census.
+	censusRoot := buildCensusForTest(t, stg, 0, 1)
+	makeTestProcessWithCensus(t, stg, processID, censusRoot)
+
+	seq := &Sequencer{stg: stg, processIDs: NewProcessIDMap()}
+	input := []*storage.AggregatorBallot{ballot(0), ballot(999), ballot(1)}
+
+	got, err := seq.filterBallotsByCensus(processID, input)
+	c.Assert(err, qt.IsNil)
+	c.Assert(got, qt.HasLen, 2)
+	// The two surviving ballots must be the ones with indices 0 and 1.
+	c.Assert(got[0].Address.Cmp(testutil.DeterministicAddress(0).Big()), qt.Equals, 0)
+	c.Assert(got[1].Address.Cmp(testutil.DeterministicAddress(1).Big()), qt.Equals, 0)
+}
+
+// TestFilterBallotsByCensusCensusUnavailable verifies that an error is
+// returned when the census root stored on the process has no corresponding
+// entry in the census database, so the caller can retry rather than silently
+// dropping all ballots.
+func TestFilterBallotsByCensusCensusUnavailable(t *testing.T) {
+	c := qt.New(t)
+	stg := newTestSequencerStorage(t)
+	defer stg.Close()
+
+	processID := testutil.RandomProcessID()
+	// Create the process with a census root that was never imported into the DB.
+	missingRoot := types.HexBytes(testutil.RandomCensusRoot().Bytes())
+	makeTestProcessWithCensus(t, stg, processID, missingRoot)
+
+	seq := &Sequencer{stg: stg, processIDs: NewProcessIDMap()}
+	input := []*storage.AggregatorBallot{ballot(0)}
+
+	_, err := seq.filterBallotsByCensus(processID, input)
+	c.Assert(err, qt.Not(qt.IsNil))
+	c.Assert(err.Error(), qt.Contains, "failed to load census")
+}

--- a/sequencer/helpers_test.go
+++ b/sequencer/helpers_test.go
@@ -12,6 +12,8 @@ import (
 	leancensus "github.com/vocdoni/lean-imt-go/census"
 )
 
+const testMetadataURI = "http://example.com/metadata"
+
 // buildCensusForTest creates an in-memory census tree with the given addresses
 // (all with weight 1), imports it into stg, and returns the census root bytes.
 func buildCensusForTest(t *testing.T, stg *storage.Storage, addrs ...uint64) types.HexBytes {

--- a/sequencer/onchain_test.go
+++ b/sequencer/onchain_test.go
@@ -51,7 +51,7 @@ func ensureSequencerTestProcess(t *testing.T, stg *storage.Storage, pid types.Pr
 		Status:        types.ProcessStatusReady,
 		StartTime:     time.Now(),
 		Duration:      time.Hour,
-		MetadataURI:   "http://example.com/metadata",
+		MetadataURI:   testMetadataURI,
 		BallotMode:    testutil.BallotMode(),
 		EncryptionKey: &encryptionKey,
 		StateRoot:     types.BigIntConverter(stateRoot),
@@ -97,7 +97,7 @@ func TestPushStateTransitionCallbackMarksBatchDoneAfterSuccess(t *testing.T) {
 		Status:      types.ProcessStatusReady,
 		StartTime:   time.Now(),
 		Duration:    time.Hour,
-		MetadataURI: "http://example.com/metadata",
+		MetadataURI: testMetadataURI,
 		BallotMode:  ballotMode,
 		EncryptionKey: func() *types.EncryptionKey {
 			key := types.EncryptionKeyFromPoint(encryptionKey)

--- a/sequencer/sequencer_test.go
+++ b/sequencer/sequencer_test.go
@@ -211,7 +211,7 @@ func createReadyProcess(t *testing.T, pid types.ProcessID) *types.Process {
 		Status:        types.ProcessStatusReady,
 		StartTime:     time.Now(),
 		Duration:      time.Hour,
-		MetadataURI:   "http://example.com/metadata",
+		MetadataURI:   testMetadataURI,
 		BallotMode:    testutil.BallotMode(),
 		EncryptionKey: &encryptionKey,
 		StateRoot:     types.BigIntConverter(stateRoot),

--- a/sequencer/statetransition.go
+++ b/sequencer/statetransition.go
@@ -3,6 +3,7 @@ package sequencer
 import (
 	"fmt"
 	"math/big"
+	"strings"
 	"time"
 
 	"github.com/consensys/gnark/backend/groth16"
@@ -107,9 +108,16 @@ func (s *Sequencer) processPendingTransitions() {
 		for i, b := range batch.Ballots {
 			censusProofs[i] = b.CensusProof
 		}
-		censusRoot, circuitCensusProofs, err := s.processCensusProofs(batch.ProcessID, reencryptedVotes, censusProofs)
+		censusRoot, circuitCensusProofs, reencryptedVotes, err := s.processCensusProofs(batch.ProcessID, reencryptedVotes, censusProofs)
 		if err != nil {
 			log.Errorw(err, "failed to get census proofs")
+			s.markAggregatorBatchFailed(batchID)
+			return true // Continue to next process ID
+		}
+		if len(reencryptedVotes) == 0 {
+			log.Errorw(fmt.Errorf("all votes in batch were skipped due to census proof failures"),
+				"failed state transition batch",
+				"processID", processID.String())
 			s.markAggregatorBatchFailed(batchID)
 			return true // Continue to next process ID
 		}
@@ -372,11 +380,11 @@ func (s *Sequencer) processCensusProofs(
 	processID types.ProcessID,
 	votes []*state.Vote,
 	censusProofs []*types.CensusProof,
-) (*types.BigInt, *statetransition.CensusProofs, error) {
+) (*types.BigInt, *statetransition.CensusProofs, []*state.Vote, error) {
 	// get the process from the storage
 	process, err := s.stg.Process(processID)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get process metadata: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to get process metadata: %w", err)
 	}
 
 	var root *big.Int
@@ -390,34 +398,48 @@ func (s *Sequencer) processCensusProofs(
 		if process.Census.CensusOrigin == types.CensusOriginMerkleTreeOnchainDynamicV1 {
 			contracts, err := s.contractsForProcess(processID)
 			if err != nil {
-				return nil, nil, fmt.Errorf("failed to resolve contracts for process %s: %w", processID.String(), err)
+				return nil, nil, nil, fmt.Errorf("failed to resolve contracts for process %s: %w", processID.String(), err)
 			}
 			chainID = contracts.ChainID
 		}
 		censusRef, err = s.stg.LoadCensus(chainID, process.Census)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to load census for process %s: %w", processID.String(), err)
+			return nil, nil, nil, fmt.Errorf("failed to load census for process %s: %w", processID.String(), err)
 		}
 		// get the merkle tree and its root
 		censusTree := censusRef.Tree()
 		var ok bool
 		if root, ok = censusTree.Root(); !ok {
-			log.Warnw("census tree has no root?", "censusRoot", process.Census.CensusRoot.String(), "fetchedRoot", root.String())
+			log.Warnw("census tree has no root?", "censusRoot", process.Census.CensusRoot.String(), "fetchedRoot", root)
 		}
-		// iterate over the votes to generate the merkle proofs of each voter
-		for i := range params.VotesPerBatch {
-			if i < len(votes) {
-				addr := common.BigToAddress(votes[i].Address)
-				proof, err := censusTree.GenerateProof(addr)
-				if err != nil {
-					return nil, nil, fmt.Errorf("error generating census proof for address %s: %w", addr.Hex(), err)
+		// iterate over the votes to generate the merkle proofs of each voter;
+		// skip any vote whose address is absent from the census tree.
+		filteredVotes := make([]*state.Vote, 0, len(votes))
+		proofIdx := 0
+		for _, v := range votes {
+			addr := common.BigToAddress(v.Address)
+			proof, err := censusTree.GenerateProof(addr)
+			if err != nil {
+				if strings.Contains(err.Error(), "not found in census") {
+					log.Warnw("address not found in census, skipping ballot",
+						"processID", processID.String(),
+						"address", addr.Hex(),
+					)
+					continue
 				}
-				merkleProofs[i] = imtcircuit.CensusProofToMerkleProof(proof)
-			} else {
-				merkleProofs[i] = statetransition.DummyMerkleProof()
+				return nil, nil, nil, fmt.Errorf("error generating census proof for address %s: %w", addr.Hex(), err)
 			}
+			filteredVotes = append(filteredVotes, v)
+			merkleProofs[proofIdx] = imtcircuit.CensusProofToMerkleProof(proof)
+			proofIdx++
+		}
+		for i := proofIdx; i < params.VotesPerBatch; i++ {
+			merkleProofs[i] = statetransition.DummyMerkleProof()
+		}
+		for i := range params.VotesPerBatch {
 			cspProofs[i] = statetransition.DummyCSPProof()
 		}
+		votes = filteredVotes
 	case process.Census.CensusOrigin.IsCSP():
 		// iterate over the votes to get the CSP proofs
 		root = process.Census.CensusRoot.BigInt().MathBigInt()
@@ -425,7 +447,7 @@ func (s *Sequencer) processCensusProofs(
 			if i < len(votes) {
 				proof, err := csp.CensusProofToCSPProof(process.Census.CensusOrigin.CurveID(), censusProofs[i])
 				if err != nil {
-					return nil, nil, fmt.Errorf("error transforming census proof for address %s: %w", common.BigToAddress(votes[i].Address).Hex(), err)
+					return nil, nil, nil, fmt.Errorf("error transforming census proof for address %s: %w", common.BigToAddress(votes[i].Address).Hex(), err)
 				}
 				cspProofs[i] = *proof
 			} else {
@@ -434,10 +456,10 @@ func (s *Sequencer) processCensusProofs(
 			merkleProofs[i] = statetransition.DummyMerkleProof()
 		}
 	default:
-		return nil, nil, fmt.Errorf("unsupported census origin: %s", process.Census.CensusOrigin.String())
+		return nil, nil, nil, fmt.Errorf("unsupported census origin: %s", process.Census.CensusOrigin.String())
 	}
 	return new(types.BigInt).SetBigInt(root), &statetransition.CensusProofs{
 		MerkleProofs: merkleProofs,
 		CSPProofs:    cspProofs,
-	}, nil
+	}, votes, nil
 }

--- a/sequencer/statetransition.go
+++ b/sequencer/statetransition.go
@@ -95,6 +95,23 @@ func (s *Sequencer) processPendingTransitions() {
 			"ballotCount", len(batch.Ballots),
 		)
 
+		// Pre-flight census check: remove any ballot whose address is absent
+		// from the census tree before the more expensive reencrypt+proof path.
+		batch.Ballots, err = s.filterBallotsByCensus(batch.ProcessID, batch.Ballots)
+		if err != nil {
+			log.Errorw(err, "pre-flight census check failed",
+				"processID", processID.String())
+			s.markAggregatorBatchFailed(batchID)
+			return true // Continue to next process ID
+		}
+		if len(batch.Ballots) == 0 {
+			log.Errorw(fmt.Errorf("all ballots removed by pre-flight census check"),
+				"failed state transition batch",
+				"processID", processID.String())
+			s.markAggregatorBatchFailed(batchID)
+			return true // Continue to next process ID
+		}
+
 		// Reencrypt the votes with a new k
 		reencryptedVotes, kSeed, err := s.reencryptVotes(batch.ProcessID, batch.Ballots)
 		if err != nil {

--- a/sequencer/statetransition.go
+++ b/sequencer/statetransition.go
@@ -99,15 +99,13 @@ func (s *Sequencer) processPendingTransitions() {
 		// from the census tree before the more expensive reencrypt+proof path.
 		batch.Ballots, err = s.filterBallotsByCensus(batch.ProcessID, batch.Ballots)
 		if err != nil {
-			log.Errorw(err, "pre-flight census check failed",
-				"processID", processID.String())
+			log.Errorw(err, "pre-flight census check failed")
 			s.markAggregatorBatchFailed(batchID)
 			return true // Continue to next process ID
 		}
 		if len(batch.Ballots) == 0 {
-			log.Errorw(fmt.Errorf("all ballots removed by pre-flight census check"),
-				"failed state transition batch",
-				"processID", processID.String())
+			log.Errorw(fmt.Errorf("all ballots removed by pre-flight census check for process %s", processID.String()),
+				"failed state transition batch")
 			s.markAggregatorBatchFailed(batchID)
 			return true // Continue to next process ID
 		}
@@ -132,9 +130,8 @@ func (s *Sequencer) processPendingTransitions() {
 			return true // Continue to next process ID
 		}
 		if len(reencryptedVotes) == 0 {
-			log.Errorw(fmt.Errorf("all votes in batch were skipped due to census proof failures"),
-				"failed state transition batch",
-				"processID", processID.String())
+			log.Errorw(fmt.Errorf("all votes in batch were skipped due to census proof failures for process %s", processID.String()),
+				"failed state transition batch")
 			s.markAggregatorBatchFailed(batchID)
 			return true // Continue to next process ID
 		}

--- a/sequencer/statetransition.go
+++ b/sequencer/statetransition.go
@@ -3,7 +3,6 @@ package sequencer
 import (
 	"fmt"
 	"math/big"
-	"strings"
 	"time"
 
 	"github.com/consensys/gnark/backend/groth16"
@@ -95,21 +94,6 @@ func (s *Sequencer) processPendingTransitions() {
 			"ballotCount", len(batch.Ballots),
 		)
 
-		// Pre-flight census check: remove any ballot whose address is absent
-		// from the census tree before the more expensive reencrypt+proof path.
-		batch.Ballots, err = s.filterBallotsByCensus(batch.ProcessID, batch.Ballots)
-		if err != nil {
-			log.Errorw(err, "pre-flight census check failed")
-			s.markAggregatorBatchFailed(batchID)
-			return true // Continue to next process ID
-		}
-		if len(batch.Ballots) == 0 {
-			log.Errorw(fmt.Errorf("all ballots removed by pre-flight census check for process %s", processID.String()),
-				"failed state transition batch")
-			s.markAggregatorBatchFailed(batchID)
-			return true // Continue to next process ID
-		}
-
 		// Reencrypt the votes with a new k
 		reencryptedVotes, kSeed, err := s.reencryptVotes(batch.ProcessID, batch.Ballots)
 		if err != nil {
@@ -123,15 +107,9 @@ func (s *Sequencer) processPendingTransitions() {
 		for i, b := range batch.Ballots {
 			censusProofs[i] = b.CensusProof
 		}
-		censusRoot, circuitCensusProofs, reencryptedVotes, err := s.processCensusProofs(batch.ProcessID, reencryptedVotes, censusProofs)
+		censusRoot, circuitCensusProofs, err := s.processCensusProofs(batch.ProcessID, reencryptedVotes, censusProofs)
 		if err != nil {
 			log.Errorw(err, "failed to get census proofs")
-			s.markAggregatorBatchFailed(batchID)
-			return true // Continue to next process ID
-		}
-		if len(reencryptedVotes) == 0 {
-			log.Errorw(fmt.Errorf("all votes in batch were skipped due to census proof failures for process %s", processID.String()),
-				"failed state transition batch")
 			s.markAggregatorBatchFailed(batchID)
 			return true // Continue to next process ID
 		}
@@ -394,11 +372,11 @@ func (s *Sequencer) processCensusProofs(
 	processID types.ProcessID,
 	votes []*state.Vote,
 	censusProofs []*types.CensusProof,
-) (*types.BigInt, *statetransition.CensusProofs, []*state.Vote, error) {
+) (*types.BigInt, *statetransition.CensusProofs, error) {
 	// get the process from the storage
 	process, err := s.stg.Process(processID)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to get process metadata: %w", err)
+		return nil, nil, fmt.Errorf("failed to get process metadata: %w", err)
 	}
 
 	var root *big.Int
@@ -412,13 +390,13 @@ func (s *Sequencer) processCensusProofs(
 		if process.Census.CensusOrigin == types.CensusOriginMerkleTreeOnchainDynamicV1 {
 			contracts, err := s.contractsForProcess(processID)
 			if err != nil {
-				return nil, nil, nil, fmt.Errorf("failed to resolve contracts for process %s: %w", processID.String(), err)
+				return nil, nil, fmt.Errorf("failed to resolve contracts for process %s: %w", processID.String(), err)
 			}
 			chainID = contracts.ChainID
 		}
 		censusRef, err = s.stg.LoadCensus(chainID, process.Census)
 		if err != nil {
-			return nil, nil, nil, fmt.Errorf("failed to load census for process %s: %w", processID.String(), err)
+			return nil, nil, fmt.Errorf("failed to load census for process %s: %w", processID.String(), err)
 		}
 		// get the merkle tree and its root
 		censusTree := censusRef.Tree()
@@ -427,37 +405,23 @@ func (s *Sequencer) processCensusProofs(
 			log.Warnw("census tree has no root",
 				"censusRoot", process.Census.CensusRoot.String(),
 				"fetchedRoot", root)
-			return nil, nil, nil, fmt.Errorf("census tree has no root for process %s (censusRoot=%s)",
+			return nil, nil, fmt.Errorf("census tree has no root for process %s (censusRoot=%s)",
 				processID.String(), process.Census.CensusRoot.String())
 		}
-		// iterate over the votes to generate the merkle proofs of each voter;
-		// skip any vote whose address is absent from the census tree.
-		filteredVotes := make([]*state.Vote, 0, len(votes))
-		proofIdx := 0
-		for _, v := range votes {
-			addr := common.BigToAddress(v.Address)
-			proof, err := censusTree.GenerateProof(addr)
-			if err != nil {
-				if strings.Contains(err.Error(), "not found in census") {
-					log.Warnw("address not found in census, skipping ballot",
-						"processID", processID.String(),
-						"address", addr.Hex(),
-					)
-					continue
-				}
-				return nil, nil, nil, fmt.Errorf("error generating census proof for address %s: %w", addr.Hex(), err)
-			}
-			filteredVotes = append(filteredVotes, v)
-			merkleProofs[proofIdx] = imtcircuit.CensusProofToMerkleProof(proof)
-			proofIdx++
-		}
-		for i := proofIdx; i < params.VotesPerBatch; i++ {
-			merkleProofs[i] = statetransition.DummyMerkleProof()
-		}
+		// iterate over the votes to generate the merkle proofs of each voter
 		for i := range params.VotesPerBatch {
+			if i < len(votes) {
+				addr := common.BigToAddress(votes[i].Address)
+				proof, err := censusTree.GenerateProof(addr)
+				if err != nil {
+					return nil, nil, fmt.Errorf("error generating census proof for address %s: %w", addr.Hex(), err)
+				}
+				merkleProofs[i] = imtcircuit.CensusProofToMerkleProof(proof)
+			} else {
+				merkleProofs[i] = statetransition.DummyMerkleProof()
+			}
 			cspProofs[i] = statetransition.DummyCSPProof()
 		}
-		votes = filteredVotes
 	case process.Census.CensusOrigin.IsCSP():
 		// iterate over the votes to get the CSP proofs
 		root = process.Census.CensusRoot.BigInt().MathBigInt()
@@ -465,7 +429,7 @@ func (s *Sequencer) processCensusProofs(
 			if i < len(votes) {
 				proof, err := csp.CensusProofToCSPProof(process.Census.CensusOrigin.CurveID(), censusProofs[i])
 				if err != nil {
-					return nil, nil, nil, fmt.Errorf("error transforming census proof for address %s: %w", common.BigToAddress(votes[i].Address).Hex(), err)
+					return nil, nil, fmt.Errorf("error transforming census proof for address %s: %w", common.BigToAddress(votes[i].Address).Hex(), err)
 				}
 				cspProofs[i] = *proof
 			} else {
@@ -474,10 +438,10 @@ func (s *Sequencer) processCensusProofs(
 			merkleProofs[i] = statetransition.DummyMerkleProof()
 		}
 	default:
-		return nil, nil, nil, fmt.Errorf("unsupported census origin: %s", process.Census.CensusOrigin.String())
+		return nil, nil, fmt.Errorf("unsupported census origin: %s", process.Census.CensusOrigin.String())
 	}
 	return new(types.BigInt).SetBigInt(root), &statetransition.CensusProofs{
 		MerkleProofs: merkleProofs,
 		CSPProofs:    cspProofs,
-	}, votes, nil
+	}, nil
 }

--- a/sequencer/statetransition.go
+++ b/sequencer/statetransition.go
@@ -376,7 +376,7 @@ func (s *Sequencer) processCensusProofs(
 	// get the process from the storage
 	process, err := s.stg.Process(processID)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get process metadata: %w", err)
+		return nil, nil, fmt.Errorf(errGetProcessMetadata, err)
 	}
 
 	var root *big.Int

--- a/sequencer/statetransition.go
+++ b/sequencer/statetransition.go
@@ -410,7 +410,11 @@ func (s *Sequencer) processCensusProofs(
 		censusTree := censusRef.Tree()
 		var ok bool
 		if root, ok = censusTree.Root(); !ok {
-			log.Warnw("census tree has no root?", "censusRoot", process.Census.CensusRoot.String(), "fetchedRoot", root)
+			log.Warnw("census tree has no root",
+				"censusRoot", process.Census.CensusRoot.String(),
+				"fetchedRoot", root)
+			return nil, nil, nil, fmt.Errorf("census tree has no root for process %s (censusRoot=%s)",
+				processID.String(), process.Census.CensusRoot.String())
 		}
 		// iterate over the votes to generate the merkle proofs of each voter;
 		// skip any vote whose address is absent from the census tree.

--- a/sequencer/statetransition_test.go
+++ b/sequencer/statetransition_test.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/consensys/gnark/backend/groth16"
 	"github.com/ethereum/go-ethereum/accounts/abi"
@@ -12,11 +13,15 @@ import (
 	stc "github.com/vocdoni/davinci-node/circuits/statetransition"
 	statetransitiontest "github.com/vocdoni/davinci-node/circuits/test/statetransition"
 	"github.com/vocdoni/davinci-node/internal/testutil"
+	spechash "github.com/vocdoni/davinci-node/spec/hash"
 	specutil "github.com/vocdoni/davinci-node/spec/util"
+	"github.com/vocdoni/davinci-node/state"
 	statetest "github.com/vocdoni/davinci-node/state/testutil"
 	"github.com/vocdoni/davinci-node/storage"
 	"github.com/vocdoni/davinci-node/types"
 	"github.com/vocdoni/davinci-node/web3"
+	leanimt "github.com/vocdoni/lean-imt-go"
+	leancensus "github.com/vocdoni/lean-imt-go/census"
 )
 
 func testVariableAsBigInt(t *testing.T, v interface{}) *big.Int {
@@ -326,4 +331,134 @@ func publicStateTransitionCircuitFromInputs(inputs storage.StateTransitionBatchP
 	circuit.BlobCommitmentLimbs[1] = inputs.BlobCommitmentLimbs[1]
 	circuit.BlobCommitmentLimbs[2] = inputs.BlobCommitmentLimbs[2]
 	return circuit
+}
+
+// makeTestProcessWithCensus creates a process in storage with the given MerkleTree census root.
+func makeTestProcessWithCensus(t *testing.T, stg *storage.Storage, processID types.ProcessID, censusRoot types.HexBytes) {
+	t.Helper()
+	encryptionKey := testutil.RandomEncryptionPubKey()
+	censusOrigin := types.CensusOriginMerkleTreeOffchainStaticV1
+	stateRoot, err := spechash.StateRoot(
+		processID.MathBigInt(),
+		censusOrigin.BigInt().MathBigInt(),
+		encryptionKey.X.MathBigInt(),
+		encryptionKey.Y.MathBigInt(),
+		testutil.BallotModePacked(),
+	)
+	if err != nil {
+		t.Fatalf("spechash.StateRoot: %v", err)
+	}
+	proc := &types.Process{
+		ID:            &processID,
+		Status:        types.ProcessStatusReady,
+		StartTime:     time.Now(),
+		Duration:      time.Hour,
+		MetadataURI:   "http://example.com/metadata",
+		BallotMode:    testutil.BallotMode(),
+		EncryptionKey: &encryptionKey,
+		StateRoot:     types.BigIntConverter(stateRoot),
+		Census: &types.Census{
+			CensusOrigin: censusOrigin,
+			CensusRoot:   censusRoot,
+		},
+	}
+	if err := stg.NewProcess(proc); err != nil {
+		t.Fatalf("NewProcess: %v", err)
+	}
+}
+
+// TestProcessCensusProofsNilRootReturnsError verifies that processCensusProofs
+// returns an error when the census tree exists in storage but has no root
+// (empty tree, no entries).
+func TestProcessCensusProofsNilRootReturnsError(t *testing.T) {
+	c := qt.New(t)
+	stg := newTestSequencerStorage(t)
+	defer stg.Close()
+
+	processID := testutil.RandomProcessID()
+	censusRoot := types.HexBytes(testutil.RandomCensusRoot().Bytes())
+
+	// Register an empty census (no entries) so LoadCensus succeeds but
+	// Tree().Root() returns (nil, false).
+	_, err := stg.CensusDB().NewByRoot(censusRoot)
+	c.Assert(err, qt.IsNil)
+	makeTestProcessWithCensus(t, stg, processID, censusRoot)
+
+	seq := &Sequencer{stg: stg, processIDs: NewProcessIDMap()}
+
+	_, _, _, err = seq.processCensusProofs(processID, nil, nil)
+	c.Assert(err, qt.Not(qt.IsNil))
+	c.Assert(err.Error(), qt.Contains, "census tree has no root")
+}
+
+// TestProcessCensusProofsMissingAddressSkipsBallot verifies that a vote whose
+// address is absent from the census tree is silently skipped while the
+// remaining valid votes are returned without error.
+func TestProcessCensusProofsMissingAddressSkipsBallot(t *testing.T) {
+	c := qt.New(t)
+	stg := newTestSequencerStorage(t)
+	defer stg.Close()
+
+	processID := testutil.RandomProcessID()
+
+	addr0 := testutil.DeterministicAddress(0)
+	addr1 := testutil.DeterministicAddress(1)
+	sourceTree, err := leancensus.NewCensusIMT(nil, leanimt.PoseidonHasher)
+	c.Assert(err, qt.IsNil)
+	c.Assert(sourceTree.Add(addr0, big.NewInt(1)), qt.IsNil)
+	c.Assert(sourceTree.Add(addr1, big.NewInt(1)), qt.IsNil)
+	root, ok := sourceTree.Root()
+	c.Assert(ok, qt.IsTrue)
+
+	censusRoot := types.HexBytes(root.Bytes())
+	_, err = stg.CensusDB().Import(censusRoot, sourceTree.Dump())
+	c.Assert(err, qt.IsNil)
+	makeTestProcessWithCensus(t, stg, processID, censusRoot)
+
+	// addr0 and addr1 are in the census; addr2 (index 999) is not.
+	addr2 := testutil.DeterministicAddress(999)
+	votes := []*state.Vote{
+		{Address: addr0.Big(), Weight: big.NewInt(1)},
+		{Address: addr1.Big(), Weight: big.NewInt(1)},
+		{Address: addr2.Big(), Weight: big.NewInt(1)},
+	}
+
+	seq := &Sequencer{stg: stg, processIDs: NewProcessIDMap()}
+	_, _, filtered, err := seq.processCensusProofs(processID, votes, nil)
+	c.Assert(err, qt.IsNil)
+	c.Assert(filtered, qt.HasLen, 2)
+}
+
+// TestProcessCensusProofsAllValidReturnsAllVotes verifies that when every vote
+// address is present in the census tree, all votes are returned unchanged.
+func TestProcessCensusProofsAllValidReturnsAllVotes(t *testing.T) {
+	c := qt.New(t)
+	stg := newTestSequencerStorage(t)
+	defer stg.Close()
+
+	processID := testutil.RandomProcessID()
+
+	addr0 := testutil.DeterministicAddress(0)
+	addr1 := testutil.DeterministicAddress(1)
+	sourceTree, err := leancensus.NewCensusIMT(nil, leanimt.PoseidonHasher)
+	c.Assert(err, qt.IsNil)
+	c.Assert(sourceTree.Add(addr0, big.NewInt(1)), qt.IsNil)
+	c.Assert(sourceTree.Add(addr1, big.NewInt(1)), qt.IsNil)
+	root, ok := sourceTree.Root()
+	c.Assert(ok, qt.IsTrue)
+
+	censusRoot := types.HexBytes(root.Bytes())
+	_, err = stg.CensusDB().Import(censusRoot, sourceTree.Dump())
+	c.Assert(err, qt.IsNil)
+	makeTestProcessWithCensus(t, stg, processID, censusRoot)
+
+	votes := []*state.Vote{
+		{Address: addr0.Big(), Weight: big.NewInt(1)},
+		{Address: addr1.Big(), Weight: big.NewInt(1)},
+	}
+
+	seq := &Sequencer{stg: stg, processIDs: NewProcessIDMap()}
+	_, _, filtered, err := seq.processCensusProofs(processID, votes, nil)
+	c.Assert(err, qt.IsNil)
+	c.Assert(filtered, qt.HasLen, 2)
 }

--- a/sequencer/statetransition_test.go
+++ b/sequencer/statetransition_test.go
@@ -353,7 +353,7 @@ func makeTestProcessWithCensus(t *testing.T, stg *storage.Storage, processID typ
 		Status:        types.ProcessStatusReady,
 		StartTime:     time.Now(),
 		Duration:      time.Hour,
-		MetadataURI:   "http://example.com/metadata",
+		MetadataURI:   testMetadataURI,
 		BallotMode:    testutil.BallotMode(),
 		EncryptionKey: &encryptionKey,
 		StateRoot:     types.BigIntConverter(stateRoot),

--- a/sequencer/statetransition_test.go
+++ b/sequencer/statetransition_test.go
@@ -386,15 +386,16 @@ func TestProcessCensusProofsNilRootReturnsError(t *testing.T) {
 
 	seq := &Sequencer{stg: stg, processIDs: NewProcessIDMap()}
 
-	_, _, _, err = seq.processCensusProofs(processID, nil, nil)
+	_, _, err = seq.processCensusProofs(processID, nil, nil)
 	c.Assert(err, qt.Not(qt.IsNil))
 	c.Assert(err.Error(), qt.Contains, "census tree has no root")
 }
 
-// TestProcessCensusProofsMissingAddressSkipsBallot verifies that a vote whose
-// address is absent from the census tree is silently skipped while the
-// remaining valid votes are returned without error.
-func TestProcessCensusProofsMissingAddressSkipsBallot(t *testing.T) {
+// TestProcessCensusProofsMissingAddressReturnsError verifies that processCensusProofs
+// returns an error when a vote's address is absent from the census tree. Census
+// filtering must happen before aggregation (to preserve the aggregator proof's
+// BatchHash public input); a missing address at state-transition time is fatal.
+func TestProcessCensusProofsMissingAddressReturnsError(t *testing.T) {
 	c := qt.New(t)
 	stg := newTestSequencerStorage(t)
 	defer stg.Close()
@@ -424,9 +425,8 @@ func TestProcessCensusProofsMissingAddressSkipsBallot(t *testing.T) {
 	}
 
 	seq := &Sequencer{stg: stg, processIDs: NewProcessIDMap()}
-	_, _, filtered, err := seq.processCensusProofs(processID, votes, nil)
-	c.Assert(err, qt.IsNil)
-	c.Assert(filtered, qt.HasLen, 2)
+	_, _, err = seq.processCensusProofs(processID, votes, nil)
+	c.Assert(err, qt.Not(qt.IsNil))
 }
 
 // TestProcessCensusProofsAllValidReturnsAllVotes verifies that when every vote
@@ -458,7 +458,6 @@ func TestProcessCensusProofsAllValidReturnsAllVotes(t *testing.T) {
 	}
 
 	seq := &Sequencer{stg: stg, processIDs: NewProcessIDMap()}
-	_, _, filtered, err := seq.processCensusProofs(processID, votes, nil)
+	_, _, err = seq.processCensusProofs(processID, votes, nil)
 	c.Assert(err, qt.IsNil)
-	c.Assert(filtered, qt.HasLen, 2)
 }

--- a/types/hexbytes_test.go
+++ b/types/hexbytes_test.go
@@ -7,6 +7,8 @@ import (
 	qt "github.com/frankban/quicktest"
 )
 
+const testNameEmpty = "empty"
+
 func TestHexBytes(t *testing.T) {
 	c := qt.New(t)
 
@@ -26,7 +28,7 @@ func TestHexBytes(t *testing.T) {
 			want string
 		}{
 			{name: "nil slice", in: nil, want: "0x"},
-			{name: "empty", in: HexBytes{}, want: "0x"},
+			{name: testNameEmpty, in: HexBytes{}, want: "0x"},
 			{name: "non-empty", in: HexBytes{0x00, 0xAB, 0xCD}, want: "0x00abcd"},
 		}
 
@@ -43,7 +45,7 @@ func TestHexBytes(t *testing.T) {
 			in   HexBytes
 			want string
 		}{
-			{name: "empty", in: HexBytes{}, want: "0"},
+			{name: testNameEmpty, in: HexBytes{}, want: "0"},
 			{name: "big-endian", in: HexBytes{0x01, 0x00}, want: "256"},
 			{name: "leading zeros", in: HexBytes{0x00, 0x00, 0x02}, want: "2"},
 		}
@@ -170,7 +172,7 @@ func TestHexBytes(t *testing.T) {
 				in   HexBytes
 				want string
 			}{
-				{name: "empty", in: HexBytes{}, want: `"0x"`},
+				{name: testNameEmpty, in: HexBytes{}, want: `"0x"`},
 				{name: "non-empty", in: HexBytes{0xDE, 0xAD, 0xBE, 0xEF}, want: `"0xdeadbeef"`},
 			}
 
@@ -196,7 +198,7 @@ func TestHexBytes(t *testing.T) {
 				{name: "with 0x prefix", in: `"0xdeadbeef"`, want: HexBytes{0xDE, 0xAD, 0xBE, 0xEF}},
 				{name: "with 0X prefix", in: `"0Xdeadbeef"`, want: HexBytes{0xDE, 0xAD, 0xBE, 0xEF}},
 				{name: "without prefix", in: `"deadbeef"`, want: HexBytes{0xDE, 0xAD, 0xBE, 0xEF}},
-				{name: "empty", in: `"0x"`, want: HexBytes{}},
+				{name: testNameEmpty, in: `"0x"`, want: HexBytes{}},
 			}
 
 			for _, tc := range testCases {
@@ -253,7 +255,7 @@ func TestHexBytes(t *testing.T) {
 			{name: "with prefix", in: "0xdeadbeef", want: HexBytes{0xDE, 0xAD, 0xBE, 0xEF}},
 			{name: "with uppercase prefix", in: "0Xdeadbeef", want: HexBytes{0xDE, 0xAD, 0xBE, 0xEF}},
 			{name: "without prefix", in: "deadbeef", want: HexBytes{0xDE, 0xAD, 0xBE, 0xEF}},
-			{name: "empty", in: "", want: HexBytes{}},
+			{name: testNameEmpty, in: "", want: HexBytes{}},
 		}
 
 		for _, tc := range testCases {

--- a/util/circomgnark/cache_test.go
+++ b/util/circomgnark/cache_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/vocdoni/davinci-node/circuits/ballotproof"
 )
 
+const testProtocol = "groth16"
+
 func TestUnmarshalCircomVerificationKeyJSONCachesByInput(t *testing.T) {
 	c := qt.New(t)
 
@@ -59,7 +61,7 @@ func TestToGnarkRecursionFixedVkSkipsVerificationKeyConversion(t *testing.T) {
 			"4110411832118690910191887320272248494012149664813960539989768130756673868858",
 			"1",
 		},
-		Protocol: "groth16",
+		Protocol: testProtocol,
 	}
 
 	recursionProof, err := proof.ToGnarkRecursion(&CircomVerificationKey{}, []string{

--- a/util/circomgnark/marshal_test.go
+++ b/util/circomgnark/marshal_test.go
@@ -13,7 +13,7 @@ func TestMarshalCircomProofJSON(t *testing.T) {
 		PiA:      []string{"1", "2", "1"},
 		PiB:      [][]string{{"1", "2"}, {"3", "4"}, {"1", "0"}},
 		PiC:      []string{"5", "6", "1"},
-		Protocol: "groth16",
+		Protocol: testProtocol,
 	}
 
 	data, err := MarshalCircomProofJSON(proof)
@@ -28,7 +28,7 @@ func TestMarshalCircomVerificationKeyJSON(t *testing.T) {
 	c := qt.New(t)
 
 	vk := &CircomVerificationKey{
-		Protocol:      "groth16",
+		Protocol:      testProtocol,
 		Curve:         "bn128",
 		NPublic:       3,
 		VkAlpha1:      []string{"1", "2", "1"},

--- a/web3/contracts_test.go
+++ b/web3/contracts_test.go
@@ -21,6 +21,11 @@ import (
 	"github.com/vocdoni/davinci-node/web3/rpc"
 )
 
+const (
+	testMetadataURI = "https://example.com/metadata"
+	testCensusURI   = "https://example.com/census"
+)
+
 type testRPCRequest struct {
 	ID     json.RawMessage `json:"id"`
 	Method string          `json:"method"`
@@ -106,13 +111,13 @@ func TestProcessAtBlockUsesHistoricalSnapshot(t *testing.T) {
 			OverwrittenVotesCount: big.NewInt(0),
 			CreationBlock:         big.NewInt(10),
 			BatchNumber:           big.NewInt(0),
-			MetadataURI:           "https://example.com/metadata",
+			MetadataURI:           testMetadataURI,
 			BallotMode:            npbindings.DAVINCITypesBallotMode{UniqueValues: false, NumFields: 5, GroupSize: 0, CostExponent: 2, MaxValue: big.NewInt(10), MinValue: big.NewInt(0), MaxValueSum: big.NewInt(100), MinValueSum: big.NewInt(0)},
 			Census: npbindings.DAVINCITypesCensus{
 				CensusOrigin:    uint8(types.CensusOriginMerkleTreeOffchainStaticV1),
 				CensusRoot:      [32]byte{},
 				ContractAddress: common.Address{},
-				CensusURI:       "https://example.com/census",
+				CensusURI:       testCensusURI,
 			},
 		},
 		latest: npbindings.DAVINCITypesProcess{
@@ -128,13 +133,13 @@ func TestProcessAtBlockUsesHistoricalSnapshot(t *testing.T) {
 			OverwrittenVotesCount: big.NewInt(0),
 			CreationBlock:         big.NewInt(10),
 			BatchNumber:           big.NewInt(0),
-			MetadataURI:           "https://example.com/metadata",
+			MetadataURI:           testMetadataURI,
 			BallotMode:            npbindings.DAVINCITypesBallotMode{UniqueValues: false, NumFields: 5, GroupSize: 0, CostExponent: 2, MaxValue: big.NewInt(10), MinValue: big.NewInt(0), MaxValueSum: big.NewInt(100), MinValueSum: big.NewInt(0)},
 			Census: npbindings.DAVINCITypesCensus{
 				CensusOrigin:    uint8(types.CensusOriginMerkleTreeOffchainStaticV1),
 				CensusRoot:      [32]byte{},
 				ContractAddress: common.Address{},
-				CensusURI:       "https://example.com/census",
+				CensusURI:       testCensusURI,
 			},
 		},
 	}
@@ -175,13 +180,13 @@ func TestProcessAtBlockUsesCreationSnapshot(t *testing.T) {
 			OverwrittenVotesCount: big.NewInt(0),
 			CreationBlock:         big.NewInt(10),
 			BatchNumber:           big.NewInt(0),
-			MetadataURI:           "https://example.com/metadata",
+			MetadataURI:           testMetadataURI,
 			BallotMode:            npbindings.DAVINCITypesBallotMode{UniqueValues: false, NumFields: 5, GroupSize: 0, CostExponent: 2, MaxValue: big.NewInt(10), MinValue: big.NewInt(0), MaxValueSum: big.NewInt(100), MinValueSum: big.NewInt(0)},
 			Census: npbindings.DAVINCITypesCensus{
 				CensusOrigin:    uint8(types.CensusOriginMerkleTreeOffchainStaticV1),
 				CensusRoot:      [32]byte{},
 				ContractAddress: common.Address{},
-				CensusURI:       "https://example.com/census",
+				CensusURI:       testCensusURI,
 			},
 		},
 	}

--- a/web3/rpc/chainlist/chainlist_test.go
+++ b/web3/rpc/chainlist/chainlist_test.go
@@ -300,7 +300,7 @@ func TestEnhancedHealthCheck(t *testing.T) {
 			supportsGetLogs  bool
 			correctChainID   bool
 		}{
-			testValidBlockAndLogsEndpoint:               {true, true, true},
+			testValidBlockAndLogsEndpoint: {true, true, true},
 			"https://valid-block-no-logs.example.com":   {true, false, true},
 			"https://zero-block-valid-logs.example.com": {false, true, true},
 			"https://zero-block-no-logs.example.com":    {false, false, true},

--- a/web3/rpc/chainlist/chainlist_test.go
+++ b/web3/rpc/chainlist/chainlist_test.go
@@ -300,7 +300,7 @@ func TestEnhancedHealthCheck(t *testing.T) {
 			supportsGetLogs  bool
 			correctChainID   bool
 		}{
-			testValidBlockAndLogsEndpoint: {true, true, true},
+			testValidBlockAndLogsEndpoint:               {true, true, true},
 			"https://valid-block-no-logs.example.com":   {true, false, true},
 			"https://zero-block-valid-logs.example.com": {false, true, true},
 			"https://zero-block-no-logs.example.com":    {false, false, true},

--- a/web3/rpc/chainlist/chainlist_test.go
+++ b/web3/rpc/chainlist/chainlist_test.go
@@ -11,6 +11,12 @@ import (
 	"time"
 )
 
+const (
+	testArbRPC1                   = "https://arb-rpc-1.example.com"
+	testArbRPC2                   = "https://arb-rpc-2.example.com"
+	testValidBlockAndLogsEndpoint = "https://valid-block-and-logs.example.com"
+)
+
 // testRand is a package-level random number generator for consistent test results
 var testRand = rand.New(rand.NewSource(1234))
 
@@ -81,8 +87,8 @@ func TestEndpointList(t *testing.T) {
 			ShortName: "arb1",
 			ChainID:   42161,
 			RPC: []RPCEntry{
-				{URL: "https://arb-rpc-1.example.com"},
-				{URL: "https://arb-rpc-2.example.com"},
+				{URL: testArbRPC1},
+				{URL: testArbRPC2},
 			},
 		},
 	}
@@ -104,8 +110,8 @@ func TestEndpointList(t *testing.T) {
 
 		// Verify all endpoints are present (in any order due to randomization)
 		expectURLs := map[string]bool{
-			"https://arb-rpc-1.example.com": true,
-			"https://arb-rpc-2.example.com": true,
+			testArbRPC1: true,
+			testArbRPC2: true,
 		}
 
 		for _, url := range endpoints {
@@ -128,8 +134,8 @@ func TestEndpointList(t *testing.T) {
 		}
 
 		expectURLs := map[string]bool{
-			"https://arb-rpc-1.example.com": true,
-			"https://arb-rpc-2.example.com": true,
+			testArbRPC1: true,
+			testArbRPC2: true,
 		}
 		for _, url := range endpoints {
 			if !expectURLs[url] {
@@ -257,7 +263,7 @@ func TestEnhancedHealthCheck(t *testing.T) {
 			ShortName: "test",
 			ChainID:   1,
 			RPC: []RPCEntry{
-				{URL: "https://valid-block-and-logs.example.com"},  // Both valid
+				{URL: testValidBlockAndLogsEndpoint},               // Both valid
 				{URL: "https://valid-block-no-logs.example.com"},   // Only valid block but no getLogs
 				{URL: "https://zero-block-valid-logs.example.com"}, // Zero block but valid getLogs
 				{URL: "https://zero-block-no-logs.example.com"},    // Neither valid
@@ -294,7 +300,7 @@ func TestEnhancedHealthCheck(t *testing.T) {
 			supportsGetLogs  bool
 			correctChainID   bool
 		}{
-			"https://valid-block-and-logs.example.com":  {true, true, true},
+			testValidBlockAndLogsEndpoint:               {true, true, true},
 			"https://valid-block-no-logs.example.com":   {true, false, true},
 			"https://zero-block-valid-logs.example.com": {false, true, true},
 			"https://zero-block-no-logs.example.com":    {false, false, true},
@@ -324,8 +330,8 @@ func TestEnhancedHealthCheck(t *testing.T) {
 		}
 
 		// Verify it's the correct endpoint
-		if len(endpoints) > 0 && endpoints[0] != "https://valid-block-and-logs.example.com" {
-			t.Errorf("Expected healthy endpoint 'https://valid-block-and-logs.example.com', got %s", endpoints[0])
+		if len(endpoints) > 0 && endpoints[0] != testValidBlockAndLogsEndpoint {
+			t.Errorf("Expected healthy endpoint '%s', got %s", testValidBlockAndLogsEndpoint, endpoints[0])
 		}
 	})
 }

--- a/web3/rpc/web3_pool_test.go
+++ b/web3/rpc/web3_pool_test.go
@@ -9,6 +9,12 @@ import (
 	qt "github.com/frankban/quicktest"
 )
 
+const (
+	testEndpoint1 = "http://endpoint1.example.com"
+	testEndpoint2 = "http://endpoint2.example.com"
+	testEndpoint3 = "http://endpoint3.example.com"
+)
+
 // TestEndpointSwitchingOnFailure tests that when an endpoint fails,
 // the retry mechanism switches to the next available endpoint
 func TestEndpointSwitchingOnFailure(t *testing.T) {
@@ -17,9 +23,9 @@ func TestEndpointSwitchingOnFailure(t *testing.T) {
 
 	// Create a mock iterator with multiple endpoints
 	endpoints := []*Web3Endpoint{
-		{ChainID: 1, URI: "http://endpoint1.example.com"},
-		{ChainID: 1, URI: "http://endpoint2.example.com"},
-		{ChainID: 1, URI: "http://endpoint3.example.com"},
+		{ChainID: 1, URI: testEndpoint1},
+		{ChainID: 1, URI: testEndpoint2},
+		{ChainID: 1, URI: testEndpoint3},
 	}
 
 	pool.endpoints[1] = NewWeb3Iterator(endpoints...)
@@ -28,16 +34,16 @@ func TestEndpointSwitchingOnFailure(t *testing.T) {
 	c.Assert(pool.NumberOfEndpoints(1, true), qt.Equals, 3)
 
 	// Disable first endpoint
-	pool.DisableEndpoint(1, "http://endpoint1.example.com")
+	pool.DisableEndpoint(1, testEndpoint1)
 	c.Assert(pool.NumberOfEndpoints(1, true), qt.Equals, 2)
 	c.Assert(pool.NumberOfEndpoints(1, false), qt.Equals, 3)
 
 	// Disable second endpoint
-	pool.DisableEndpoint(1, "http://endpoint2.example.com")
+	pool.DisableEndpoint(1, testEndpoint2)
 	c.Assert(pool.NumberOfEndpoints(1, true), qt.Equals, 1)
 
 	// Disable third endpoint - should trigger reset
-	pool.DisableEndpoint(1, "http://endpoint3.example.com")
+	pool.DisableEndpoint(1, testEndpoint3)
 
 	// After disabling all endpoints, they should be reset to available
 	c.Assert(pool.NumberOfEndpoints(1, true), qt.Equals, 3)
@@ -50,8 +56,8 @@ func TestDisableNonExistentEndpoint(t *testing.T) {
 	pool := NewWeb3Pool()
 
 	endpoints := []*Web3Endpoint{
-		{ChainID: 1, URI: "http://endpoint1.example.com"},
-		{ChainID: 1, URI: "http://endpoint2.example.com"},
+		{ChainID: 1, URI: testEndpoint1},
+		{ChainID: 1, URI: testEndpoint2},
 	}
 
 	pool.endpoints[1] = NewWeb3Iterator(endpoints...)
@@ -63,7 +69,7 @@ func TestDisableNonExistentEndpoint(t *testing.T) {
 	c.Assert(pool.NumberOfEndpoints(1, true), qt.Equals, 2)
 
 	// Try to disable from a chainID that doesn't exist
-	pool.DisableEndpoint(999, "http://endpoint1.example.com")
+	pool.DisableEndpoint(999, testEndpoint1)
 
 	// Original chain should still have 2 endpoints
 	c.Assert(pool.NumberOfEndpoints(1, true), qt.Equals, 2)
@@ -73,9 +79,9 @@ func TestDisableNonExistentEndpoint(t *testing.T) {
 func TestIteratorRoundRobin(t *testing.T) {
 	c := qt.New(t)
 	endpoints := []*Web3Endpoint{
-		{ChainID: 1, URI: "http://endpoint1.example.com"},
-		{ChainID: 1, URI: "http://endpoint2.example.com"},
-		{ChainID: 1, URI: "http://endpoint3.example.com"},
+		{ChainID: 1, URI: testEndpoint1},
+		{ChainID: 1, URI: testEndpoint2},
+		{ChainID: 1, URI: testEndpoint3},
 	}
 
 	iter := NewWeb3Iterator(endpoints...)
@@ -83,29 +89,29 @@ func TestIteratorRoundRobin(t *testing.T) {
 	// Get endpoints in round-robin fashion
 	ep1, err := iter.Next()
 	c.Assert(err, qt.IsNil)
-	c.Assert(ep1.URI, qt.Equals, "http://endpoint1.example.com")
+	c.Assert(ep1.URI, qt.Equals, testEndpoint1)
 
 	ep2, err := iter.Next()
 	c.Assert(err, qt.IsNil)
-	c.Assert(ep2.URI, qt.Equals, "http://endpoint2.example.com")
+	c.Assert(ep2.URI, qt.Equals, testEndpoint2)
 
 	ep3, err := iter.Next()
 	c.Assert(err, qt.IsNil)
-	c.Assert(ep3.URI, qt.Equals, "http://endpoint3.example.com")
+	c.Assert(ep3.URI, qt.Equals, testEndpoint3)
 
 	// Should wrap around to first endpoint
 	ep4, err := iter.Next()
 	c.Assert(err, qt.IsNil)
-	c.Assert(ep4.URI, qt.Equals, "http://endpoint1.example.com")
+	c.Assert(ep4.URI, qt.Equals, testEndpoint1)
 }
 
 // TestIteratorDisableAndNext tests that disabling an endpoint properly updates the next index
 func TestIteratorDisableAndNext(t *testing.T) {
 	c := qt.New(t)
 	endpoints := []*Web3Endpoint{
-		{ChainID: 1, URI: "http://endpoint1.example.com"},
-		{ChainID: 1, URI: "http://endpoint2.example.com"},
-		{ChainID: 1, URI: "http://endpoint3.example.com"},
+		{ChainID: 1, URI: testEndpoint1},
+		{ChainID: 1, URI: testEndpoint2},
+		{ChainID: 1, URI: testEndpoint3},
 	}
 
 	iter := NewWeb3Iterator(endpoints...)
@@ -113,32 +119,32 @@ func TestIteratorDisableAndNext(t *testing.T) {
 	// Get first endpoint (nextIndex moves to 1, pointing to endpoint2)
 	ep1, err := iter.Next()
 	c.Assert(err, qt.IsNil)
-	c.Assert(ep1.URI, qt.Equals, "http://endpoint1.example.com")
+	c.Assert(ep1.URI, qt.Equals, testEndpoint1)
 
 	// Disable the second endpoint (at index 1, which is where nextIndex points)
 	// After removal: [endpoint1, endpoint3], nextIndex stays at 1 but gets decremented to 0
 	// because we removed an element before it
-	iter.Disable("http://endpoint2.example.com")
+	iter.Disable(testEndpoint2)
 
 	// Next should return endpoint1 (at index 0, since nextIndex was adjusted)
 	// Then nextIndex moves to 1
 	ep2, err := iter.Next()
 	c.Assert(err, qt.IsNil)
-	c.Assert(ep2.URI, qt.Equals, "http://endpoint1.example.com")
+	c.Assert(ep2.URI, qt.Equals, testEndpoint1)
 
 	// Next should return endpoint3 (at index 1)
 	ep3, err := iter.Next()
 	c.Assert(err, qt.IsNil)
-	c.Assert(ep3.URI, qt.Equals, "http://endpoint3.example.com")
+	c.Assert(ep3.URI, qt.Equals, testEndpoint3)
 }
 
 // TestIteratorDisableCurrentEndpoint tests disabling the current endpoint
 func TestIteratorDisableCurrentEndpoint(t *testing.T) {
 	c := qt.New(t)
 	endpoints := []*Web3Endpoint{
-		{ChainID: 1, URI: "http://endpoint1.example.com"},
-		{ChainID: 1, URI: "http://endpoint2.example.com"},
-		{ChainID: 1, URI: "http://endpoint3.example.com"},
+		{ChainID: 1, URI: testEndpoint1},
+		{ChainID: 1, URI: testEndpoint2},
+		{ChainID: 1, URI: testEndpoint3},
 	}
 
 	iter := NewWeb3Iterator(endpoints...)
@@ -153,7 +159,7 @@ func TestIteratorDisableCurrentEndpoint(t *testing.T) {
 	// Next should return endpoint2 (index 0 after removal, but nextIndex was adjusted)
 	ep2, err := iter.Next()
 	c.Assert(err, qt.IsNil)
-	c.Assert(ep2.URI, qt.Equals, "http://endpoint2.example.com")
+	c.Assert(ep2.URI, qt.Equals, testEndpoint2)
 }
 
 // TestIteratorEmptyPool tests behavior with no endpoints
@@ -171,17 +177,17 @@ func TestIteratorEmptyPool(t *testing.T) {
 func TestIteratorAllDisabled(t *testing.T) {
 	c := qt.New(t)
 	endpoints := []*Web3Endpoint{
-		{ChainID: 1, URI: "http://endpoint1.example.com"},
-		{ChainID: 1, URI: "http://endpoint2.example.com"},
+		{ChainID: 1, URI: testEndpoint1},
+		{ChainID: 1, URI: testEndpoint2},
 	}
 
 	iter := NewWeb3Iterator(endpoints...)
 
 	// Disable all endpoints
-	iter.Disable("http://endpoint1.example.com")
+	iter.Disable(testEndpoint1)
 	c.Assert(iter.Available(), qt.Equals, 1)
 
-	iter.Disable("http://endpoint2.example.com")
+	iter.Disable(testEndpoint2)
 
 	// Should have reset all to available
 	c.Assert(iter.Available(), qt.Equals, 2)
@@ -192,9 +198,9 @@ func TestIteratorAllDisabled(t *testing.T) {
 func TestConcurrentAccess(t *testing.T) {
 	c := qt.New(t)
 	endpoints := []*Web3Endpoint{
-		{ChainID: 1, URI: "http://endpoint1.example.com"},
-		{ChainID: 1, URI: "http://endpoint2.example.com"},
-		{ChainID: 1, URI: "http://endpoint3.example.com"},
+		{ChainID: 1, URI: testEndpoint1},
+		{ChainID: 1, URI: testEndpoint2},
+		{ChainID: 1, URI: testEndpoint3},
 	}
 
 	iter := NewWeb3Iterator(endpoints...)
@@ -214,7 +220,7 @@ func TestConcurrentAccess(t *testing.T) {
 	// Also disable endpoints concurrently
 	go func() {
 		for range 10 {
-			iter.Disable("http://endpoint1.example.com")
+			iter.Disable(testEndpoint1)
 			time.Sleep(time.Millisecond)
 		}
 		done <- true
@@ -235,8 +241,8 @@ func TestRetryLogic(t *testing.T) {
 	pool := NewWeb3Pool()
 
 	endpoints := []*Web3Endpoint{
-		{ChainID: 1, URI: "http://endpoint1.example.com"},
-		{ChainID: 1, URI: "http://endpoint2.example.com"},
+		{ChainID: 1, URI: testEndpoint1},
+		{ChainID: 1, URI: testEndpoint2},
 	}
 
 	pool.endpoints[1] = NewWeb3Iterator(endpoints...)
@@ -272,8 +278,8 @@ func TestRetryAllEndpointsFail(t *testing.T) {
 	pool := NewWeb3Pool()
 
 	endpoints := []*Web3Endpoint{
-		{ChainID: 1, URI: "http://endpoint1.example.com"},
-		{ChainID: 1, URI: "http://endpoint2.example.com"},
+		{ChainID: 1, URI: testEndpoint1},
+		{ChainID: 1, URI: testEndpoint2},
 	}
 
 	pool.endpoints[1] = NewWeb3Iterator(endpoints...)

--- a/workers/worker_manager_test.go
+++ b/workers/worker_manager_test.go
@@ -69,7 +69,7 @@ func TestWorkerIsBanned(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			worker := &Worker{
-				Address:          "test-worker",
+				Address:          testWorkerAddr,
 				consecutiveFails: int64(tt.consecutiveFails),
 			}
 
@@ -113,8 +113,8 @@ func TestWorkerManagerGetWorker(t *testing.T) {
 	c.Assert(exists, qt.IsFalse)
 
 	// Add a worker and test getting it
-	addedWorker := wm.AddWorker("test-worker", testWorkerName)
-	retrievedWorker, exists := wm.GetWorker("test-worker")
+	addedWorker := wm.AddWorker(testWorkerAddr, testWorkerName)
+	retrievedWorker, exists := wm.GetWorker(testWorkerAddr)
 	c.Assert(retrievedWorker, qt.IsNotNil)
 	c.Assert(exists, qt.IsTrue)
 	c.Assert(retrievedWorker, qt.Equals, addedWorker)
@@ -259,8 +259,8 @@ func TestWorkerManagerStartStop(t *testing.T) {
 	c.Assert(wm.cancelFunc, qt.IsNotNil)
 
 	// Add a worker to verify it exists
-	wm.AddWorker("test-worker", testWorkerName)
-	worker, exists := wm.GetWorker("test-worker")
+	wm.AddWorker(testWorkerAddr, testWorkerName)
+	worker, exists := wm.GetWorker(testWorkerAddr)
 	c.Assert(exists, qt.IsTrue)
 	c.Assert(worker, qt.IsNotNil)
 
@@ -268,7 +268,7 @@ func TestWorkerManagerStartStop(t *testing.T) {
 	wm.Stop()
 
 	// Verify workers are cleared
-	worker, exists = wm.GetWorker("test-worker")
+	worker, exists = wm.GetWorker(testWorkerAddr)
 	c.Assert(exists, qt.IsFalse)
 	c.Assert(worker, qt.IsNil)
 }
@@ -568,8 +568,8 @@ func TestWorkerManagerContextCancellation(t *testing.T) {
 	c.Assert(wm.innerCtx, qt.IsNotNil)
 
 	// Add a worker
-	wm.AddWorker("test-worker", testWorkerName)
-	_, exists := wm.GetWorker("test-worker")
+	wm.AddWorker(testWorkerAddr, testWorkerName)
+	_, exists := wm.GetWorker(testWorkerAddr)
 	c.Assert(exists, qt.IsTrue)
 
 	// Cancel context
@@ -579,7 +579,7 @@ func TestWorkerManagerContextCancellation(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	// Worker should be cleared because context cancellation calls stop() which clears workers
-	_, exists = wm.GetWorker("test-worker")
+	_, exists = wm.GetWorker(testWorkerAddr)
 	c.Assert(exists, qt.IsFalse)
 }
 

--- a/workers/worker_manager_time_ban_test.go
+++ b/workers/worker_manager_time_ban_test.go
@@ -18,7 +18,7 @@ func TestWorkerTimeBanCoverage(t *testing.T) {
 
 	t.Run("Time-based banning scenarios", func(t *testing.T) {
 		worker := &Worker{
-			Address:          "test-worker",
+			Address:          testWorkerAddr,
 			consecutiveFails: 0, // No consecutive fails
 		}
 
@@ -48,7 +48,7 @@ func TestWorkerTimeBanCoverage(t *testing.T) {
 	t.Run("Combined consecutive fails and time-based banning", func(t *testing.T) {
 		// Test worker that is banned by consecutive fails AND has a time-based ban
 		worker := &Worker{
-			Address:          "test-worker",
+			Address:          testWorkerAddr,
 			consecutiveFails: 5, // Above threshold
 		}
 
@@ -77,7 +77,7 @@ func TestWorkerTimeBanCoverage(t *testing.T) {
 
 	t.Run("Edge cases for time comparison", func(t *testing.T) {
 		worker := &Worker{
-			Address:          "test-worker",
+			Address:          testWorkerAddr,
 			consecutiveFails: 0,
 		}
 


### PR DESCRIPTION
Closes #441

## Summary

This PR fixes: **StateTransition is stuck because of a single "address not found in census"**

## Issue Description

```
2026-05-12T19:50:44.920Z DBG circuits/artifacts.go:575 > proof generated circuit=voteverifier took=1.892s
19:50:44 DBG verifier done backend=groth16 curve=bls12_377 took=1.707007
2026-05-12T19:50:44.921Z DBG circuits/artifacts.go:608 > proof verified circuit=voteverifier took=0.002s
2026-05-12T19:50:44.922Z INF sequencer/ballot.go:191 > vote verification proof generated address=0x9eab35260c4d613953dde4bc4641778951c9c148 processID=470d1ddc7ddceb0d818751d171d40366f010a3ccbd9bb82500000000000002 took=1.894s voteID=0xb3b55b42ca332c39
2026-05-12T19:50:44.985Z INF sequencer/ballot.go:94 > processing ballot address=0xa50a81e4bb9c1c6cfa36a216554243fc82616d38 processID=470d1ddc7ddceb0d818751d171d40366f010a3ccbd9bb82500000000000002 voteID=0xb3e580d713032a9a
2026-05-12T19:50:44.985Z DBG sequencer/helpers.go:54 > using current in-construction state currentRoot=4771891759905882140092194460988022897751274860967242414710763691207048428628 processID=470d1ddc7ddceb0d818751d171d40366f010a3ccbd9bb82500000000000002
2026-05-12T19:50:44.986Z DBG sequencer/statetransition.go:92 > state transition ready for processing ballotCount=60 processID=470d1ddc7ddceb0d818751d171d40366f010a3ccbd9bb82500000000000002
2026-05-12T19:50:45.047Z INF sequencer/statetransition.go:332 > votes reencrypted len(votes)=60 processID=470d1ddc7ddceb0d818751d171d40366f010a3ccbd9bb82500000000000002
2026-05-12T19:50:45.047Z WRN sequencer/statetransition.go:405 > census tree has no root? censusRoot=0x2505a232d4fe843f5ba3c6d4cb47ef1af36b35790af0ac4b6d6cfb362da1966d fetchedRoot=<nil>
2026-05-12T19:50:45.047Z ERR sequencer/statetransition.go:112 > failed to get census proofs error="error generating census proof for address 0xA0165188B5941A3B3025680611AA1636cea566c4: address not found in census"
2026-05-12T19:50:45.092Z DBG sequencer/ballot.go:178 > vote verifier inputs ready address=0xa50a81e4bb9c1c6cfa36a216554243fc82616d38 inputsHash=3080416453661017708391917452563110777829132339235139832444192921816718726271 processID=470d1ddc7ddceb0d818751d171d40366f010a3ccbd9bb82500000000000002 voteID=0xb3e580d713032a9a
2026-05-12T19:50:45.092Z DBG sequencer/ballot.go:185 > generating vote verification proof... processID=470d1ddc7ddceb0d818751d171d40366f010a3ccbd9bb82500000000000002 voteID=0xb3e580d713032a9a
```

First we should find why the address is not found in the census. Looks like an error on the sequencer side. 
Secondly, we should never reach this point, meaning that before aggregating the batch, we should be sure we have all data available to perform afterwards the state-transition. 

