### PR TITLE
fix(web3): derive blob slot from execution time

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -176,7 +176,6 @@ require (
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/holiman/billy v0.0.0-20250707135307-f2f9b9aae7db // indirect
 	github.com/holiman/bloomfilter/v2 v2.0.3 // indirect
-	github.com/huandu/go-clone v1.6.0 // indirect
 	github.com/huin/goupnp v1.3.0 // indirect
 	github.com/iden3/go-rapidsnark/types v0.0.3 // indirect
 	github.com/iden3/wasmer-go v0.0.1 // indirect
@@ -255,7 +254,6 @@ require (
 	github.com/pion/stun/v2 v2.0.0 // indirect
 	github.com/pion/transport/v2 v2.2.10 // indirect
 	github.com/pion/transport/v3 v3.0.7 // indirect
-	github.com/pk910/dynamic-ssz v0.0.4 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
@@ -265,7 +263,6 @@ require (
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
-	github.com/r3labs/sse/v2 v2.10.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/ronanh/intcomp v1.1.1 // indirect
@@ -345,8 +342,6 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260226221140-a57be14db171 // indirect
 	google.golang.org/grpc v1.79.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
-	gopkg.in/Knetic/govaluate.v3 v3.0.0 // indirect
-	gopkg.in/cenkalti/backoff.v1 v1.1.0 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -586,8 +586,6 @@ github.com/holiman/bloomfilter/v2 v2.0.3/go.mod h1:zpoh+gs7qcpqrHr3dB55AMiJwo0iU
 github.com/holiman/uint256 v1.3.2 h1:a9EgMPSC1AAaj1SZL5zIQD3WbwTuHrMGOerLjGmM/TA=
 github.com/holiman/uint256 v1.3.2/go.mod h1:EOMSn4q6Nyt9P6efbI3bueV4e1b3dGlUCXeiRV4ng7E=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/huandu/go-assert v1.1.5 h1:fjemmA7sSfYHJD7CUqs9qTwwfdNAx7/j2/ZlHXzNB3c=
-github.com/huandu/go-assert v1.1.5/go.mod h1:yOLvuqZwmcHIC5rIzrBhT7D3Q9c3GFnd0JrPVhn/06U=
 github.com/huandu/go-clone v1.6.0 h1:HMo5uvg4wgfiy5FoGOqlFLQED/VGRm2D9Pi8g1FXPGc=
 github.com/huandu/go-clone v1.6.0/go.mod h1:ReGivhG6op3GYr+UY3lS6mxjKp7MIGTknuU5TbTVaXE=
 github.com/huandu/go-clone/generic v1.6.0 h1:Wgmt/fUZ28r16F2Y3APotFD59sHk1p78K0XLdbUYN5U=
@@ -901,8 +899,6 @@ github.com/pion/transport/v2 v2.2.10/go.mod h1:sq1kSLWs+cHW9E+2fJP95QudkzbK7wscs
 github.com/pion/transport/v3 v3.0.1/go.mod h1:UY7kiITrlMv7/IKgd5eTUcaahZx5oUN3l9SzK5f5xE0=
 github.com/pion/transport/v3 v3.0.7 h1:iRbMH05BzSNwhILHoBoAPxoB9xQgOaJk+591KC9P1o0=
 github.com/pion/transport/v3 v3.0.7/go.mod h1:YleKiTZ4vqNxVwh77Z0zytYi7rXHl7j6uPLGhhz9rwo=
-github.com/pk910/dynamic-ssz v0.0.4 h1:DT29+1055tCEPCaR4V/ez+MOKW7BzBsmjyFvBRqx0ME=
-github.com/pk910/dynamic-ssz v0.0.4/go.mod h1:b6CrLaB2X7pYA+OSEEbkgXDEcRnjLOZIxZTsMuO/Y9c=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -944,8 +940,6 @@ github.com/prometheus/procfs v0.20.1 h1:XwbrGOIplXW/AU3YhIhLODXMJYyC1isLFfYCsTEy
 github.com/prometheus/procfs v0.20.1/go.mod h1:o9EMBZGRyvDrSPH1RqdxhojkuXstoe4UlK79eF5TGGo=
 github.com/prysmaticlabs/gohashtree v0.0.4-beta h1:H/EbCuXPeTV3lpKeXGPpEV9gsUpkqOOVnWapUyeWro4=
 github.com/prysmaticlabs/gohashtree v0.0.4-beta/go.mod h1:BFdtALS+Ffhg3lGQIHv9HDWuHS8cTvHZzrHWxwOtGOs=
-github.com/r3labs/sse/v2 v2.10.0 h1:hFEkLLFY4LDifoHdiCN/LlGBAdVJYsANaLqNYa1l/v0=
-github.com/r3labs/sse/v2 v2.10.0/go.mod h1:Igau6Whc+F17QUgML1fYe1VPZzTV6EMCnYktEmkNJ7I=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
@@ -1269,7 +1263,6 @@ golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190724013045-ca1201d0de80/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20191116160921-f9c825593386/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -1624,12 +1617,8 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
-gopkg.in/Knetic/govaluate.v3 v3.0.0 h1:18mUyIt4ZlRlFZAAfVetz4/rzlJs9yhN+U02F4u1AOc=
-gopkg.in/Knetic/govaluate.v3 v3.0.0/go.mod h1:csKLBORsPbafmSCGTEh3U7Ozmsuq8ZSIlKk1bcqph0E=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
-gopkg.in/cenkalti/backoff.v1 v1.1.0 h1:Arh75ttbsvlpVA7WtVpH4u9h6Zl46xuptxqLxPiSo4Y=
-gopkg.in/cenkalti/backoff.v1 v1.1.0/go.mod h1:J6Vskwqd+OMVJl8C33mmtxTBs2gyzfv7UDAkHu8BrjI=
 gopkg.in/cenkalti/backoff.v2 v2.2.1 h1:eJ9UAg01/HIHG987TwxvnzK2MgxXq97YY6rYDpY9aII=
 gopkg.in/cenkalti/backoff.v2 v2.2.1/go.mod h1:S0QdOvT2AlerfSBkp0O+dk+bbIMaNbEmVk876gPCthU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/web3/blobs.go
+++ b/web3/blobs.go
@@ -6,21 +6,16 @@ import (
 	"fmt"
 	"math/big"
 	"slices"
-	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	gethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/holiman/uint256"
-	"github.com/rs/zerolog"
 	"github.com/vocdoni/davinci-node/log"
 	"github.com/vocdoni/davinci-node/types"
+	"github.com/vocdoni/davinci-node/web3/rpc"
 	"github.com/vocdoni/davinci-node/web3/txmanager"
-
-	eth2client "github.com/attestantio/go-eth2-client"
-	eth2api "github.com/attestantio/go-eth2-client/api"
-	eth2http "github.com/attestantio/go-eth2-client/http"
 )
 
 const (
@@ -186,49 +181,6 @@ func (c *Contracts) TransactionAndBlockHeader(ctx context.Context, txHash common
 	return tx, blockHeader, nil
 }
 
-// BlobSidecarsOfBlock returns the blob sidecars stored in consensus layer,
-// of a block identified by a parentBeaconRoot
-func (c *Contracts) BlobSidecarsOfBlock(ctx context.Context, parentBeaconRoot *common.Hash) ([]*types.BlobSidecar, error) {
-	// CL: Beacon client
-	bc, err := eth2http.New(ctx,
-		eth2http.WithAddress(strings.TrimRight(c.Web3ConsensusAPIEndpoint, "/")),
-		eth2http.WithLogLevel(zerolog.DebugLevel), // zerolog.TraceLevel is useful for debugging
-	)
-	if err != nil {
-		return nil, fmt.Errorf("beacon client: %w", err)
-	}
-
-	// CL: resolve parent root -> parent slot
-	// Block IDs can be roots, slots, or keywords; use the root string directly.
-	var parentSlot uint64
-	if provider, isProvider := bc.(eth2client.BeaconBlockHeadersProvider); isProvider {
-		headers, err := provider.BeaconBlockHeader(ctx, &eth2api.BeaconBlockHeaderOpts{
-			Block: parentBeaconRoot.Hex(),
-		})
-		if err != nil {
-			return nil, fmt.Errorf("beacon headers(%s): %w", parentBeaconRoot, err)
-		}
-		parentSlot = uint64(headers.Data.Header.Message.Slot)
-	}
-	slot := parentSlot + 1 // slot of our EL block
-
-	// CL: fetch blob sidecars for that slot
-	var sidecars []*types.BlobSidecar
-	if provider, isProvider := bc.(eth2client.BlobSidecarsProvider); isProvider {
-		resp, err := provider.BlobSidecars(ctx, &eth2api.BlobSidecarsOpts{
-			Block: fmt.Sprintf("%d", slot),
-		})
-		if err != nil {
-			return nil, fmt.Errorf("blob sidecars(slot=%d): %w", slot, err)
-		}
-		for _, sc := range resp.Data {
-			sidecars = append(sidecars, types.NewBlobSidecarFromDeneb(sc))
-		}
-	}
-
-	return sidecars, nil
-}
-
 // BlobsByTxHash returns all the blobs sidecars of a tx, given a `txHash`.
 func (c *Contracts) BlobsByTxHash(
 	ctx context.Context,
@@ -236,13 +188,15 @@ func (c *Contracts) BlobsByTxHash(
 ) ([]*types.BlobSidecar, error) {
 	tx, blockHeader, err := c.TransactionAndBlockHeader(ctx, txHash)
 	if err != nil {
-		return nil, fmt.Errorf("tx parent beacon root: %w", err)
+		return nil, fmt.Errorf("transaction and block header: %w", err)
 	}
 	if tx.Type() != gethtypes.BlobTxType {
 		return nil, fmt.Errorf("not a blob tx (type=%d)", tx.Type())
 	}
-	if blockHeader.ParentBeaconRoot == nil {
-		return nil, fmt.Errorf("parent beacon root missing (EL client too old?)")
+
+	slot, err := c.beaconSlotFromBlockTime(blockHeader.Time)
+	if err != nil {
+		return nil, fmt.Errorf("derive beacon slot from block time: %w", err)
 	}
 
 	var sidecars []*types.BlobSidecar
@@ -255,7 +209,7 @@ func (c *Contracts) BlobsByTxHash(
 			case <-time.After(sleep):
 			}
 		}
-		sidecars, err = c.BlobSidecarsOfBlock(ctx, blockHeader.ParentBeaconRoot)
+		sidecars, err = c.blobSidecarsAtSlot(ctx, slot)
 		if err == nil {
 			break
 		}
@@ -274,4 +228,62 @@ func (c *Contracts) BlobsByTxHash(
 		}
 	}
 	return blobs, nil
+}
+
+func (c *Contracts) beaconSlotFromBlockTime(blockTime uint64) (uint64, error) {
+	if c.Web3ConsensusAPIEndpoint == "" {
+		return 0, fmt.Errorf("consensus API endpoint is empty")
+	}
+	if c.beaconSlotSeconds == 0 {
+		return 0, fmt.Errorf("beacon timing not initialized")
+	}
+
+	genesisUnix := c.beaconGenesisUnix
+	if blockTime < genesisUnix {
+		return 0, fmt.Errorf("block time %d is before beacon genesis time %d", blockTime, genesisUnix)
+	}
+
+	deltaSeconds := blockTime - genesisUnix
+	if deltaSeconds%c.beaconSlotSeconds != 0 {
+		return 0, fmt.Errorf(
+			"block time %d does not align with beacon slots (genesis=%d, slotSeconds=%d)",
+			blockTime,
+			genesisUnix,
+			c.beaconSlotSeconds,
+		)
+	}
+
+	slot := deltaSeconds / c.beaconSlotSeconds
+	log.Debugw("derived beacon slot from execution block time",
+		"blockTime", blockTime,
+		"genesisTime", genesisUnix,
+		"slotSeconds", c.beaconSlotSeconds,
+		"slot", slot,
+	)
+
+	return slot, nil
+}
+
+func (c *Contracts) blobSidecarsAtSlot(ctx context.Context, slot uint64) ([]*types.BlobSidecar, error) {
+	if c.Web3ConsensusAPIEndpoint == "" {
+		return nil, fmt.Errorf("consensus API endpoint is empty")
+	}
+	if c.beaconSlotSeconds == 0 {
+		return nil, fmt.Errorf("beacon timing not initialized")
+	}
+
+	resp, err := rpc.BeaconBlobSidecars(ctx, c.Web3ConsensusAPIEndpoint, slot)
+	if err != nil {
+		return nil, fmt.Errorf("blob sidecars(slot=%d): %w", slot, err)
+	}
+
+	sidecars := make([]*types.BlobSidecar, 0, len(resp))
+	for _, sc := range resp {
+		if sc == nil {
+			continue
+		}
+		sidecars = append(sidecars, types.NewBlobSidecarFromDeneb(sc))
+	}
+
+	return sidecars, nil
 }

--- a/web3/blobs_test.go
+++ b/web3/blobs_test.go
@@ -1,0 +1,302 @@
+package web3
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/attestantio/go-eth2-client/api/v1"
+	"github.com/attestantio/go-eth2-client/spec/deneb"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/ethereum/go-ethereum/common"
+	gethtypes "github.com/ethereum/go-ethereum/core/types"
+	qt "github.com/frankban/quicktest"
+	"github.com/holiman/uint256"
+	"github.com/vocdoni/davinci-node/types"
+	"github.com/vocdoni/davinci-node/web3/rpc"
+)
+
+const (
+	testRPCMethodChainID                        = "eth_chainId"
+	testRPCMethodGetBlockByNumber               = "eth_getBlockByNumber"
+	testRPCMethodGetBlockTransactionCountByHash = "eth_getBlockTransactionCountByHash"
+)
+
+func TestBlobsByTxHashUsesExecutionBlockTimeSlot(t *testing.T) {
+	c := qt.New(t)
+
+	const (
+		chainID       = uint64(1)
+		executionSlot = uint64(102)
+	)
+
+	genesisTime := time.Unix(1_700_000_000, 0).UTC()
+	slotDuration := 12 * time.Second
+	executionTime := genesisTime.Add(time.Duration(executionSlot) * slotDuration)
+	executionBlockTime := uint64(executionTime.Unix())
+
+	parentBeaconRoot := common.HexToHash("0x1111111111111111111111111111111111111111111111111111111111111111")
+	executionBlockHash := common.HexToHash("0x2222222222222222222222222222222222222222222222222222222222222222")
+	parentHash := common.HexToHash("0x3333333333333333333333333333333333333333333333333333333333333333")
+
+	var blobCommitment deneb.KZGCommitment
+	blobCommitmentHash := types.KZGCommitment(blobCommitment)
+	blobHashBytes := blobCommitmentHash.CalcBlobHashV1(sha256.New())
+	blobHash := common.BytesToHash(blobHashBytes[:])
+
+	tx := gethtypes.NewTx(&gethtypes.BlobTx{
+		ChainID:    uint256.NewInt(chainID),
+		Nonce:      7,
+		GasTipCap:  uint256.NewInt(1),
+		GasFeeCap:  uint256.NewInt(2),
+		Gas:        21000,
+		To:         common.HexToAddress("0x4444444444444444444444444444444444444444"),
+		Value:      uint256.NewInt(0),
+		Data:       []byte{},
+		BlobFeeCap: uint256.NewInt(1),
+		BlobHashes: []common.Hash{blobHash},
+		V:          uint256.NewInt(0),
+		R:          uint256.NewInt(1),
+		S:          uint256.NewInt(1),
+	})
+	txJSON, err := json.Marshal(tx)
+	c.Assert(err, qt.IsNil)
+	txHash := tx.Hash()
+
+	executionHeader := newTestHeader(parentHash, 102, executionBlockTime, &parentBeaconRoot)
+	executionHeaderJSON := mustJSONMap(c, executionHeader)
+	executionBlockJSON := mustJSONMap(c, executionHeader)
+	executionBlockJSON["transactions"] = []any{}
+
+	var proof deneb.KZGCommitmentInclusionProof
+	sidecar := &deneb.BlobSidecar{
+		Index:         0,
+		Blob:          deneb.Blob{},
+		KZGCommitment: blobCommitment,
+		KZGProof:      deneb.KZGProof{},
+		SignedBlockHeader: &phase0.SignedBeaconBlockHeader{
+			Message: &phase0.BeaconBlockHeader{
+				Slot:          phase0.Slot(executionSlot),
+				ProposerIndex: 0,
+				ParentRoot:    phase0.Root{},
+				StateRoot:     phase0.Root{},
+				BodyRoot:      phase0.Root{},
+			},
+			Signature: phase0.BLSSignature{},
+		},
+		KZGCommitmentInclusionProof: proof,
+	}
+	sidecarJSON := mustJSON(c, sidecar)
+
+	var requestedSlotsMu sync.Mutex
+	requestedSlots := make([]uint64, 0, 1)
+	var countsMu sync.Mutex
+	genesisCalls := 0
+	specCalls := 0
+	sidecarCalls := 0
+
+	beaconSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/eth/v1/config/spec":
+			countsMu.Lock()
+			specCalls++
+			countsMu.Unlock()
+			writeTestJSON(w, http.StatusOK, map[string]any{
+				"data": map[string]any{
+					"SECONDS_PER_SLOT": "12",
+				},
+			})
+		case r.URL.Path == "/eth/v1/beacon/genesis":
+			countsMu.Lock()
+			genesisCalls++
+			countsMu.Unlock()
+			writeTestJSON(w, http.StatusOK, map[string]any{
+				"data": &v1.Genesis{
+					GenesisTime:           genesisTime,
+					GenesisValidatorsRoot: phase0.Root{},
+					GenesisForkVersion:    phase0.Version{},
+				},
+			})
+		case strings.HasPrefix(r.URL.Path, "/eth/v1/beacon/blob_sidecars/"):
+			countsMu.Lock()
+			sidecarCalls++
+			countsMu.Unlock()
+			slotStr := strings.TrimPrefix(r.URL.Path, "/eth/v1/beacon/blob_sidecars/")
+			slot, err := strconv.ParseUint(slotStr, 10, 64)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+
+			requestedSlotsMu.Lock()
+			requestedSlots = append(requestedSlots, slot)
+			requestedSlotsMu.Unlock()
+
+			if slot != executionSlot {
+				http.NotFound(w, r)
+				return
+			}
+
+			writeTestJSON(w, http.StatusOK, map[string]any{
+				"data": []json.RawMessage{json.RawMessage(sidecarJSON)},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	c.Cleanup(beaconSrv.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	elSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			_ = r.Body.Close()
+		}()
+
+		var req testRPCRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		resp := testRPCResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+		}
+
+		switch req.Method {
+		case testRPCMethodChainID:
+			resp.Result = "0x1"
+		case testRPCMethodGetBlockByNumber:
+			resp.Result = executionBlockJSON
+		case testRPCMethodGetBlockTransactionCountByHash:
+			resp.Result = "0x0"
+		case "eth_getTransactionReceipt":
+			resp.Result = map[string]any{
+				"blockHash":         executionBlockHash.Hex(),
+				"blockNumber":       "0x66",
+				"contractAddress":   nil,
+				"cumulativeGasUsed": "0x5208",
+				"effectiveGasPrice": "0x1",
+				"from":              common.Address{}.Hex(),
+				"gasUsed":           "0x5208",
+				"logs":              []any{},
+				"logsBloom":         "0x" + strings.Repeat("0", 512),
+				"status":            "0x1",
+				"to":                common.Address{}.Hex(),
+				"transactionHash":   txHash.Hex(),
+				"transactionIndex":  "0x0",
+				"type":              "0x3",
+			}
+		case "eth_getTransactionByHash":
+			resp.Result = json.RawMessage(txJSON)
+		case "eth_getBlockByHash":
+			resp.Result = executionHeaderJSON
+		default:
+			resp.Error = &testRPCError{
+				Code:    -32601,
+				Message: "method not found",
+			}
+		}
+
+		writeTestJSON(w, http.StatusOK, resp)
+	}))
+	c.Cleanup(elSrv.Close)
+
+	pool := rpc.NewWeb3Pool()
+	addedChainID, err := pool.AddEndpoint(elSrv.URL)
+	c.Assert(err, qt.IsNil)
+	c.Assert(addedChainID, qt.Equals, chainID)
+
+	cli, err := pool.Client(addedChainID)
+	c.Assert(err, qt.IsNil)
+
+	contracts := &Contracts{
+		ChainID:                  addedChainID,
+		web3pool:                 pool,
+		cli:                      cli,
+		Web3ConsensusAPIEndpoint: beaconSrv.URL,
+		supportForBlobTxs:        true,
+	}
+	c.Assert(contracts.initBeaconTiming(ctx), qt.IsNil)
+
+	sidecars, err := contracts.BlobsByTxHash(ctx, txHash)
+	c.Assert(err, qt.IsNil)
+	c.Assert(sidecars, qt.HasLen, 1)
+	c.Assert(sidecars[0].VersionedBlobHash(), qt.Equals, blobHash)
+
+	sidecars, err = contracts.BlobsByTxHash(ctx, txHash)
+	c.Assert(err, qt.IsNil)
+	c.Assert(sidecars, qt.HasLen, 1)
+	c.Assert(sidecars[0].VersionedBlobHash(), qt.Equals, blobHash)
+
+	requestedSlotsMu.Lock()
+	defer requestedSlotsMu.Unlock()
+	c.Assert(requestedSlots, qt.DeepEquals, []uint64{executionSlot, executionSlot})
+
+	countsMu.Lock()
+	defer countsMu.Unlock()
+	c.Assert(genesisCalls, qt.Equals, 1)
+	c.Assert(specCalls, qt.Equals, 1)
+	c.Assert(sidecarCalls, qt.Equals, 2)
+}
+
+func newTestHeader(parentHash common.Hash, number uint64, blockTime uint64, parentBeaconRoot *common.Hash) *gethtypes.Header {
+	header := &gethtypes.Header{
+		ParentHash:  parentHash,
+		UncleHash:   gethtypes.EmptyUncleHash,
+		Coinbase:    common.Address{},
+		Root:        common.Hash{},
+		TxHash:      gethtypes.EmptyTxsHash,
+		ReceiptHash: gethtypes.EmptyReceiptsHash,
+		Bloom:       gethtypes.Bloom{},
+		Difficulty:  big.NewInt(0),
+		Number:      new(big.Int).SetUint64(number),
+		GasLimit:    30_000_000,
+		GasUsed:     0,
+		Time:        blockTime,
+		Extra:       []byte{},
+		MixDigest:   common.Hash{},
+		Nonce:       gethtypes.BlockNonce{},
+		BaseFee:     big.NewInt(0),
+	}
+
+	if parentBeaconRoot != nil {
+		header.ParentBeaconRoot = parentBeaconRoot
+	}
+
+	blobGasUsed := uint64(0)
+	excessBlobGas := uint64(0)
+	header.BlobGasUsed = &blobGasUsed
+	header.ExcessBlobGas = &excessBlobGas
+
+	return header
+}
+
+func mustJSONMap(c *qt.C, value any) map[string]any {
+	raw := mustJSON(c, value)
+	var out map[string]any
+	c.Assert(json.Unmarshal(raw, &out), qt.IsNil)
+	return out
+}
+
+func mustJSON(c *qt.C, value any) []byte {
+	raw, err := json.Marshal(value)
+	c.Assert(err, qt.IsNil)
+	return raw
+}
+
+func writeTestJSON(w http.ResponseWriter, status int, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(value)
+}

--- a/web3/contracts.go
+++ b/web3/contracts.go
@@ -108,6 +108,9 @@ type Contracts struct {
 	txManager *txmanager.TxManager
 	// Whether the current contracts support blob transactions
 	supportForBlobTxs bool
+
+	beaconGenesisUnix uint64
+	beaconSlotSeconds uint64
 }
 
 // New creates a new Contracts instance with the given web3 endpoints.
@@ -298,6 +301,47 @@ func (c *Contracts) LoadContracts(addresses *Addresses) error {
 	if err != nil {
 		log.Warnw("failed to check blob transaction support, defaulting to false", "error", err)
 	}
+
+	if err := c.initBeaconTiming(context.Background()); err != nil {
+		log.Warnw("failed to initialize beacon timing, blob fetching (and thus statesync) will not work",
+			"error", err,
+			"consensusAPI", c.Web3ConsensusAPIEndpoint,
+		)
+	}
+	return nil
+}
+
+func (c *Contracts) initBeaconTiming(ctx context.Context) error {
+	if c.Web3ConsensusAPIEndpoint == "" {
+		return nil
+	}
+	if c.beaconSlotSeconds != 0 {
+		return nil
+	}
+	if !c.supportForBlobTxs {
+		return nil
+	}
+
+	genesisUnix, slotDuration, err := rpc.BeaconTiming(ctx, c.Web3ConsensusAPIEndpoint)
+	if err != nil {
+		return fmt.Errorf("beacon timing: %w", err)
+	}
+	if slotDuration <= 0 {
+		return fmt.Errorf("invalid beacon slot duration %s", slotDuration)
+	}
+	if slotDuration%time.Second != 0 {
+		return fmt.Errorf("beacon slot duration must be a whole number of seconds, got %s", slotDuration)
+	}
+
+	c.beaconGenesisUnix = genesisUnix
+	c.beaconSlotSeconds = uint64(slotDuration / time.Second)
+
+	log.Debugw("initialized beacon timing",
+		"endpoint", c.Web3ConsensusAPIEndpoint,
+		"genesisUnix", c.beaconGenesisUnix,
+		"slotSeconds", c.beaconSlotSeconds,
+	)
+
 	return nil
 }
 

--- a/web3/contracts_test.go
+++ b/web3/contracts_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
@@ -16,14 +17,16 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	qt "github.com/frankban/quicktest"
 	npbindings "github.com/vocdoni/davinci-contracts/golang-types"
+	"github.com/vocdoni/davinci-node/config"
 	"github.com/vocdoni/davinci-node/internal/testutil"
 	"github.com/vocdoni/davinci-node/types"
 	"github.com/vocdoni/davinci-node/web3/rpc"
 )
 
 type testRPCRequest struct {
-	ID     json.RawMessage `json:"id"`
-	Method string          `json:"method"`
+	ID     json.RawMessage   `json:"id"`
+	Method string            `json:"method"`
+	Params []json.RawMessage `json:"params"`
 }
 
 type testRPCResponse struct {
@@ -232,6 +235,56 @@ func TestMonitoredProcessRegistry(t *testing.T) {
 	})
 }
 
