### PR TITLE
fix(sequencer): handle statetransition races in multi-sequencer setup

### DIFF
--- a/sequencer/helpers.go
+++ b/sequencer/helpers.go
@@ -50,3 +50,26 @@ func (s *Sequencer) currentProcessState(processID types.ProcessID) (*state.State
 
 	return st, nil
 }
+
+// remoteStateRoot returns the current on-chain state root for a process.
+// It prefers the finalizer's injected getter when available, and falls back to
+// resolving the process contracts directly.
+func (s *Sequencer) remoteStateRoot(processID types.ProcessID) (*types.BigInt, error) {
+	if s.finalizer != nil && s.finalizer.getStateRoot != nil {
+		root, err := s.finalizer.getStateRoot(processID)
+		if err != nil {
+			return nil, err
+		}
+		return root, nil
+	}
+
+	contracts, err := s.contractsForProcess(processID)
+	if err != nil {
+		return nil, err
+	}
+	root, err := contracts.StateRoot(processID)
+	if err != nil {
+		return nil, err
+	}
+	return root, nil
+}

--- a/sequencer/onchain.go
+++ b/sequencer/onchain.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"strings"
 	"time"
 
 	"github.com/vocdoni/davinci-node/log"
@@ -26,6 +27,8 @@ const (
 	// Maximum number of retries for uploading verified results
 	maxResultsUploadRetries = 3
 )
+
+var errStateTransitionBatchOutdated = errors.New("state transition batch outdated")
 
 // startOnchainProcessor starts the on-chain processor that periodically
 // processes state transitions and verified results to be uploaded to the
