### PR TITLE
bug: multi processes census bug

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -159,6 +159,8 @@ func (a *API) registerHandlers() {
 	a.router.Get(ProcessesEndpoint, a.processList)
 	log.Infow("register handler", "endpoint", CensusParticipantEndpoint, "method", "GET")
 	a.router.Get(CensusParticipantEndpoint, a.processParticipant)
+	log.Infow("register handler", "endpoint", CensusParticipantsEndpoint, "method", "GET")
+	a.router.Get(CensusParticipantsEndpoint, a.processParticipants)
 	log.Infow("register handler", "endpoint", NewEncryptionKeysEndpoint, "method", "POST")
 	a.router.Post(NewEncryptionKeysEndpoint, a.processEncryptionKeys)
 

--- a/api/process.go
+++ b/api/process.go
@@ -229,3 +229,59 @@ func (a *API) processParticipant(w http.ResponseWriter, r *http.Request) {
 		Weight: (*types.BigInt)(weight),
 	})
 }
+
+// processParticipants retrieves information about all participants in a voting
+// GET /processes/{processId}/participants
+func (a *API) processParticipants(w http.ResponseWriter, r *http.Request) {
+	// Unmarshal the process ID from URL parameter
+	processID, err := types.HexStringToProcessID(chi.URLParam(r, ProcessURLParam))
+	if err != nil {
+		ErrMalformedProcessID.Withf("could not parse process ID: %v", err).Write(w)
+		return
+	}
+
+	// Load the process from storage
+	process, err := a.storage.Process(processID)
+	if err != nil {
+		if err == storage.ErrNotFound {
+			ErrProcessNotFound.Withf("could not retrieve process: %v", err).Write(w)
+			return
+		}
+		ErrGenericInternalServerError.Withf("could not retrieve process: %v", err).Write(w)
+		return
+	}
+
+	// Retrieve the participant info
+	runtime, err := a.runtimes.RuntimeForProcess(processID)
+	if err != nil {
+		ErrGenericInternalServerError.Withf("could not resolve process runtime: %v", err).Write(w)
+		return
+	}
+	censusRef, err := a.storage.LoadCensus(runtime.Contracts.ChainID, process.Census)
+	if err != nil {
+		ErrGenericInternalServerError.Withf("could not retrieve participant info: %v", err).Write(w)
+		return
+	}
+	if censusRef == nil {
+		ErrMalformedParam.With("census not compatible with local processing").Write(w)
+		return
+	}
+
+	// Get the participants weights
+	participants := []CensusParticipant{}
+	dump, err := censusRef.Tree().DumpAll()
+	if err != nil {
+		ErrGenericInternalServerError.Withf("could not get census participants: %v", err).Write(w)
+		return
+	}
+	for _, participant := range dump.Participants {
+		participants = append(participants, CensusParticipant{
+			Key:    participant.Address.Bytes(),
+			Weight: (*types.BigInt)(participant.Weight),
+		})
+	}
+	// Write the response
+	httpWriteJSON(w, map[string][]CensusParticipant{
+		"participants": participants,
+	})
+}