+func TestLoadContractsContinuesWhenBeaconTimingFails(t *testing.T) {
+	c := qt.New(t)
+
+	oldTransport := http.DefaultTransport
+	http.DefaultTransport = testRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Host {
+		case "web3.test":
+			return handleTestWeb3RPC(req)
+		case "beacon.test":
+			return &http.Response{
+				StatusCode: http.StatusServiceUnavailable,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader("beacon unavailable")),
+				Request:    req,
+			}, nil
+		default:
+			return &http.Response{
+				StatusCode: http.StatusNotFound,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader("not found")),
+				Request:    req,
+			}, nil
+		}
+	})
+	c.Cleanup(func() {
+		http.DefaultTransport = oldTransport
+	})
+
+	pool := rpc.NewWeb3Pool()
+	chainID, err := pool.AddEndpoint("http://web3.test")
+	c.Assert(err, qt.IsNil)
+
+	client, err := pool.Client(chainID)
+	c.Assert(err, qt.IsNil)
+
+	contracts := &Contracts{
+		ChainID:                  chainID,
+		web3pool:                 pool,
+		cli:                      client,
+		Web3ConsensusAPIEndpoint: "http://beacon.test",
+	}
+
+	err = contracts.LoadContracts(nil)
+	c.Assert(err, qt.IsNil)
+	c.Assert(contracts.SupportBlobTxs(), qt.IsTrue)
+	c.Assert(contracts.beaconSlotSeconds, qt.Equals, uint64(0))
+	c.Assert(contracts.ContractsAddresses, qt.Not(qt.IsNil))
+	c.Assert(contracts.processes, qt.Not(qt.IsNil))
+}
+
 func (b *testProcessRegistryBackend) CodeAt(context.Context, common.Address, *big.Int) ([]byte, error) {
 	return []byte{0x1}, nil
 }
