### PR TITLE
fix census downloader identity and retry poisoning

### DIFF
--- a/census/importer.go
+++ b/census/importer.go
@@ -58,8 +58,17 @@ func (d *CensusImporter) ImportCensus(ctx context.Context, chainID uint64, censu
 		if census.CensusOrigin == types.CensusOriginMerkleTreeOnchainDynamicV1 && chainID == 0 {
 			return 0, fmt.Errorf("chain ID is required for dynamic on-chain census import")
 		}
-		// If the census already exists, skip the import.
-		if d.storage.CensusDB().ExistsByRoot(census.CensusRoot) {
+		// If the census already exists, skip the import. Dynamic on-chain
+		// censuses are scoped by chain+contract address instead of root.
+		if census.CensusOrigin == types.CensusOriginMerkleTreeOnchainDynamicV1 {
+			if d.storage.CensusDB().ExistsByScopedAddress(chainID, census.ContractAddress) {
+				log.Infow("scoped census already exists, skipping import",
+					"chainID", chainID,
+					"address", census.ContractAddress.Hex(),
+					"root", census.CensusRoot.String())
+				return processedElements, nil
+			}
+		} else if d.storage.CensusDB().ExistsByRoot(census.CensusRoot) {
 			log.Infow("census root already exists, skipping import",
 				"root", census.CensusRoot.String())
 			return processedElements, nil

--- a/service/census_service.go
+++ b/service/census_service.go
@@ -260,6 +260,12 @@ func (cd *CensusDownloader) OnCensusDownloaded(processID types.ProcessID, census
 			status, exists := cd.downloadCensusStatus(chainID, census)
 			if exists {
 				switch {
+				case status.Complete:
+					// If the census download is complete, clean up the pending
+					// status and call the callback with nil error.
+					cd.CleanUp(status.chainID, status.census)
+					callback(nil)
+					return
 				case status.Terminal && status.LastErr != nil:
 					// Return the last error if the downloader has reached a
 					// terminal error.
@@ -269,12 +275,6 @@ func (cd *CensusDownloader) OnCensusDownloaded(processID types.ProcessID, census
 					// Return the last error if the downloader has reached the
 					// maximum number of attempts.
 					callback(status.LastErr)
-					return
-				case status.Complete:
-					// If the census download is complete, clean up the pending
-					// status and call the callback with nil error.
-					cd.CleanUp(status.chainID, status.census)
-					callback(nil)
 					return
 				}
 			}
@@ -401,8 +401,11 @@ func (cd *CensusDownloader) addPendingCensus(icensus internalCensus) bool {
 	cd.mu.Lock()
 	defer cd.mu.Unlock()
 	key := censusKey(icensus.Census, icensus.ChainID)
-	if _, exists := cd.censusStatus[key]; exists {
-		return false
+	if status, exists := cd.censusStatus[key]; exists {
+		// Allow retrying a census after a previous terminal failure.
+		if !status.Terminal {
+			return false
+		}
 	}
 	cd.censusStatus[key] = DownloadStatus{
 		Attempts: 0,
@@ -456,6 +459,11 @@ func (cd *CensusDownloader) updateInternalStatus(icensus internalCensus, err err
 		status.Complete = err == nil
 		status.Terminal = isTerminalDownloadError(err)
 		status.Attempts++
+		if err == nil {
+			status.LastErr = nil
+			cd.censusStatus[key] = status
+			return
+		}
 		if status.Terminal {
 			status.LastErr = fmt.Errorf("terminal census download failure: %w", err)
 		} else if status.Attempts < cd.attempts() {
@@ -531,9 +539,6 @@ func (cd *CensusDownloader) cleanUpPendingCensuses() {
 
 	now := time.Now()
 	for _, status := range cd.censusStatus {
-		if status.Terminal {
-			continue
-		}
 		if status.lastUpdated.Add(cd.config.Expiration).Before(now) {
 			cd.cleanUpStatusUnsafe(status.chainID, status.census)
 		}


### PR DESCRIPTION
  ## Summary

  This PR fixes a census downloader/importer bug that could make valid voters appear ineligible when reusing the same censusRoot across processes/chains, and
  could keep that census key “poisoned” after a failure.

  ## Root Cause

  1. Dynamic on-chain censuses were treated as already imported using only censusRoot, but runtime lookup is chain-scoped by (chainID, contractAddress).
  2. Failed census statuses could remain sticky in downloader state, blocking re-queue/retry for future processes using the same key.

  ## Changes

  ### 1) Use scoped identity for dynamic census existence checks

  File: census/importer.go

  - For CensusOriginMerkleTreeOnchainDynamicV1, skip import only if ExistsByScopedAddress(chainID, contractAddress) is true.
  - Keep root-based skip (ExistsByRoot) for non-dynamic Merkle censuses.

  ### 2) Prevent stale error from overriding successful completion

  File: service/census_service.go

  - In OnCensusDownloaded, handle status.Complete before error branches.

  ### 3) Allow retry after terminal failures

  File: service/census_service.go

  - In addPendingCensus, if a status exists but is terminal, allow replacing it and re-queueing.

  ### 4) Clear stale errors on success

  File: service/census_service.go

  - In updateInternalStatus, when err == nil, clear LastErr.

  ### 5) Expire terminal statuses as well

  File: service/census_service.go

  - cleanUpPendingCensuses now cleans expired entries regardless of Terminal state.

  ## Impact

  - Reusing the same census/root across processes and chains no longer incorrectly blocks voting due to missing scoped census entries.
  - Previous terminal download failures no longer permanently poison future process attempts for that census key.

  ## Notes

  - No dependency changes.
  - No install/test execution was performed as requested; this PR is code-only.