--- a/api/process.go
+++ b/api/process.go
@@ -230,7 +230,7 @@ func (a *API) processParticipant(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// processParticipants retrieves information about all participants in a voting
+// processParticipants retrieves information about all participants in a voting process
 // GET /processes/{processId}/participants
 func (a *API) processParticipants(w http.ResponseWriter, r *http.Request) {
 	// Unmarshal the process ID from URL parameter

--- a/api/routes.go
+++ b/api/routes.go
@@ -13,12 +13,13 @@ const (
 	PingEndpoint = "/ping" // Health check endpoint
 
 	// Process endpoints
-	ProcessURLParam           = "processId"                                                                   // URL parameter for process ID
-	AddressURLParam           = "address"                                                                     // URL parameter for address
-	ProcessesEndpoint         = "/processes"                                                                  // GET: List processes, POST: Create process
-	ProcessEndpoint           = "/processes/{" + ProcessURLParam + "}"                                        // GET: Get process info
-	CensusParticipantEndpoint = "/processes/{" + ProcessURLParam + "}/participants/{" + AddressURLParam + "}" // GET: Get participant info for a process
-	NewEncryptionKeysEndpoint = "/processes/keys"                                                             // POST: Create new encryption keys for a process
+	ProcessURLParam            = "processId"                                                                   // URL parameter for process ID
+	AddressURLParam            = "address"                                                                     // URL parameter for address
+	ProcessesEndpoint          = "/processes"                                                                  // GET: List processes, POST: Create process
+	ProcessEndpoint            = "/processes/{" + ProcessURLParam + "}"                                        // GET: Get process info
+	CensusParticipantsEndpoint = "/processes/{" + ProcessURLParam + "}/participants"                           // GET: Get all participants info for a process
+	CensusParticipantEndpoint  = "/processes/{" + ProcessURLParam + "}/participants/{" + AddressURLParam + "}" // GET: Get participant info for a process
+	NewEncryptionKeysEndpoint  = "/processes/keys"                                                             // POST: Create new encryption keys for a process
 
 	// Vote endpoints
 	VotesEndpoint = "/votes" // POST: Submit a vote

--- a/census/censusdb/censusdb.go
+++ b/census/censusdb/censusdb.go
@@ -785,6 +785,11 @@ func unpackSiblings(packed []byte) []*big.Int {
 // CensusRef and any error encountered during the process, such as decoding
 // errors or tree creation/import errors.
 func (c *CensusDB) Import(root types.HexBytes, reader io.Reader) (*CensusRef, error) {
+	// Early exit: census already exists in memory or persistent DB.
+	if c.ExistsByRoot(root) {
+		return c.LoadByRoot(root)
+	}
+
 	// Create a new census tree by its root
 	censusID := rootToCensusID(root.Bytes())
 	treeDB := prefixeddb.NewPrefixedDatabase(c.db, censusTreeDBPrefix(censusID))
@@ -799,8 +804,12 @@ func (c *CensusDB) Import(root types.HexBytes, reader io.Reader) (*CensusRef, er
 	if err := tree.Sync(); err != nil {
 		return nil, fmt.Errorf("failed to sync census tree after import: %w", err)
 	}
-	// Create a new CensusRef with the imported tree
-	return c.newCensus(censusID, rootDBPrefix(root), tree)
+	// Create or reuse a CensusRef with the imported tree.
+	ref, err := c.newCensus(censusID, rootDBPrefix(root), tree)
+	if errors.Is(err, ErrCensusAlreadyExists) {
+		return c.LoadByRoot(root)
+	}
+	return ref, err
 }
 
 // ImportByScopedAddress imports a census from a JSON-encoded census dump read
@@ -843,8 +852,17 @@ func (c *CensusDB) ImportAll(data []byte) (*CensusRef, error) {
 	if dump.Root == nil {
 		return nil, fmt.Errorf("census dump root is nil")
 	}
+
+	// Early exit: census already exists in memory or persistent DB.
+	// This prevents creating and resetting a shared Pebble tree that is
+	// already open by another goroutine.
+	censusRoot := dump.Root.Bytes()
+	if c.ExistsByRoot(censusRoot) {
+		return c.LoadByRoot(censusRoot)
+	}
+
 	// Create a new census tree by its root
-	censusID := rootToCensusID(dump.Root.Bytes())
+	censusID := rootToCensusID(censusRoot)
 	tree, err := census.NewCensusIMTWithPebble(
 		censusPrefix(censusID),
 		censusHasher,
@@ -856,8 +874,16 @@ func (c *CensusDB) ImportAll(data []byte) (*CensusRef, error) {
 	if err := tree.ImportAll(&dump); err != nil {
 		return nil, fmt.Errorf("failed to import census dump into tree: %w", err)
 	}
-	// Create a new CensusRef with the imported tree
-	return c.newCensus(censusID, rootDBPrefix(dump.Root.Bytes()), tree)
+	// Create or reuse a CensusRef with the imported tree. Under the CensusDB
+	// mutex, newCensus atomically checks for existence and creates the ref.
+	// If another goroutine raced past the ExistsByRoot check above, the
+	// ErrCensusAlreadyExists branch handles it safely.
+	ref, err := c.newCensus(censusID, rootDBPrefix(censusRoot), tree)
+	if errors.Is(err, ErrCensusAlreadyExists) {
+		_ = tree.Close()
+		return c.LoadByRoot(censusRoot)
+	}
+	return ref, err
 }
 
 // ImportAllByScopedAddress imports a JSON-encoded census dump and stores it


### PR DESCRIPTION
When two processes share the same census root, they share the same on-disk merkletree. If the second download races past the existence check, `resetPersistentState()` wipes the shared tree mid-flight, leaving the first process with an empty census. The fix gates on `ExistsByRoot` before ever opening the database, and catches the remaining race in `newCensus` by returning the existing ref instead of erroring. 

Also a new endpoint is included to show the participants of a process (based on its census).