@@ -272,6 +325,94 @@ func testContractsForReceipt(c *qt.C, txHash common.Hash, receiptStatus uint64) 
 		ChainID:  chainID,
 		web3pool: pool,
 		cli:      client,
+	}
+}
+
+type testRoundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f testRoundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func handleTestWeb3RPC(req *http.Request) (*http.Response, error) {
+	defer func() {
+		_ = req.Body.Close()
+	}()
+
+	var rpcReq testRPCRequest
+	if err := json.NewDecoder(req.Body).Decode(&rpcReq); err != nil {
+		return nil, err
+	}
+
+	resp := testRPCResponse{
+		JSONRPC: "2.0",
+		ID:      rpcReq.ID,
+	}
+
+	switch rpcReq.Method {
+	case "eth_chainId":
+		resp.Result = "0x1"
+	case "eth_blockNumber":
+		resp.Result = "0x2"
+	case "eth_getBlockByNumber":
+		resp.Result = map[string]any{
+			"hash":         common.HexToHash("0x1111").Hex(),
+			"number":       "0x1",
+			"transactions": []any{},
+		}
+	case "eth_getBlockTransactionCountByHash":
+		resp.Result = "0x0"
+	case "eth_getCode":
+		resp.Result = "0x60006000"
+	case "eth_call":
+		if len(rpcReq.Params) == 0 {
+			resp.Result = "0x"
+			break
+		}
+		var callMsg struct {
+			To    string `json:"to"`
+			Data  string `json:"data"`
+			Input string `json:"input"`
+		}
+		if err := json.Unmarshal(rpcReq.Params[0], &callMsg); err != nil {
+			return nil, err
+		}
+		callData := callMsg.Data
+		if callData == "" {
+			callData = callMsg.Input
+		}
+		switch {
+		case strings.HasPrefix(strings.ToLower(callData), "0xcdf497c8"):
+			resp.Result = common.BigToHash(big.NewInt(1)).Hex()
+		case strings.HasPrefix(strings.ToLower(callData), "0x4c0acc56"):
+			resp.Result = common.BytesToHash(types.HexStringToHexBytesMustUnmarshal(config.StateTransitionProvingKeyHash)).Hex()
+		case strings.HasPrefix(strings.ToLower(callData), "0xf9aa4499"):
+			resp.Result = common.BytesToHash(types.HexStringToHexBytesMustUnmarshal(config.ResultsVerifierProvingKeyHash)).Hex()
+		default:
+			resp.Result = "0x"
+		}
+	default:
+		resp.Result = "0x"
+	}
+
+	return jsonResponse(req, resp), nil
+}
+
+func jsonResponse(req *http.Request, value any) *http.Response {
+	body, err := json.Marshal(value)
+	if err != nil {
+		return &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(err.Error())),
+			Request:    req,
+		}
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(string(body))),
+		Request:    req,
 	}
 }
 

