### PR TITLE
fix(sequencer): reduce log spam

### DIFF
--- a/circuits/statetransition/statetransition.go
+++ b/circuits/statetransition/statetransition.go
@@ -2,7 +2,6 @@ package statetransition
 
 import (
 	"github.com/consensys/gnark/frontend"
-	"github.com/consensys/gnark/std"
 	"github.com/consensys/gnark/std/algebra/emulated/sw_bn254"
 	"github.com/consensys/gnark/std/algebra/emulated/sw_bw6761"
 	"github.com/consensys/gnark/std/math/emulated"
@@ -117,7 +116,6 @@ func (v Vote) OverwrittenBallotLeafValues() []frontend.Variable {
 
 // Define declares the circuit's constraints
 func (circuit StateTransitionCircuit) Define(api frontend.API) error {
-	std.RegisterHints()
 	// compute the isRealVote for real votes
 	isRealVote := circuit.VoteMask(api)
 	// recursive proof

--- a/crypto/blobs/evaluation_test.go
+++ b/crypto/blobs/evaluation_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/consensys/gnark/backend/groth16"
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/cs/r1cs"
-	"github.com/consensys/gnark/std"
 	"github.com/consensys/gnark/std/math/emulated"
 	"github.com/consensys/gnark/test"
 	qt "github.com/frankban/quicktest"
@@ -67,7 +66,6 @@ func TestBlobEvaluationCircuitProgressive(t *testing.T) {
 	if os.Getenv("RUN_CIRCUIT_TESTS") == "" || os.Getenv("RUN_CIRCUIT_TESTS") == falseStr {
 		t.Skip("skipping circuit tests...")
 	}
-	std.RegisterHints()
 	c := qt.New(t)
 
 	testCounts := []int{10, 100}

--- a/crypto/blobs/testdata.go
+++ b/crypto/blobs/testdata.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/consensys/gnark/frontend"
-	"github.com/consensys/gnark/std"
 	"github.com/consensys/gnark/std/algebra/emulated/sw_bls12381"
 	"github.com/consensys/gnark/std/math/emulated"
 	"github.com/vocdoni/davinci-node/types"
@@ -54,7 +53,6 @@ type blobEvalCircuitBarycentricOnly struct {
 }
 
 func (c *blobEvalCircuitBarycentricOnly) Define(api frontend.API) error {
-	std.RegisterHints()
 	return VerifyBarycentricEvaluation(api, &c.Z, &c.Y, c.Blob)
 }
 
@@ -73,7 +71,6 @@ type blobEvalCircuitBN254 struct {
 }
 
 func (c *blobEvalCircuitBN254) Define(api frontend.API) error {
-	std.RegisterHints()
 	return VerifyFullBlobEvaluationBN254(
 		api,
 		c.ProcessID,

--- a/sequencer/processidmap.go
+++ b/sequencer/processidmap.go
@@ -57,7 +57,12 @@ func (p *ProcessIDMap) Remove(processID types.ProcessID) bool {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
+	if _, exists := p.data[processID]; !exists {
+		return false
+	}
+
 	delete(p.data, processID)
+	delete(p.firstBallotTimes, processID)
 	return true
 }
 

--- a/sequencer/processidmap_test.go
+++ b/sequencer/processidmap_test.go
@@ -28,6 +28,7 @@ func TestProcessIDMap(t *testing.T) {
 	// Test Remove
 	c.Assert(pidMap.Remove(pid1), qt.IsTrue, qt.Commentf("Should return true when removing an existing process ID"))
 	c.Assert(pidMap.Exists(pid1), qt.IsFalse, qt.Commentf("Should return false after removal"))
+	c.Assert(pidMap.Remove(pid1), qt.IsFalse, qt.Commentf("Should return false when removing a missing process ID"))
 
 	// Test ForEach
 	c.Assert(pidMap.Add(pid1), qt.IsTrue, qt.Commentf("Should return true when adding a new process ID"))

--- a/sequencer/statetransition.go
+++ b/sequencer/statetransition.go
@@ -52,8 +52,6 @@ func (s *Sequencer) processPendingTransitions() {
 		// work. The queued batch must remain available after the pending tx is
 		// confirmed or fails.
 		if s.stg.HasPendingTx(storage.StateTransitionTx, processID) {
-			log.Debugw("skipping state transition processing due to pending txs",
-				"processID", processID.String())
 			return true // Continue to next process ID
 		}
 

--- a/web3/process.go
+++ b/web3/process.go
@@ -137,36 +137,18 @@ func (c *Contracts) sendProcessTransition(processID types.ProcessID, proof, inpu
 	}
 
 	// Use transaction manager for automatic nonce management
-	var sentTx *gethtypes.Transaction
 	txID, txHash, err := c.txManager.SendTx(ctx, func(nonce uint64) (*gethtypes.Transaction, error) {
 		internalCtx, cancel := context.WithTimeout(context.Background(), web3WaitTimeout)
 		defer cancel()
 		// Build the transaction based on whether blobs are provided
 		switch blobsSidecar {
 		case nil: // Regular transaction
-			// No blobs so we dont not need to track sidecar, sentTx will be nil
 			return c.txManager.BuildDynamicFeeTx(internalCtx, c.ContractsAddresses.ProcessRegistry, data, nonce)
 		default: // Blob transaction
-			// Store tx in sentTx for tracking sidecar later
-			sentTx, err = c.NewEIP4844TransactionWithNonce(internalCtx, c.ContractsAddresses.ProcessRegistry,
+			return c.NewEIP4844TransactionWithNonce(internalCtx, c.ContractsAddresses.ProcessRegistry,
 				data, nonce, blobsSidecar)
-			return sentTx, err
 		}
 	})
-	// If blob transaction sent successfully, store sidecar for recovery
-	if err == nil && sentTx != nil && sentTx.BlobTxSidecar() != nil {
-		if err := c.txManager.TrackBlobTxWithSidecar(sentTx); err != nil {
-			log.Warnw("failed to track blob sidecar for recovery",
-				"error", err,
-				"hash", txHash.Hex(),
-				"txID", txID.String())
-		} else {
-			log.Infow("blob sidecar tracked for stuck transaction recovery",
-				"hash", txHash.Hex(),
-				"txID", txID.String(),
-				"blobCount", len(blobsSidecar.Blobs))
-		}
-	}
 	log.Infow("state transition submitted, wait to be mined",
 		"processID", processID.String())
 	return txID, txHash, err

--- a/web3/txmanager/txmanager_test.go
+++ b/web3/txmanager/txmanager_test.go
@@ -1,11 +1,16 @@
 package txmanager
 
 import (
+	"bytes"
 	"context"
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
+	gethtypes "github.com/ethereum/go-ethereum/core/types"
 	qt "github.com/frankban/quicktest"
+	"github.com/holiman/uint256"
+	"github.com/vocdoni/davinci-node/types"
 )
 
 func TestWaitTxByIDInvokesAllCallbacks(t *testing.T) {
@@ -45,4 +50,40 @@ func TestWaitTxByIDInvokesAllCallbacks(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("second callback was not called")
 	}
+}
+
+func TestTrackTxStoresBlobSidecarImmediately(t *testing.T) {
+	c := qt.New(t)
+
+	blobData := bytes.Repeat([]byte{0x01}, types.BlobLength)
+	blob := types.MustBlobFromBytes(blobData)
+	sidecar, err := types.ComputeBlobTxSidecar(types.BlobTxSidecarVersion0, []*types.Blob{blob})
+	c.Assert(err, qt.IsNil)
+
+	to := common.HexToAddress("0x0000000000000000000000000000000000000001")
+	tx := gethtypes.NewTx(&gethtypes.BlobTx{
+		ChainID:    uint256.NewInt(1),
+		Nonce:      7,
+		GasTipCap:  uint256.NewInt(1),
+		GasFeeCap:  uint256.NewInt(2),
+		Gas:        21000,
+		To:         to,
+		Value:      uint256.NewInt(0),
+		Data:       []byte("blob"),
+		BlobFeeCap: uint256.NewInt(3),
+		BlobHashes: sidecar.BlobHashes(),
+		Sidecar:    sidecar.AsGethSidecar(),
+	})
+
+	tm := &TxManager{
+		pendingTxs: make(map[uint64]*PendingTransaction),
+	}
+	tm.trackTx([]byte{0x01}, tx)
+
+	ptx := tm.pendingTxs[7]
+	c.Assert(ptx, qt.Not(qt.IsNil))
+	c.Assert(ptx.IsBlob, qt.IsTrue)
+	c.Assert(ptx.BlobSidecar, qt.Not(qt.IsNil))
+	c.Assert(ptx.BlobSidecar.Version, qt.Equals, sidecar.Version)
+	c.Assert(ptx.BlobSidecar.BlobHashes(), qt.DeepEquals, sidecar.BlobHashes())
 }

--- a/web3/txmanager/txsend.go
+++ b/web3/txmanager/txsend.go
@@ -79,33 +79,6 @@ func (tm *TxManager) SendTx(
 	return id, &hash, nil
 }
 
-// TrackBlobTxWithSidecar tracks a blob transaction with its sidecar for
-// potential recovery. This should be called immediately after sending a blob
-// transaction if recovery is desired.
-func (tm *TxManager) TrackBlobTxWithSidecar(tx *gethtypes.Transaction) error {
-	tm.mu.Lock()
-	defer tm.mu.Unlock()
-	if tx.Type() != gethtypes.BlobTxType {
-		return fmt.Errorf("transaction is not a blob transaction")
-	}
-	// Check if transaction is already tracked
-	ptx, exists := tm.pendingTxs[tx.Nonce()]
-	if !exists {
-		return fmt.Errorf("transaction not tracked, call SendTransactionWithFallback first")
-	}
-	// Update with sidecar
-	sidecar := tx.BlobTxSidecar()
-	if sidecar == nil {
-		return fmt.Errorf("transaction has no blob sidecar")
-	}
-	ptx.BlobSidecar = types.NewBlobTxSidecarFromGeth(sidecar)
-	log.Infow("blob transaction sidecar stored for recovery",
-		"nonce", tx.Nonce(),
-		"hash", tx.Hash().Hex(),
-		"blobCount", len(sidecar.Blobs))
-	return nil
-}
-
 // trackTx adds a transaction to the pending list for tracking and potential
 // recovery. It extracts necessary information from the transaction and stores
 // it in the pending transactions map.
@@ -128,15 +101,16 @@ func (tm *TxManager) trackTx(id []byte, tx *gethtypes.Transaction) {
 		ptx.OriginalGasPrice = tx.GasFeeCap()
 		ptx.OriginalBlobFee = tx.BlobGasFeeCap()
 		ptx.BlobHashes = tx.BlobHashes()
-		// NOTE: Cannot extract sidecar from transaction after creation due
-		// to unexported fields in go-ethereum. Blob sidecars must be stored
-		// separately via TrackBlobTxWithSidecar() to enable recovery.
-		// WARNING: Without the sidecar, stuck blob transactions CANNOT be
-		// recovered (they cannot be cancelled like regular txs, only replaced
-		// with same blob data).
-		log.Debugw("tracking blob transaction (sidecar not stored - recovery not possible)",
-			"nonce", tx.Nonce(),
-			"blobCount", len(tx.BlobHashes()))
+		if sidecar := tx.BlobTxSidecar(); sidecar != nil {
+			ptx.BlobSidecar = types.NewBlobTxSidecarFromGeth(sidecar)
+			log.Debugw("tracking blob transaction with sidecar",
+				"nonce", tx.Nonce(),
+				"blobCount", len(sidecar.Blobs))
+		} else {
+			log.Warnw("tracking blob transaction without sidecar; recovery not possible",
+				"nonce", tx.Nonce(),
+				"blobCount", len(ptx.BlobHashes))
+		}
 	case gethtypes.DynamicFeeTxType:
 		ptx.OriginalGasPrice = tx.GasFeeCap()
 	case gethtypes.LegacyTxType:


### PR DESCRIPTION
ProcessIDMap.Remove now returns false when the ID was never
registered, so the periodic monitor no longer logs unregister events
for processes that were never tracked.

Added a regression test covering removal of a missing process ID.