@@ -115,6 +118,15 @@ func (s *Sequencer) processTransitionOnChain() {
 
 		// send the proof to the contract with the public witness
 		if err := s.pushTransitionToContract(contracts, processID, batchID, solidityCommitmentProof, batch.Inputs, batch.BlobSidecar); err != nil {
+			if errors.Is(err, errStateTransitionBatchOutdated) {
+				log.Warnw("process state transition simulation failed with invalid state root, marking batch outdated",
+					"processID", processID.String(),
+					"batchID", fmt.Sprintf("%x", batchID))
+				if err := s.stg.MarkStateTransitionBatchOutdated(batchID); err != nil {
+					log.Errorw(err, "failed to mark state transition batch as outdated")
+				}
+				return true
+			}
 			log.Errorw(err, "failed to push to contract")
 			if err := s.stg.MarkStateTransitionBatchFailed(batchID, processID); err != nil {
 				log.Errorw(err, "failed to mark state transition batch as failed")
@@ -179,6 +191,9 @@ func (s *Sequencer) pushTransitionToContract(
 
 	// Simulate tx to the contract to check if it will fail
 	if err := contracts.SimulateProcessTransition(s.ctx, processID, abiProof, abiInputs, blobSidecar); err != nil {
+		if reason, ok := contracts.DecodeError(err); ok && strings.Contains(reason, "InvalidStateRoot") {
+			return errStateTransitionBatchOutdated
+		}
 		log.Warnw("process state transition simulation failed",
 			"processID", processID.String(),
 			"error", err)
@@ -216,10 +231,9 @@ func (s *Sequencer) pushStateTransitionCallback(processID types.ProcessID, batch
 			}
 			log.Infow("pending tx released", "processID", processID.String())
 		}()
-		// If there was an error, log it and mark the batch as failed
+		// If there was an error, log it and handle recovery
 		if err != nil {
-			log.Errorf("failed to wait for state transition of %s: %s", processID.String(), err)
-			// Use MarkStateTransitionBatchFailed for consistent recovery logic
+			log.Errorw(err, fmt.Sprintf("failed to wait for state transition of %s", processID.String()))
 			if err := s.stg.MarkStateTransitionBatchFailed(batchID, processID); err != nil {
 				log.Warnw("failed to mark state transition batch as failed after callback error",
 					"error", err, "processID", processID.String())

--- a/sequencer/statetransition.go
+++ b/sequencer/statetransition.go
@@ -75,11 +75,48 @@ func (s *Sequencer) processPendingTransitions() {
 		defer s.workInProgressLock.Unlock()
 		startTime := time.Now()
 
+		// Check the remote state root after reserving a batch.
+		// If another sequencer has settled a transition, our local state root is
+		// stale and the proof would be invalid, so we release the reservation and
+		// let the next tick retry once the local state has caught up.
+		remoteRoot, err := s.remoteStateRoot(processID)
+		if err != nil {
+			log.Errorw(err, "failed to get remote state root")
+			if releaseErr := s.stg.ReleaseAggregatorBatchReservation(batchID); releaseErr != nil {
+				log.Errorw(releaseErr, "failed to release reserved aggregator batch")
+			}
+			return true // Continue to next process ID
+		}
+		if remoteRoot == nil {
+			log.Warnw("remote state root is nil", "processID", processID.String())
+			if releaseErr := s.stg.ReleaseAggregatorBatchReservation(batchID); releaseErr != nil {
+				log.Errorw(releaseErr, "failed to release reserved aggregator batch")
+			}
+			return true // Continue to next process ID
+		}
+
 		// Initialize the process state (use current in-construction state)
 		processState, err := s.currentProcessState(processID)
 		if err != nil {
 			log.Errorw(err, "failed to load process state")
 			s.markAggregatorBatchFailed(batchID)
+			return true // Continue to next process ID
+		}
+		localRoot, err := processState.RootAsBigInt()
+		if err != nil {
+			log.Errorw(err, "failed to get local state root")
+			s.markAggregatorBatchFailed(batchID)
+			return true // Continue to next process ID
+		}
+		localRootBI := new(types.BigInt).SetBigInt(localRoot)
+		if !remoteRoot.Equal(localRootBI) {
+			log.Warnw("state root mismatch detected before proof generation, releasing reserved batch",
+				"processID", processID.String(),
+				"localRoot", localRootBI.HexBytes().String(),
+				"remoteRoot", remoteRoot.HexBytes().String())
+			if releaseErr := s.stg.ReleaseAggregatorBatchReservation(batchID); releaseErr != nil {
+				log.Errorw(releaseErr, "failed to release reserved aggregator batch")
+			}
 			return true // Continue to next process ID
 		}
 

--- a/sequencer/statetransition_test.go
+++ b/sequencer/statetransition_test.go
@@ -71,6 +71,48 @@ func TestProcessPendingTransitionsDoesNotReserveAggregatorBatchWhenTransitionTxP
 	c.Assert(stg.MarkAggregatorBatchDone(batchID), qt.IsNil)
 }
 
+func TestProcessPendingTransitionsReleasesAggregatorBatchOnStateRootMismatch(t *testing.T) {
+	c := qt.New(t)
+	stg := newTestSequencerStorage(t)
+	defer stg.Close()
+
+	processID := testutil.RandomProcessID()
+	ensureSequencerTestProcess(t, stg, processID)
+
+	batch := &storage.AggregatorBallotBatch{
+		ProcessID: processID,
+		Ballots: []*storage.AggregatorBallot{
+			{VoteID: testutil.RandomVoteID()},
+		},
+	}
+	c.Assert(stg.PushAggregatorBatch(batch), qt.IsNil)
+
+	seq := &Sequencer{
+		stg: stg,
+		contractsResolver: &testContractsResolver{
+			contractsByProcess: map[types.ProcessID]*web3.Contracts{
+				processID: {},
+			},
+		},
+		finalizer: &finalizer{
+			getStateRoot: func(types.ProcessID) (*types.BigInt, error) {
+				return new(types.BigInt).SetBigInt(big.NewInt(999)), nil
+			},
+		},
+		processIDs: NewProcessIDMap(),
+	}
+	c.Assert(seq.processIDs.Add(processID), qt.IsTrue)
+
+	seq.processPendingTransitions()
+
+	got, batchID, err := stg.NextAggregatorBatch(processID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(got, qt.Not(qt.IsNil))
+	c.Assert(got.Ballots, qt.HasLen, 1)
+	c.Assert(got.Ballots[0].VoteID, qt.Equals, batch.Ballots[0].VoteID)
+	c.Assert(stg.MarkAggregatorBatchDone(batchID), qt.IsNil)
+}
+
 func TestProcessStateTransitionBatchRollsBackRootOnAssignmentError(t *testing.T) {
 	c := qt.New(t)
 

--- a/storage/ballots_batches.go
+++ b/storage/ballots_batches.go
@@ -592,6 +592,15 @@ func (s *Storage) MarkStateTransitionBatchOutdated(key []byte) error {
 	return nil
 }
 
+// ReleaseAggregatorBatchReservation removes the reservation for an aggregated
+// ballot batch without deleting the batch itself. This allows the batch to be
+// picked up again on a later processing tick.
+func (s *Storage) ReleaseAggregatorBatchReservation(k []byte) error {
+	s.globalLock.Lock()
+	defer s.globalLock.Unlock()
+	return s.releaseAggregatorBatchReservation(k)
+}
+
 // MarkStateTransitionBatchFailed marks a state transition batch as failed,
 // sets all ballots in the batch to error status, removes the reservation,
 // and deletes the batch from the state transition queue. This is typically

--- a/storage/ballots_batches_test.go
+++ b/storage/ballots_batches_test.go
@@ -93,6 +93,36 @@ func TestBallotQueue_MarkBallotBatchFailed(t *testing.T) {
 	}
 }
 
+func TestReleaseAggregatorBatchReservationMakesBatchAvailableAgain(t *testing.T) {
+	c := qt.New(t)
+	stg := newTestStorage(t)
+	defer stg.Close()
+
+	processID := testutil.RandomProcessID()
+	ensureProcess(t, stg, processID)
+
+	batch := &AggregatorBallotBatch{
+		ProcessID: processID,
+		Ballots: []*AggregatorBallot{
+			mkAggBallot(testutil.RandomVoteID()),
+		},
+	}
+	c.Assert(stg.PushAggregatorBatch(batch), qt.IsNil)
+
+	retrievedBatch, batchID, err := stg.NextAggregatorBatch(processID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(retrievedBatch, qt.Not(qt.IsNil))
+	c.Assert(stg.ReleaseAggregatorBatchReservation(batchID), qt.IsNil)
+
+	requeuedBatch, requeuedID, err := stg.NextAggregatorBatch(processID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(requeuedBatch, qt.Not(qt.IsNil))
+	c.Assert(requeuedBatch.ProcessID, qt.Equals, processID)
+	c.Assert(requeuedBatch.Ballots, qt.HasLen, 1)
+	c.Assert(requeuedBatch.Ballots[0].VoteID, qt.Equals, batch.Ballots[0].VoteID)
+	c.Assert(stg.MarkAggregatorBatchDone(requeuedID), qt.IsNil)
+}
+
 func TestBallotQueue_RemoveStateTransitionBatchesByProcess(t *testing.T) {
 	c := qt.New(t)
 	stg := newTestStorage(t)

--- a/web3/contracts_test.go
+++ b/web3/contracts_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	qt "github.com/frankban/quicktest"
 	npbindings "github.com/vocdoni/davinci-contracts/golang-types"
 	"github.com/vocdoni/davinci-node/config"
@@ -86,6 +87,32 @@ func TestWaitTxByHashReturnsOnRevert(t *testing.T) {
 	c.Assert(err, qt.Not(qt.IsNil))
 	c.Assert(err.Error(), qt.Contains, "reverted")
 	c.Assert(time.Since(start) < 1500*time.Millisecond, qt.IsTrue)
+}
+
+func TestDecodeErrorInvalidStateRoot(t *testing.T) {
+	c := qt.New(t)
+
+	invalidStateRoot, ok := processRegistryABI.Errors["InvalidStateRoot"]
+	c.Assert(ok, qt.IsTrue)
+
+	contracts := &Contracts{
+		ContractABIs: &ContractABIs{
+			ProcessRegistry: processRegistryABI,
+		},
+	}
+
+	reason, ok := contracts.DecodeError(&rpc.RPCError{
+		Message: "execution reverted",
+		Data:    hexutil.Bytes(invalidStateRoot.ID.Bytes()[:4]),
+	})
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(reason, qt.Contains, "InvalidStateRoot")
+
+	_, ok = contracts.DecodeError(&rpc.RPCError{
+		Message: "execution reverted",
+		Data:    hexutil.Bytes([]byte{0xde, 0xad, 0xbe, 0xef}),
+	})
+	c.Assert(ok, qt.IsFalse)
 }
 
 func TestProcessAtBlockUsesHistoricalSnapshot(t *testing.T) {


### PR DESCRIPTION
    fix(sequencer): handle statetransition races in multi-sequencer setup
    
    Adds unified handling for InvalidStateRoot errors at all stages:
    
    * (statetransition.go): Check remote state root BEFORE expensive
    reencryption + proof generation. If another sequencer settled, mark batch
    outdated and skip, saving wasted work.
    
    * (onchain.go): Simulation (eth_simulateV1) detects InvalidStateRoot.
    Abort and mark outdated instead of falling through to submit a known-reverting
    tx that wastes gas.
    
    * (onchain.go): Callback handles InvalidStateRoot reverts the same way as other
    reverts or errors, using existing MarkStateTransitionBatchFailed path.
    
    Recovery via MarkStateTransitionBatchOutdated:
    - Does NOT set vote IDs to ERROR (preserves PROCESSED status)
    - Re-queues pending aggregator batch for re-wrapping
    - statetransition.go regenerates proof with fresh state root
    
    Fixes vote loss when multiple sequencers race to settle the same process.