--- a/web3/rpc/beacon.go
+++ b/web3/rpc/beacon.go
@@ -10,12 +10,18 @@ import (
 	"strings"
 	"time"
 
+	"github.com/attestantio/go-eth2-client/api/v1"
+	"github.com/attestantio/go-eth2-client/spec/deneb"
 	"github.com/vocdoni/davinci-node/log"
 )
 
 const (
 	// beaconConfigSpecPath is the Beacon API endpoint path to retrieve chain spec configuration.
 	beaconConfigSpecPath = "/eth/v1/config/spec"
+	// beaconGenesisPath is the Beacon API endpoint path to retrieve genesis information.
+	beaconGenesisPath = "/eth/v1/beacon/genesis"
+	// beaconBlobSidecarsPath is the Beacon API endpoint path to retrieve blob sidecars by slot.
+	beaconBlobSidecarsPath = "/eth/v1/beacon/blob_sidecars/%d"
 	// beaconConfigTimeout is the timeout for beacon API HTTP requests.
 	beaconConfigTimeout = 10 * time.Second
 )
@@ -30,41 +36,60 @@ type beaconSpecData struct {
 	DepositNetworkID string `json:"DEPOSIT_NETWORK_ID"`
 }
 
-// BeaconChainID is the context-aware variant of BeaconChainID. It sends a
-// GET request to the Beacon API /eth/v1/config/spec endpoint and extracts the
-// chain ID from the DEPOSIT_NETWORK_ID field.
-func BeaconChainID(ctx context.Context, beaconEndpoint string) (uint64, error) {
+type beaconGenesisResponse struct {
+	Data *v1.Genesis `json:"data"`
+}
+
+type beaconBlobSidecarsResponse struct {
+	Data []*deneb.BlobSidecar `json:"data"`
+}
+
+func fetchBeaconEndpoint(ctx context.Context, beaconEndpoint, endpointPath string) ([]byte, string, error) {
 	if beaconEndpoint == "" {
-		return 0, fmt.Errorf("beacon endpoint URL is empty")
+		return nil, "", fmt.Errorf("beacon endpoint URL is empty")
 	}
 
-	// Normalise the endpoint URL: strip trailing slash before appending the path.
 	base := strings.TrimRight(beaconEndpoint, "/")
-	url := base + beaconConfigSpecPath
+	url := base + endpointPath
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return 0, fmt.Errorf("create beacon spec request: %w", err)
+		return nil, "", fmt.Errorf("create beacon request: %w", err)
 	}
 
 	client := &http.Client{Timeout: beaconConfigTimeout}
 	resp, err := client.Do(req)
 	if err != nil {
-		return 0, fmt.Errorf("fetch beacon spec from %s: %w", url, err)
+		return nil, "", fmt.Errorf("fetch beacon endpoint %s: %w", url, err)
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			log.Debugw("error closing beacon spec response body", "url", url, "error", cerr)
+			log.Debugw("error closing beacon response body", "url", url, "error", cerr)
 		}
 	}()
 
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return 0, fmt.Errorf("beacon spec returned status %d from %s: %s", resp.StatusCode, url, strings.TrimSpace(string(body)))
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, "", fmt.Errorf("read beacon response from %s: %w", url, err)
 	}
 
