### PR TITLE
fix(circuits): remove redundant std.RegisterHints()

### DIFF
--- a/circuits/statetransition/statetransition.go
+++ b/circuits/statetransition/statetransition.go
@@ -2,7 +2,6 @@ package statetransition
 
 import (
 	"github.com/consensys/gnark/frontend"
-	"github.com/consensys/gnark/std"
 	"github.com/consensys/gnark/std/algebra/emulated/sw_bn254"
 	"github.com/consensys/gnark/std/algebra/emulated/sw_bw6761"
 	"github.com/consensys/gnark/std/math/emulated"
@@ -117,7 +116,6 @@ func (v Vote) OverwrittenBallotLeafValues() []frontend.Variable {
 
 // Define declares the circuit's constraints
 func (circuit StateTransitionCircuit) Define(api frontend.API) error {
-	std.RegisterHints()
 	// compute the isRealVote for real votes
 	isRealVote := circuit.VoteMask(api)
 	// recursive proof

--- a/crypto/blobs/evaluation_test.go
+++ b/crypto/blobs/evaluation_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/consensys/gnark/backend/groth16"
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/cs/r1cs"
-	"github.com/consensys/gnark/std"
 	"github.com/consensys/gnark/std/math/emulated"
 	"github.com/consensys/gnark/test"
 	qt "github.com/frankban/quicktest"
@@ -67,7 +66,6 @@ func TestBlobEvaluationCircuitProgressive(t *testing.T) {
 	if os.Getenv("RUN_CIRCUIT_TESTS") == "" || os.Getenv("RUN_CIRCUIT_TESTS") == falseStr {
 		t.Skip("skipping circuit tests...")
 	}
-	std.RegisterHints()
 	c := qt.New(t)
 
 	testCounts := []int{10, 100}

--- a/crypto/blobs/testdata.go
+++ b/crypto/blobs/testdata.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/consensys/gnark/frontend"
-	"github.com/consensys/gnark/std"
 	"github.com/consensys/gnark/std/algebra/emulated/sw_bls12381"
 	"github.com/consensys/gnark/std/math/emulated"
 	"github.com/vocdoni/davinci-node/types"
@@ -54,7 +53,6 @@ type blobEvalCircuitBarycentricOnly struct {
 }
 
 func (c *blobEvalCircuitBarycentricOnly) Define(api frontend.API) error {
-	std.RegisterHints()
 	return VerifyBarycentricEvaluation(api, &c.Z, &c.Y, c.Blob)
 }
 
@@ -73,7 +71,6 @@ type blobEvalCircuitBN254 struct {
 }
 
 func (c *blobEvalCircuitBN254) Define(api frontend.API) error {
-	std.RegisterHints()
 	return VerifyFullBlobEvaluationBN254(
 		api,
 		c.ProcessID,


### PR DESCRIPTION
notably, a mere import "github.com/consensys/gnark/std" triggers a log spam
on every startup of e2e-test and davinci-sequencer.

`DBG function registered multiple times name=github.com/consensys/gnark/std/...`

all hints are registered during init of gnark anyway, no need to call std.RegisterHints()