+	if resp.StatusCode != http.StatusOK {
+		return nil, "", fmt.Errorf("beacon endpoint returned status %d from %s: %s", resp.StatusCode, url, strings.TrimSpace(string(body)))
+	}
+
+	return body, url, nil
+}
+
+// BeaconChainID is the context-aware variant of BeaconChainID. It sends a
+// GET request to the Beacon API /eth/v1/config/spec endpoint and extracts the
+// chain ID from the DEPOSIT_NETWORK_ID field.
+func BeaconChainID(ctx context.Context, beaconEndpoint string) (uint64, error) {
+	body, url, err := fetchBeaconEndpoint(ctx, beaconEndpoint, beaconConfigSpecPath)
+	if err != nil {
+		return 0, err
+	}
 	var specResp beaconSpecResponse
-	if err := json.NewDecoder(resp.Body).Decode(&specResp); err != nil {
+	if err := json.Unmarshal(body, &specResp); err != nil {
 		return 0, fmt.Errorf("decode beacon spec response from %s: %w", url, err)
 	}
 
@@ -87,4 +112,65 @@ func BeaconChainID(ctx context.Context, beaconEndpoint string) (uint64, error) {
 		"chainID", chainID)
 
 	return chainID, nil
+}
+
+// BeaconTiming returns the beacon genesis time and slot duration for the chain.
+func BeaconTiming(ctx context.Context, beaconEndpoint string) (uint64, time.Duration, error) {
+	genesisBody, genesisURL, err := fetchBeaconEndpoint(ctx, beaconEndpoint, beaconGenesisPath)
+	if err != nil {
+		return 0, 0, err
+	}
+	var genesisResp beaconGenesisResponse
+	if err := json.Unmarshal(genesisBody, &genesisResp); err != nil {
+		return 0, 0, fmt.Errorf("decode beacon genesis response from %s: %w", genesisURL, err)
+	}
+	if genesisResp.Data == nil {
+		return 0, 0, fmt.Errorf("beacon genesis response from %s contains no data", genesisURL)
+	}
+
+	specBody, specURL, err := fetchBeaconEndpoint(ctx, beaconEndpoint, beaconConfigSpecPath)
+	if err != nil {
+		return 0, 0, err
+	}
+	var specResp struct {
+		Data struct {
+			SecondsPerSlot string `json:"SECONDS_PER_SLOT"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(specBody, &specResp); err != nil {
+		return 0, 0, fmt.Errorf("decode beacon spec response from %s: %w", specURL, err)
+	}
+
+	if specResp.Data.SecondsPerSlot == "" {
+		return 0, 0, fmt.Errorf("beacon spec response from %s missing SECONDS_PER_SLOT", specURL)
+	}
+	slotSeconds, err := strconv.ParseInt(specResp.Data.SecondsPerSlot, 10, 64)
+	if err != nil {
+		return 0, 0, fmt.Errorf("parse SECONDS_PER_SLOT %q from %s: %w", specResp.Data.SecondsPerSlot, specURL, err)
+	}
+	if slotSeconds <= 0 {
+		return 0, 0, fmt.Errorf("beacon spec response from %s has non-positive SECONDS_PER_SLOT %q", specURL, specResp.Data.SecondsPerSlot)
+	}
+
+	genesisUnix := genesisResp.Data.GenesisTime.Unix()
+	if genesisUnix < 0 {
+		return 0, 0, fmt.Errorf("beacon genesis time is before unix epoch: %s", genesisResp.Data.GenesisTime)
+	}
+
+	return uint64(genesisUnix), time.Duration(slotSeconds) * time.Second, nil
+}
+
+// BeaconBlobSidecars returns the blob sidecars stored in the beacon API for a slot.
+func BeaconBlobSidecars(ctx context.Context, beaconEndpoint string, slot uint64) ([]*deneb.BlobSidecar, error) {
+	body, url, err := fetchBeaconEndpoint(ctx, beaconEndpoint, fmt.Sprintf(beaconBlobSidecarsPath, slot))
+	if err != nil {
+		return nil, err
+	}
+
+	var resp beaconBlobSidecarsResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("decode beacon blob sidecars response from %s: %w", url, err)
+	}
+
+	return resp.Data, nil
 }

--- a/web3/rpc/beacon_test.go
+++ b/web3/rpc/beacon_test.go
@@ -4,10 +4,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/attestantio/go-eth2-client/api/v1"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	qt "github.com/frankban/quicktest"
 )
 
@@ -21,10 +26,10 @@ type testBeaconSpecData struct {
 }
 
 // testBeaconSpecServer creates a test HTTP server that responds to
-// /eth/v1/config/spec with the given chain ID.
+// beaconConfigSpecPath with the given chain ID.
 func testBeaconSpecServer(chainID uint64) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/eth/v1/config/spec" {
+		if r.URL.Path != beaconConfigSpecPath {
 			http.NotFound(w, r)
 			return
 		}
@@ -80,6 +85,107 @@ func TestBeaconChainID(t *testing.T) {
 		qt.Assert(t, err, qt.Not(qt.IsNil))
 		qt.Assert(t, err.Error(), qt.Contains, "empty")
 	})
+}
+
+func TestBeaconTimingRejectsOversizedSlotSeconds(t *testing.T) {
+	c := qt.New(t)
+	genesisTime := time.Unix(1_700_000_000, 0).UTC()
+	genesisBody, err := json.Marshal(map[string]any{
+		"data": &v1.Genesis{
+			GenesisTime:           genesisTime,
+			GenesisValidatorsRoot: phase0.Root{},
+			GenesisForkVersion:    phase0.Version{},
+		},
+	})
+	c.Assert(err, qt.IsNil)
+
+	oldTransport := http.DefaultTransport
+	http.DefaultTransport = roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		var body string
+		switch req.URL.Path {
+		case "/eth/v1/beacon/genesis":
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(string(genesisBody))),
+				Request:    req,
+			}, nil
+		case beaconConfigSpecPath:
+			body = `{"data":{"SECONDS_PER_SLOT":"9223372036854775808"}}`
+		default:
+			return &http.Response{
+				StatusCode: http.StatusNotFound,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader("not found")),
+				Request:    req,
+			}, nil
+		}
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Request:    req,
+		}, nil
+	})
+	c.Cleanup(func() {
+		http.DefaultTransport = oldTransport
+	})
+
+	_, _, err = BeaconTiming(t.Context(), "http://beacon.test")
+	c.Assert(err, qt.Not(qt.IsNil))
+	c.Assert(err.Error(), qt.Contains, "parse SECONDS_PER_SLOT")
+}
+
+func TestBeaconTimingIgnoresBlobScheduleArrays(t *testing.T) {
+	c := qt.New(t)
+	genesisTime := time.Unix(1_700_000_000, 0).UTC()
+	genesisBody, err := json.Marshal(map[string]any{
+		"data": &v1.Genesis{
+			GenesisTime:           genesisTime,
+			GenesisValidatorsRoot: phase0.Root{},
+			GenesisForkVersion:    phase0.Version{},
+		},
+	})
+	c.Assert(err, qt.IsNil)
+
+	oldTransport := http.DefaultTransport
+	http.DefaultTransport = roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		var body string
+		switch req.URL.Path {
+		case "/eth/v1/beacon/genesis":
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(string(genesisBody))),
+				Request:    req,
+			}, nil
+		case beaconConfigSpecPath:
+			body = `{"data":{"SECONDS_PER_SLOT":"12","BLOB_SCHEDULE":[{"EPOCH":"269568","MAX_BLOBS_PER_BLOCK":"6"}]}}`
+		default:
+			return &http.Response{
+				StatusCode: http.StatusNotFound,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader("not found")),
+				Request:    req,
+			}, nil
+		}
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Request:    req,
+		}, nil
+	})
+	c.Cleanup(func() {
+		http.DefaultTransport = oldTransport
+	})
+
+	genesisUnix, slotDuration, err := BeaconTiming(t.Context(), "http://beacon.test")
+	c.Assert(err, qt.IsNil)
+	c.Assert(genesisUnix, qt.Equals, uint64(genesisTime.Unix()))
+	c.Assert(slotDuration, qt.Equals, 12*time.Second)
 }
 
 func TestBeaconChainIDErrors(t *testing.T) {
@@ -179,4 +285,10 @@ func TestBeaconChainIDErrors(t *testing.T) {
 		_, err := BeaconChainID(cancelCtx, srv.URL)
 		c.Assert(err, qt.Not(qt.IsNil))
 	})
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
 }


### PR DESCRIPTION
Compute the beacon slot from the execution block timestamp and beacon\ngenesis/spec data instead of assuming parentSlot + 1. This keeps blob\nlookup deterministic across missed beacon slots and preserves the\nexisting versioned-hash filtering for the transaction blobs.\n\nAdd a regression test that simulates a missed slot and verifies the\nclient queries the correct beacon slot for the mined execution block.
